### PR TITLE
Converted docstrings from reST to Google style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 
 * xcube's code base changed its docstring format from reST style to the much better 
   readable [Google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
-  Existing docstrings have been converted using the awsome [docconvert](https://github.com/cbillingham/docconvert) 
+  Existing docstrings have been converted using the awesome [docconvert](https://github.com/cbillingham/docconvert) 
   tool.
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@
 
 * Renamed xcube's main branch from `master` to `main` on GitHub.
 
+* xcube's code base changed its docstring format from reST style to the much better 
+  readable [Google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
+  Existing docstrings have been converted using the awsome [docconvert](https://github.com/cbillingham/docconvert) 
+  tool.
+
 
 ## Changes in 1.4.1
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ from xcube.version import version
 
 
 project = 'xcube'
-copyright = '2023, Brockmann Consult GmbH'
+copyright = '2018-2024, Brockmann Consult GmbH'
 author = 'Brockmann Consult GmbH'
 
 # The full version, including alpha/beta/rc tags
@@ -59,6 +59,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
     'sphinx_autodoc_annotation',
     'sphinxarg.ext',
     'recommonmark',

--- a/docs/source/cubespec.md
+++ b/docs/source/cubespec.md
@@ -219,7 +219,7 @@ which is also the default name used by the Zarr format.
 The format of the consolidated metadata must be JSON. It is a 
 JSON object using the following structure:
 
-```json
+```
     {
         "zarr_consolidated_format": 1,
         "metadata": {

--- a/docs/source/devguide.md
+++ b/docs/source/devguide.md
@@ -179,7 +179,8 @@ Make sure your change
 
 Create new module in `xcube.core` and add your functions.
 For any functions added make sure naming is in line with other API.
-Add clear doc-string to the new API. Use Sphinx RST format.
+Add clear doc-string to the new API using 
+[Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
 
 Decide if your API methods requires [xcube datasets](./cubespec.md) as 
 inputs, if so, name the primary dataset argument `cube` and add a 

--- a/docs/source/examples/xcube_gen.rst
+++ b/docs/source/examples/xcube_gen.rst
@@ -27,7 +27,7 @@ Before starting the example, you need to activate the xcube environment:
 
     $ conda activate xcube
 
-If you want to take a look at the input data you can use :doc:`cli/xcube dump` to print out the metadata of a selected input file:
+If you want to take a look at the input data you can use :doc:`../cli/xcube_dump` to print out the metadata of a selected input file:
 
 ::
 
@@ -153,7 +153,7 @@ Optimizing and pruning a xcube dataset
 ======================================
 
 If you want to optimize your generated xcube dataset e.g. for publishing it in a xcube viewer via xcube serve
-you can use  :doc:`cli/xcube optimize`:
+you can use  :doc:`../cli/xcube_optimize`:
 
 ::
 
@@ -165,7 +165,7 @@ a file called .zmetadata. .zmetadata contains the information stored in .zattrs 
 xcube dataset and makes requests of metadata faster. The option ``-C`` optimizes coordinate variables by converting any
 chunked arrays into single, non-chunked, contiguous arrays.
 
-For deleting empty chunks :doc:`cli/xcube prune` can be used. It deletes all data files associated with empty (NaN-only)
+For deleting empty chunks :doc:`../cli/xcube_prune` can be used. It deletes all data files associated with empty (NaN-only)
 chunks of an xcube dataset, and is restricted to the ZARR format.
 
 ::
@@ -175,7 +175,7 @@ chunks of an xcube dataset, and is restricted to the ZARR format.
 The pruned xcube dataset is saved in place and does not need an output path. The size of the xcube dataset was 6,8 MB before pruning it
 and 6,5 MB afterwards. According to the output printed to the terminal, 30 block files were deleted.
 
-The metadata of the xcube dataset can be viewed with :doc:`cli/xcube dump` as well:
+The metadata of the xcube dataset can be viewed with :doc:`../cli/xcube_dump` as well:
 
 ::
 

--- a/xcube/cli/common.py
+++ b/xcube/cli/common.py
@@ -41,9 +41,7 @@ def cli_option_traceback(func):
 
 
 def cli_option_quiet(func):
-    """
-    Decorator for adding a reusable CLI option `--quiet`/'-q'.
-    """
+    """Decorator for adding a reusable CLI option `--quiet`/'-q'."""
 
     # noinspection PyUnusedLocal
     def _callback(ctx: click.Context, param: click.Option, value: bool):
@@ -62,8 +60,7 @@ def cli_option_quiet(func):
 
 
 def cli_option_verbosity(func):
-    """
-    Decorator for adding a reusable CLI option `--verbose`/'-v' that
+    """Decorator for adding a reusable CLI option `--verbose`/'-v' that
     can be used multiple times.
     The related kwarg is named `verbosity` and is of type int (= count).
     """
@@ -92,8 +89,7 @@ def cli_option_verbosity(func):
 
 
 def cli_option_dry_run(func):
-    """
-    Decorator for adding a reusable CLI option `--dry-run`/'-d'.
+    """Decorator for adding a reusable CLI option `--dry-run`/'-d'.
     The related kwarg is named `dry_run` and is of type bool.
     """
 
@@ -157,13 +153,15 @@ def cli_option_scheduler(func):
 
 
 def parse_cli_kwargs(value: str, metavar: str = None) -> Dict[str, Any]:
-    """
-    Parse a string value of the form [<kw>=<arg>{,<kw>=<arg>}] into a dictionary.
+    """Parse a string value of the form [<kw>=<arg>{,<kw>=<arg>}] into a dictionary.
     <kw> must be a valid Python identifier, <arg> must be a Python literal.
 
-    :param value: A string value.
-    :param metavar: Name of a meta-variable used in CLI.
-    :return: a dictionary of keyword-arguments
+    Args:
+        value: A string value.
+        metavar: Name of a meta-variable used in CLI.
+
+    Returns:
+        a dictionary of keyword-arguments
     """
     if value:
         try:
@@ -193,23 +191,30 @@ def parse_cli_sequence(
     separator: str = ",",
     error_type: Type[Exception] = click.ClickException,
 ) -> Optional[Tuple[Any, ...]]:
-    """
-    Parse a CLI argument that is supposed to be a sequence.
+    """Parse a CLI argument that is supposed to be a sequence.
 
-    :param seq_value: A string, a string sequence, or None.
-    :param metavar: CLI metavar name
-    :param item_parser: an optional function that takes a string and parses it
-    :param item_validator: a optional function that takes a parsed value and parses it
-    :param allow_none: whether it is ok for *seq_value* to be None
-    :param allow_empty_items: whether it is ok to have empty values in *seq_value*
-    :param strip_items: whether to strip values in *seq_value*
-    :param item_plural_name: a name for multiple items
-    :param num_items: expected number of items
-    :param num_items_min: expected minimum number of items
-    :param num_items_max: expected maximum number of items
-    :param separator: expected separator if *seq_value* is a string, default is ','.
-    :param error_type: value error to be raised in case, defaults to ``click.ClickException``
-    :return: parsed and validated *seq_value* as a tuple of values
+    Args:
+        seq_value: A string, a string sequence, or None.
+        metavar: CLI metavar name
+        item_parser: an optional function that takes a string and parses
+            it
+        item_validator: a optional function that takes a parsed value
+            and parses it
+        allow_none: whether it is ok for *seq_value* to be None
+        allow_empty_items: whether it is ok to have empty values in
+            *seq_value*
+        strip_items: whether to strip values in *seq_value*
+        item_plural_name: a name for multiple items
+        num_items: expected number of items
+        num_items_min: expected minimum number of items
+        num_items_max: expected maximum number of items
+        separator: expected separator if *seq_value* is a string,
+            default is ','.
+        error_type: value error to be raised in case, defaults to
+            ``click.ClickException``
+
+    Returns:
+        parsed and validated *seq_value* as a tuple of values
     """
     if seq_value is None:
         if allow_none:
@@ -258,8 +263,7 @@ def parse_cli_sequence(
 
 
 def assert_positive_int_item(item: int):
-    """
-    A validator for positive integer number sequences.
+    """A validator for positive integer number sequences.
     Frequently used to validate counts or image and tile sizes passes as args to the CLI.
     """
     if item <= 0:

--- a/xcube/cli/compute.py
+++ b/xcube/cli/compute.py
@@ -91,8 +91,7 @@ def compute(
     output_var_name: str,
     output_var_dtype: str,
 ):
-    """
-    Compute a cube from one or more other cubes.
+    """Compute a cube from one or more other cubes.
 
     The command computes a cube variable from other cube variables in CUBEs
     using a user-provided Python function in SCRIPT.

--- a/xcube/cli/dump.py
+++ b/xcube/cli/dump.py
@@ -40,9 +40,7 @@ import click
     help="Dump also variable encoding information.",
 )
 def dump(input, variable, encoding):
-    """
-    Dump contents of an input dataset.
-    """
+    """Dump contents of an input dataset."""
     from xcube.core.dsio import open_dataset
     from xcube.core.dump import dump_dataset
 

--- a/xcube/cli/extract.py
+++ b/xcube/cli/extract.py
@@ -46,8 +46,7 @@ def extract(
     indexes=False,
     refs=False,
 ):
-    """
-    Extract cube points.
+    """Extract cube points.
 
     Extracts data cells from CUBE at coordinates given in each POINTS record and writes the resulting values to given
     output path and format.

--- a/xcube/cli/gen2.py
+++ b/xcube/cli/gen2.py
@@ -78,8 +78,7 @@ def gen2(
     quiet: bool = False,
     verbosity: int = 0,
 ):
-    """
-    Generator tool for data cubes.
+    """Generator tool for data cubes.
 
     Creates a cube view from one or more cube stores, optionally performs some
     cube transformation, and writes the resulting cube to some target cube

--- a/xcube/cli/genpts.py
+++ b/xcube/cli/genpts.py
@@ -43,8 +43,7 @@ DEFAULT_NUM_POINTS_MAX = 100
     default=DEFAULT_NUM_POINTS_MAX,
 )
 def genpts(cube: str, output_path: str, num_points_max: int):
-    """
-    Generate synthetic data points from CUBE.
+    """Generate synthetic data points from CUBE.
 
     Generates synthetic data points for a given data CUBE and write points to a CSV and GeoJSON file.
     The primary use of the tool is to point datasets for machine learning tasks

--- a/xcube/cli/grid.py
+++ b/xcube/cli/grid.py
@@ -262,8 +262,7 @@ def list_resolutions(
     num_results: int,
     sep: str,
 ):
-    """
-    List resolutions close to a target resolution.
+    """List resolutions close to a target resolution.
 
     Lists possible resolutions of a fixed Earth grid that are close to a given target
     resolution TARGET_RES within a maximum allowed deviation DELTA_RES.
@@ -343,8 +342,7 @@ def list_resolutions(
 def list_levels(
     res: str, height: int, coverage: str, level_min: Optional[int], sep: str
 ):
-    """
-    List levels for a resolution or a tile size.
+    """List levels for a resolution or a tile size.
 
     Lists the given number of LEVELS for given resolution RES or given height in grid cells HEIGHT.
     which can both be used to define a fixed Earth grid.
@@ -396,8 +394,7 @@ def adjust_box(
     coverage: str,
     tile_factor: Optional[int],
 ):
-    """
-    Adjust a bounding box to a fixed Earth grid.
+    """Adjust a bounding box to a fixed Earth grid.
 
     Adjusts a bounding box given by GEOM  to a fixed Earth grid by the
     inverse resolution INV_RES in degrees^-1 units, which must be an integer number.
@@ -495,8 +492,7 @@ def _fetch_coverage_from_option(coverage_str: str) -> fractions.Fraction:
 
 @click.group()
 def grid():
-    """
-    Find spatial xcube dataset resolutions and adjust bounding boxes.
+    """Find spatial xcube dataset resolutions and adjust bounding boxes.
 
     We find suitable resolutions with respect to a possibly regional fixed Earth grid and adjust regional spatial
     bounding boxes to that grid. We also try to select the resolutions such

--- a/xcube/cli/io.py
+++ b/xcube/cli/io.py
@@ -94,8 +94,7 @@ def store_info(
     show_data_ids: bool,
     use_json_format: bool,
 ):
-    """
-    Show data store information.
+    """Show data store information.
 
     Dumps detailed data store information in human readable form or as JSON, when using the --json option.
 
@@ -167,8 +166,7 @@ def store_info(
 @click.argument("data_id", metavar="DATA")
 @click.argument("store_params", metavar="PARAMS", nargs=-1)
 def store_data(store_id: str, data_id: str, store_params: List[str]):
-    """
-    Show data resource information.
+    """Show data resource information.
 
     Show the data descriptor for data resource DATA in data store STORE.
     Note some stores require provision of store parameters PARAMS.
@@ -183,8 +181,7 @@ def store_data(store_id: str, data_id: str, store_params: List[str]):
 @click.command(name="info")
 @click.argument("opener_id", metavar="OPENER")
 def opener_info(opener_id: str):
-    """
-    Show data opener information.
+    """Show data opener information.
     You can obtain valid OPENER names using command "xcube io opener list".
     """
     extension = get_extension_registry().get_extension(
@@ -203,8 +200,7 @@ def opener_info(opener_id: str):
 @click.command(name="info")
 @click.argument("writer_id", metavar="WRITER")
 def writer_info(writer_id: str):
-    """
-    Show data opener information.
+    """Show data opener information.
     You can obtain valid WRITER names using command "xcube io writer list".
     """
     extension = get_extension_registry().get_extension(
@@ -305,8 +301,7 @@ def dump(
     yaml_format: bool,
     json_format: bool,
 ):
-    """
-    Dump metadata of given data stores.
+    """Dump metadata of given data stores.
 
     Dumps data store metadata and metadata for a store's data resources
     for given data stores  into a JSON file.
@@ -562,25 +557,19 @@ def _parse_props(props: str) -> Dict[str, AbstractSet]:
 
 @click.group()
 def store():
-    """
-    Tools for xcube's data stores.
-    """
+    """Tools for xcube's data stores."""
     pass
 
 
 @click.group()
 def opener():
-    """
-    Tools for xcube's data openers.
-    """
+    """Tools for xcube's data openers."""
     pass
 
 
 @click.group()
 def writer():
-    """
-    Tools for xcube's data writers.
-    """
+    """Tools for xcube's data writers."""
     pass
 
 
@@ -595,9 +584,7 @@ writer.add_command(writer_info)
 
 @click.group(hidden=True)
 def io():
-    """
-    Tools for xcube's generic I/O system.
-    """
+    """Tools for xcube's generic I/O system."""
     pass
 
 

--- a/xcube/cli/level.py
+++ b/xcube/cli/level.py
@@ -117,8 +117,7 @@ def level(
     quiet: bool,
     verbosity: int,
 ):
-    """
-    Generate multi-resolution levels.
+    """Generate multi-resolution levels.
 
     Transform the given dataset by INPUT into the levels of a
     multi-level pyramid with spatial resolution decreasing by a

--- a/xcube/cli/main.py
+++ b/xcube/cli/main.py
@@ -75,9 +75,7 @@ from xcube.version import version
     " (warnings are hidden by default).",
 )
 def cli(traceback=False, scheduler=None, log_level=None, log_file=None, warnings=None):
-    """
-    xcube Toolkit
-    """
+    """xcube Toolkit"""
     configure_logging(log_file=log_file, log_level=log_level)
     configure_warnings(warnings)
 

--- a/xcube/cli/rectify.py
+++ b/xcube/cli/rectify.py
@@ -152,9 +152,7 @@ def rectify(
     verbosity: int = 0,
     dry_run: bool = DEFAULT_DRY_RUN,
 ):
-    """
-    Rectify a dataset to WGS-84 using its per-pixel geo-locations.
-    """
+    """Rectify a dataset to WGS-84 using its per-pixel geo-locations."""
     configure_cli_output(quiet=quiet, verbosity=verbosity)
 
     input_path = dataset

--- a/xcube/cli/resample.py
+++ b/xcube/cli/resample.py
@@ -170,9 +170,7 @@ def resample(
     verbosity,
     dry_run,
 ):
-    """
-    Resample data along the time dimension.
-    """
+    """Resample data along the time dimension."""
     configure_cli_output(quiet=quiet, verbosity=verbosity)
 
     if base is not None:

--- a/xcube/cli/serve.py
+++ b/xcube/cli/serve.py
@@ -168,8 +168,7 @@ def serve(
     verbosity: int,
     paths: List[str],
 ):
-    """
-    Run the xcube Server for the given configuration and/or the given
+    """Run the xcube Server for the given configuration and/or the given
     raster dataset paths given by PATHS.
 
     Each of the PATHS arguments can point to a raster dataset such as a Zarr

--- a/xcube/cli/vars2dim.py
+++ b/xcube/cli/vars2dim.py
@@ -53,8 +53,7 @@ import click
     help="Format of the output. If not given, guessed from OUTPUT.",
 )
 def vars2dim(cube, variable, dim_name, output=None, format=None):
-    """
-    Convert cube variables into new dimension.
+    """Convert cube variables into new dimension.
     Moves all variables of CUBE into a single new variable <var-name>
     with a new dimension DIM-NAME and writes the results to OUTPUT.
     """

--- a/xcube/cli/verify.py
+++ b/xcube/cli/verify.py
@@ -29,8 +29,7 @@ from xcube.constants import LOG
 @click.command(name="verify")
 @click.argument("cube")
 def verify(cube):
-    """
-    Perform cube verification.
+    """Perform cube verification.
 
     \b
     The tool verifies that CUBE

--- a/xcube/core/_tile2.py
+++ b/xcube/core/_tile2.py
@@ -395,33 +395,35 @@ def compute_rgba_tile(
     10. turn that array into an RGBA image.
     11. encode RGBA image into PNG bytes.
 
-    :param ml_dataset: Multi-level dataset
-    :param variable_names: Single variable name
-        or a sequence of three names.
-    :param tile_x: Tile X coordinate
-    :param tile_y: Tile Y coordinate
-    :param tile_z:  Tile Z coordinate
-    :param cmap_provider: Provider for colormaps.
-    :param crs_name: Spatial tile coordinate reference system.
-        Must be a geographical CRS, such as "EPSG:4326", or
-        web mercator, i.e. "EPSG:3857". Defaults to "CRS84".
-    :param tile_size: The tile size in pixels.
-        Can be a scalar or an integer width/height pair.
-        Defaults to 256.
-    :param cmap_name: Color map name. Only used if a single
-        variable name is given. Defaults to "bone".
-    :param value_ranges: A single value range, or value ranges
-        for each variable name.
-    :param non_spatial_labels: Labels for the non-spatial dimensions
-        in the given variables.
-    :param tile_enlargement: Enlargement in pixels applied to
-        the computed source tile read from the data.
-        Can be used to increase the accuracy of the borders of target
-        tiles at high zoom levels. Defaults to 1.
-    :param format: Either 'png', 'image/png' or 'numpy'.
-    :param trace_perf: If set, detailed performance
-        metrics are logged using the level of the "xcube" logger.
-    :return: PNG bytes or unit8 numpy array, depending on *format*
+    Args:
+        ml_dataset: Multi-level dataset
+        variable_names: Single variable name or a sequence of three
+            names.
+        tile_x: Tile X coordinate
+        tile_y: Tile Y coordinate
+        tile_z: Tile Z coordinate
+        cmap_provider: Provider for colormaps.
+        crs_name: Spatial tile coordinate reference system. Must be a
+            geographical CRS, such as "EPSG:4326", or web mercator, i.e.
+            "EPSG:3857". Defaults to "CRS84".
+        tile_size: The tile size in pixels. Can be a scalar or an
+            integer width/height pair. Defaults to 256.
+        cmap_name: Color map name. Only used if a single variable name
+            is given. Defaults to "bone".
+        value_ranges: A single value range, or value ranges for each
+            variable name.
+        non_spatial_labels: Labels for the non-spatial dimensions in the
+            given variables.
+        tile_enlargement: Enlargement in pixels applied to the computed
+            source tile read from the data. Can be used to increase the
+            accuracy of the borders of target tiles at high zoom levels.
+            Defaults to 1.
+        format: Either 'png', 'image/png' or 'numpy'.
+        trace_perf: If set, detailed performance metrics are logged
+            using the level of the "xcube" logger.
+
+    Returns:
+        PNG bytes or unit8 numpy array, depending on *format*
     :raise TileNotFoundException
     :raise TileRequestException
     """

--- a/xcube/core/ancvar.py
+++ b/xcube/core/ancvar.py
@@ -91,9 +91,7 @@ def find_ancillary_var_names(
 
 
 def _get_standard_name_modifier(variable, ancillary_var):
-    """
-    See CF Conventions v 1.7, Appendix C: Standard Name Modifiers
-    """
+    """See CF Conventions v 1.7, Appendix C: Standard Name Modifiers"""
     if "standard_name" in ancillary_var.attrs:
         ancillary_var_std_name = ancillary_var.attrs["standard_name"]
         ancillary_var_std_name_parts = ancillary_var_std_name.split(" ")

--- a/xcube/core/byoa/config.py
+++ b/xcube/core/byoa/config.py
@@ -42,8 +42,7 @@ from ...constants import LOG
 
 
 class CodeConfig(JsonObject):
-    """
-    Code configuration object.
+    """Code configuration object.
 
     Instances should always be created using one of the factory methods:
 
@@ -51,24 +50,23 @@ class CodeConfig(JsonObject):
     * :meth:from_code
     * :meth:from_file_set
 
-    :param _callable: Optional function or class.
-        Cannot be given if *inline_code* or *file_set* are given.
-    :param callable_ref: Optional reference to the callable
-        in the *file_set*. Must have form "<module-name>:<callable-name>".
-    :param inline_code: Optional inline Python code string.
-        Cannot be given if *_callable* or *file_set* are given.
-    :param file_set: A file set that contains Python
-        modules or packages.
-        Must be of type :class:FileSet.
-        Cannot be given if *_callable* or *inline_code* are given.
-    :param install_required: Whether *file_set* contains
-        Python modules or packages that must be installed.
-        Can only be True if *file_set* is given.
-    :param callable_params: Optional parameters that are supposed to
-        be passed as keyword-arguments to the callable.
-        Stored as part of the configuration, but this class
-        does not apply them.
-        Must be a dictionary, if given.
+    Args:
+        _callable: Optional function or class. Cannot be given if
+            *inline_code* or *file_set* are given.
+        callable_ref: Optional reference to the callable in the
+            *file_set*. Must have form "<module-name>:<callable-name>".
+        inline_code: Optional inline Python code string. Cannot be given
+            if *_callable* or *file_set* are given.
+        file_set: A file set that contains Python modules or packages.
+            Must be of type :class:FileSet. Cannot be given if
+            *_callable* or *inline_code* are given.
+        install_required: Whether *file_set* contains Python modules or
+            packages that must be installed. Can only be True if
+            *file_set* is given.
+        callable_params: Optional parameters that are supposed to be
+            passed as keyword-arguments to the callable. Stored as part
+            of the configuration, but this class does not apply them.
+            Must be a dictionary, if given.
     """
 
     def __init__(
@@ -131,24 +129,26 @@ class CodeConfig(JsonObject):
         module_name: str = None,
         callable_params: Dict[str, Any] = None,
     ) -> "CodeConfig":
-        """
-        Create a code configuration from the given *code* which may be
+        """Create a code configuration from the given *code* which may be
         given as one or more plain text strings or callables.
 
         This will create a configuration that uses an inline
         ``code_string`` which contains the source code.
 
-        :param code: The code.
-        :param callable_name: The callable name.
-            If not given, will be inferred from first callable.
-            Otherwise, it defaults to "process_dataset".
-        :param module_name: The module name. If not given,
-            defaults to "user_code".
-        :param callable_params: Optional parameters that are supposed to
-            be passed as keyword-arguments to the callable.
-            Stored as part of the configuration, but this class
-            does not apply them. Must be a dictionary, if given.
-        :return: A new code configuration.
+        Args:
+            *code: The code.
+            callable_name: The callable name. If not given, will be
+                inferred from first callable. Otherwise, it defaults to
+                "process_dataset".
+            module_name: The module name. If not given, defaults to
+                "user_code".
+            callable_params: Optional parameters that are supposed to be
+                passed as keyword-arguments to the callable. Stored as
+                part of the configuration, but this class does not apply
+                them. Must be a dictionary, if given.
+
+        Returns:
+            A new code configuration.
         """
         assert_given(code, "code")
         inline_code, callable_ref = _normalize_inline_code(
@@ -164,8 +164,7 @@ class CodeConfig(JsonObject):
     def from_callable(
         cls, _callable: Callable, callable_params: Optional[Dict[str, Any]] = None
     ) -> "CodeConfig":
-        """
-        Create a code configuration from the callable *_callable*.
+        """Create a code configuration from the callable *_callable*.
 
         Note, the resulting code configuration is only
         valid in a local context. It cannot be JSON-serialized.
@@ -173,12 +172,15 @@ class CodeConfig(JsonObject):
         To pass such configurations to a service, convert it first
         using the :meth:to_service first.
 
-        :param _callable: A function or class
-        :param callable_params: Optional parameters that are supposed to
-            be passed as keyword-arguments to the callable.
-            Stored as part of the configuration, but this class
-            does not apply them. Must be a dictionary, if given.
-        :return: A new code configuration.
+        Args:
+            _callable: A function or class
+            callable_params: Optional parameters that are supposed to be
+                passed as keyword-arguments to the callable. Stored as
+                part of the configuration, but this class does not apply
+                them. Must be a dictionary, if given.
+
+        Returns:
+            A new code configuration.
         """
         assert_given(_callable, "_callable")
         return CodeConfig(_callable=_callable, callable_params=callable_params)
@@ -191,20 +193,22 @@ class CodeConfig(JsonObject):
         callable_params: Optional[Dict[str, Any]] = None,
         install_required: Optional[bool] = None,
     ) -> "CodeConfig":
-        """
-        Create a code configuration from a file set.
+        """Create a code configuration from a file set.
 
-        :param file_set: The file set.
-            Can be a path or a :class:FileSet instance.
-        :param callable_ref: Reference to the callable in the *file_set*,
-            must have form "<module-name>:<callable-name>"
-        :param install_required: Whether the *file_set* is
-            a package that must be installed.
-        :param callable_params: Optional parameters that are supposed to
-            be passed as keyword-arguments to the callable.
-            Stored as part of the configuration, but this class
-            does not apply them. Must be a dictionary, if given.
-        :return: A new code configuration.
+        Args:
+            file_set: The file set. Can be a path or a :class:FileSet
+                instance.
+            callable_ref: Reference to the callable in the *file_set*,
+                must have form "<module-name>:<callable-name>"
+            install_required: Whether the *file_set* is a package that
+                must be installed.
+            callable_params: Optional parameters that are supposed to be
+                passed as keyword-arguments to the callable. Stored as
+                part of the configuration, but this class does not apply
+                them. Must be a dictionary, if given.
+
+        Returns:
+            A new code configuration.
         """
         assert_given(file_set, "file_set")
         assert_given(callable_ref, "callable_ref")
@@ -227,24 +231,26 @@ class CodeConfig(JsonObject):
         gh_username: Optional[str] = None,
         gh_token: Optional[str] = None,
     ):
-        """
-        Create a code configuration from a GitHub archive.
+        """Create a code configuration from a GitHub archive.
 
-        :param gh_org: GitHub organisation name or username
-        :param gh_repo:  GitHub repository name
-        :param gh_tag: GitHub release tag
-        :param gh_release: The name of a GitHub release. It is used to
-            form the sub-path into the archive. The sub-path has the form
-            "<gh_repo>-<gh_release>".
-        :param callable_ref: Reference to the callable in the *file_set*,
-            must have form "<module-name>:<callable-name>"
-        :param callable_params: Optional parameters that are supposed to
-            be passed as keyword-arguments to the callable.
-            Stored as part of the configuration, but this class
-            does not apply them. Must be a dictionary, if given.
-        :param gh_username: Optional GitHub username.
-        :param gh_token: Optional GitHub username.
-        :return:
+        Args:
+            gh_org: GitHub organisation name or username
+            gh_repo: GitHub repository name
+            gh_tag: GitHub release tag
+            gh_release: The name of a GitHub release. It is used to form
+                the sub-path into the archive. The sub-path has the form
+                "<gh_repo>-<gh_release>".
+            callable_ref: Reference to the callable in the *file_set*,
+                must have form "<module-name>:<callable-name>"
+            callable_params: Optional parameters that are supposed to be
+                passed as keyword-arguments to the callable. Stored as
+                part of the configuration, but this class does not apply
+                them. Must be a dictionary, if given.
+            gh_username: Optional GitHub username.
+            gh_token: Optional GitHub username.
+
+        Returns:
+
         """
         assert_given(gh_org, "gh_org")
         assert_given(gh_org, "gh_repo")
@@ -264,8 +270,7 @@ class CodeConfig(JsonObject):
         )
 
     def for_service(self) -> "CodeConfig":
-        """
-        Convert this code configuration so can be used by the
+        """Convert this code configuration so can be used by the
         generator service.
 
         The returned code configuration defines either
@@ -275,8 +280,7 @@ class CodeConfig(JsonObject):
         return _for_service(self)
 
     def for_local(self) -> "CodeConfig":
-        """
-        Convert this code configuration so can be used by the
+        """Convert this code configuration so can be used by the
         local generator. This means, the returned configuration
         can be used to load executable code. i.e.
         :meth:get_callable() will return a callable.
@@ -291,12 +295,12 @@ class CodeConfig(JsonObject):
         return _for_local(self)
 
     def get_callable(self) -> Callable:
-        """
-        Get the callable specified by this configuration.
+        """Get the callable specified by this configuration.
 
         In the common case, this will require importing the callable.
 
-        :return: A callable
+        Returns:
+            A callable
         :raise ImportError if the callable can not be imported
         """
         if self._callable is None:
@@ -304,18 +308,19 @@ class CodeConfig(JsonObject):
         return self._callable
 
     def set_callable(self, func_or_class: Callable):
-        """
-        Set the callable that is represented by this configuration.
-        :param func_or_class: A callable
+        """Set the callable that is represented by this configuration.
+
+        Args:
+            func_or_class: A callable
         """
         assert_true(callable(func_or_class), f"func_or_class must be callable")
         self._callable = func_or_class
 
     def _load_callable(self) -> Callable:
-        """
-        Load the callable specified by this configuration.
+        """Load the callable specified by this configuration.
 
-        :return: A callable
+        Returns:
+            A callable
         :raise ImportError if the callable can not be imported
         """
         code_config = self.for_local()
@@ -417,15 +422,17 @@ def _for_local(code_config: CodeConfig) -> "CodeConfig":
 def _load_callable(
     dir_path: str, callable_ref: str, install_required: bool
 ) -> Callable:
-    """
-    Load the callable from given *dir_path* using the
+    """Load the callable from given *dir_path* using the
     callable reference *callable_red*.
-    :param dir_path: A local directory path
-        (local ZIPs should work too).
-    :param callable_ref: A callable reference of form "module:callable"
-    :param install_required: Whether source code in *dir_path*
-        must be installed using setup.
-    :return: The loaded callable
+
+    Args:
+        dir_path: A local directory path (local ZIPs should work too).
+        callable_ref: A callable reference of form "module:callable"
+        install_required: Whether source code in *dir_path* must be
+            installed using setup.
+
+    Returns:
+        The loaded callable
     """
     module_name, callable_name = _normalize_callable_ref(callable_ref)
     if install_required:
@@ -470,16 +477,18 @@ def _next_user_module_name() -> str:
 def _callable_to_module(
     _callable: Callable, callable_params: Dict[str, Any] = None
 ) -> CodeConfig:
-    """
-    Create a code configuration from the callable *_callable*.
+    """Create a code configuration from the callable *_callable*.
 
     This will create a configuration that uses a ``file_set``
     which contains the source code for the *func_or_class*.
 
-    :param _callable: A function or class
-    :param callable_params: The parameters passed
-        as keyword-arguments to the callable.
-    :return: A new code configuration.
+    Args:
+        _callable: A function or class
+        callable_params: The parameters passed as keyword-arguments to
+            the callable.
+
+    Returns:
+        A new code configuration.
     """
     callable_name = _callable.__name__
     if not callable_name:

--- a/xcube/core/byoa/fileset.py
+++ b/xcube/core/byoa/fileset.py
@@ -44,13 +44,14 @@ class _FileSetDetails:
     def __init__(
         self, fs: fsspec.AbstractFileSystem, root: str, local_path: Union[None, str]
     ):
-        """
-        Stores file system details about a FileSet instance.
+        """Stores file system details about a FileSet instance.
         Internal helper class.
-        :param fs: file system
-        :param root: root in file system
-        :param local_path: the local or network path.
-            None, if this is not a local path.
+
+        Args:
+            fs: file system
+            root: root in file system
+            local_path: the local or network path. None, if this is not
+                a local path.
         """
         self._fs = fs
         self._root = root
@@ -92,8 +93,7 @@ class _FileSetDetails:
 
 
 class FileSet(JsonObject):
-    """
-    A set of files that can found at some abstract root *path*.
+    """A set of files that can found at some abstract root *path*.
     The *path* may identify local or remote filesystems.
     A filesystem may require specific *parameters*, e.g.
     user credentials.
@@ -126,16 +126,17 @@ class FileSet(JsonObject):
     The *includes*, if any, are applied before the
     *excludes*, if any.
 
-    :param path: Root path of the file set.
-    :param sub_path: An optional sub-path relative to *path*.
-        If given, this is where the actual file sets starts.
-        For example, the only top-level directory entry in a
-        ZIP archive. In archive files from GitHub this would
-        be typically "<gh_repo>-<gh-release-name>".
-        Note: wildcard characters are not yet allowed.
-    :param includes: Wildcard patterns used to include a file.
-    :param excludes: Wildcard patterns used to exclude a file.
-    :param storage_params: File system specific storage parameters.
+    Args:
+        path: Root path of the file set.
+        sub_path: An optional sub-path relative to *path*. If given,
+            this is where the actual file sets starts. For example, the
+            only top-level directory entry in a ZIP archive. In archive
+            files from GitHub this would be typically "<gh_repo>-<gh-
+            release-name>". Note: wildcard characters are not yet
+            allowed.
+        includes: Wildcard patterns used to include a file.
+        excludes: Wildcard patterns used to exclude a file.
+        storage_params: File system specific storage parameters.
     """
 
     def __init__(
@@ -191,8 +192,7 @@ class FileSet(JsonObject):
 
     @property
     def storage_params(self) -> Optional[Dict[str, Any]]:
-        """
-        Get optional parameters for the file system
+        """Get optional parameters for the file system
         :attribute:path is referring to.
         """
         return self._storage_params
@@ -208,8 +208,7 @@ class FileSet(JsonObject):
         return self._excludes
 
     def keys(self) -> Iterator[str]:
-        """
-        Get keys in this file set.
+        """Get keys in this file set.
         A key is a normalized path relative to the root *path*.
         The forward slash "/" is used as path separator.
         """
@@ -219,15 +218,13 @@ class FileSet(JsonObject):
                 yield key
 
     def get_local_path(self) -> Optional[str]:
-        """
-        Get the local path, if this file set is local,
+        """Get the local path, if this file set is local,
         otherwise return None.
         """
         return self._get_details().local_path
 
     def is_local(self) -> bool:
-        """
-        Test whether this file set refers to a local file or directory.
+        """Test whether this file set refers to a local file or directory.
         The test is made on this path's protocol.
         """
         if self._details is not None:
@@ -236,9 +233,7 @@ class FileSet(JsonObject):
         return protocol is None or protocol == "file"
 
     def to_local(self) -> "FileSet":
-        """
-        Turn this file set into a locally existing file set.
-        """
+        """Turn this file set into a locally existing file set."""
         if self.is_local():
             return self
 
@@ -303,23 +298,23 @@ class FileSet(JsonObject):
             )
 
     def is_local_dir(self) -> bool:
-        """
-        Test whether this file set refers to an existing local directory.
-        """
+        """Test whether this file set refers to an existing local directory."""
         local_path = self.get_local_path()
         return os.path.isdir(local_path) if local_path is not None else False
 
     def to_local_dir(self, dir_path: str = None) -> "FileSet":
-        """
-        Convert this file set into a file set that refers to a
+        """Convert this file set into a file set that refers to a
         directory in the local file system.
 
         The *dir_path* parameter is used only if this fileset
         does not already refer to an existing local directory.
 
-        :param dir_path: An optional directory path.
-            If not given, a temporary directory is created.
-        :return: The file set representing the local directory.
+        Args:
+            dir_path: An optional directory path. If not given, a
+                temporary directory is created.
+
+        Returns:
+            The file set representing the local directory.
         """
         file_set = self.to_local()
         if (
@@ -332,20 +327,20 @@ class FileSet(JsonObject):
         return file_set._write_local_dir(dir_path)
 
     def is_local_zip(self):
-        """
-        Test whether this file set refers to an existing local ZIP archive.
-        """
+        """Test whether this file set refers to an existing local ZIP archive."""
         local_path = self.get_local_path()
         return zipfile.is_zipfile(local_path) if local_path is not None else False
 
     def to_local_zip(self, zip_path: str = None) -> "FileSet":
-        """
-        Zip this file set and return it as a new local directory file set.
+        """Zip this file set and return it as a new local directory file set.
         If this is already a ZIP archive, return this file set.
 
-        :param zip_path: An optional path for the new ZIP archive.
-            If not given, a temporary file will be created.
-        :return: The file set representing the local ZIP archive.
+        Args:
+            zip_path: An optional path for the new ZIP archive. If not
+                given, a temporary file will be created.
+
+        Returns:
+            The file set representing the local ZIP archive.
         """
         file_set = self.to_local()
         if (

--- a/xcube/core/chunk.py
+++ b/xcube/core/chunk.py
@@ -10,14 +10,16 @@ from xcube.core.update import update_dataset_chunk_encoding
 def chunk_dataset(
     dataset: xr.Dataset, chunk_sizes: Dict[str, int] = None, format_name: str = None
 ) -> xr.Dataset:
-    """
-    Chunk *dataset* using *chunk_sizes* and optionally
+    """Chunk *dataset* using *chunk_sizes* and optionally
     update encodings for given *format_name*.
 
-    :param dataset: input dataset
-    :param chunk_sizes: mapping from dimension name to new chunk size
-    :param format_name: optional format, e.g. "zarr" or "netcdf4"
-    :return: the (re)chunked dataset
+    Args:
+        dataset: input dataset
+        chunk_sizes: mapping from dimension name to new chunk size
+        format_name: optional format, e.g. "zarr" or "netcdf4"
+
+    Returns:
+        the (re)chunked dataset
     """
     dataset = dataset.chunk(chunks=chunk_sizes)
     if format_name:
@@ -30,12 +32,14 @@ def chunk_dataset(
 def get_empty_dataset_chunks(
     dataset: xr.Dataset,
 ) -> Iterator[Tuple[str, Iterator[Tuple[int, ...]]]]:
-    """
-    Identify empty dataset chunks and return their indices.
+    """Identify empty dataset chunks and return their indices.
 
-    :param dataset: The dataset.
-    :return: An iterator that provides a stream of
-        (variable name, block indices tuple) tuples.
+    Args:
+        dataset: The dataset.
+
+    Returns:
+        An iterator that provides a stream of (variable name, block
+        indices tuple) tuples.
     """
     return (
         (str(var_name), get_empty_var_chunks(dataset[var_name]))
@@ -44,11 +48,13 @@ def get_empty_dataset_chunks(
 
 
 def get_empty_var_chunks(var: xr.DataArray) -> Iterator[Tuple[int, ...]]:
-    """
-    Identify empty variable chunks and return their indices.
+    """Identify empty variable chunks and return their indices.
 
-    :param var: The variable.
-    :return: A list of block indices.
+    Args:
+        var: The variable.
+
+    Returns:
+        A list of block indices.
     """
     chunks = var.chunks
     if chunks is None:

--- a/xcube/core/chunkstore.py
+++ b/xcube/core/chunkstore.py
@@ -258,8 +258,7 @@ def _str_to_bytes(s: str):
     version="0.12.1",
 )
 class LoggingStore(LoggingZarrStore):
-    """
-    A Zarr Store that logs all method calls on another store *other*
+    """A Zarr Store that logs all method calls on another store *other*
     including execution time.
     """
 
@@ -281,6 +280,4 @@ class LoggingStore(LoggingZarrStore):
     version="0.12.1",
 )
 class MutableLoggingStore(LoggingStore):
-    """
-    Mutable version of :class:LoggingStore.
-    """
+    """Mutable version of :class:LoggingStore."""

--- a/xcube/core/compute.py
+++ b/xcube/core/compute.py
@@ -103,8 +103,7 @@ def compute_dataset(
     vectorize: bool = None,
     cube_asserted: bool = False,
 ) -> xr.Dataset:
-    """
-    Compute a new output dataset with a single variable named *output_var_name*
+    """Compute a new output dataset with a single variable named *output_var_name*
     from variables named *input_var_names* contained in zero, one, or more
     input data cubes in *input_cubes* using a cube factory function *cube_func*.
 
@@ -136,20 +135,31 @@ def compute_dataset(
     *output_var_dims* my be given in the case, where ...
     TODO: describe new output_var_dims...
 
-    :param cube_func: The cube factory function.
-    :param input_cubes: An optional sequence of input cube datasets, must be provided if *input_cube_schema* is not.
-    :param input_cube_schema: An optional input cube schema, must be provided if *input_cubes* is not.
-    :param input_var_names: A sequence of variable names
-    :param input_params: Optional dictionary with processing parameters passed to *cube_func*.
-    :param output_var_name: Optional name of the output variable, defaults to ``'output'``.
-    :param output_var_dims: Optional set of names of the output dimensions,
-        used in the case *cube_func* reduces dimensions.
-    :param output_var_dtype: Optional numpy datatype of the output variable, defaults to ``'float32'``.
-    :param output_var_attrs: Optional metadata attributes for the output variable.
-    :param vectorize: Whether all *input_cubes* have the same variables which are concatenated and passed as vectors
-        to *cube_func*. Not implemented yet.
-    :param cube_asserted: If False, *cube* will be verified, otherwise it is expected to be a valid cube.
-    :return: A new dataset that contains the computed output variable.
+    Args:
+        cube_func: The cube factory function.
+        *input_cubes: An optional sequence of input cube datasets, must
+            be provided if *input_cube_schema* is not.
+        input_cube_schema: An optional input cube schema, must be
+            provided if *input_cubes* is not.
+        input_var_names: A sequence of variable names
+        input_params: Optional dictionary with processing parameters
+            passed to *cube_func*.
+        output_var_name: Optional name of the output variable, defaults
+            to ``'output'``.
+        output_var_dims: Optional set of names of the output dimensions,
+            used in the case *cube_func* reduces dimensions.
+        output_var_dtype: Optional numpy datatype of the output
+            variable, defaults to ``'float32'``.
+        output_var_attrs: Optional metadata attributes for the output
+            variable.
+        vectorize: Whether all *input_cubes* have the same variables
+            which are concatenated and passed as vectors to *cube_func*.
+            Not implemented yet.
+        cube_asserted: If False, *cube* will be verified, otherwise it
+            is expected to be a valid cube.
+
+    Returns:
+        A new dataset that contains the computed output variable.
     """
     if vectorize is not None:
         # TODO: support vectorize = all cubes have same variables and cube_func

--- a/xcube/core/dsio.py
+++ b/xcube/core/dsio.py
@@ -65,13 +65,16 @@ _DEPRECATION_VERSION = "0.12.1"
 
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 def open_cube(input_path: str, format_name: str = None, **kwargs) -> xr.Dataset:
-    """
-    Open a xcube dataset from *input_path*.
+    """Open a xcube dataset from *input_path*.
     If *format* is not provided it will be guessed from *input_path*.
-    :param input_path: input path
-    :param format_name: format, e.g. "zarr" or "netcdf4"
-    :param kwargs: format-specific keyword arguments
-    :return: xcube dataset
+
+    Args:
+        input_path: input path
+        format_name: format, e.g. "zarr" or "netcdf4"
+        **kwargs: format-specific keyword arguments
+
+    Returns:
+        xcube dataset
     """
     return open_dataset(input_path, format_name=format_name, is_cube=True, **kwargs)
 
@@ -84,15 +87,19 @@ def write_cube(
     cube_asserted: bool = False,
     **kwargs,
 ) -> xr.Dataset:
-    """
-    Write a xcube dataset to *output_path*.
+    """Write a xcube dataset to *output_path*.
     If *format* is not provided it will be guessed from *output_path*.
-    :param cube: xcube dataset to be written.
-    :param output_path: output path
-    :param format_name: format, e.g. "zarr" or "netcdf4"
-    :param kwargs: format-specific keyword arguments
-    :param cube_asserted: If False, *cube* will be verified, otherwise it is expected to be a valid cube.
-    :return: xcube dataset *cube*
+
+    Args:
+        cube: xcube dataset to be written.
+        output_path: output path
+        format_name: format, e.g. "zarr" or "netcdf4"
+        **kwargs: format-specific keyword arguments
+        cube_asserted: If False, *cube* will be verified, otherwise it
+            is expected to be a valid cube.
+
+    Returns:
+        xcube dataset *cube*
     """
     if not cube_asserted:
         assert_cube(cube)
@@ -103,14 +110,18 @@ def write_cube(
 def open_dataset(
     input_path: str, format_name: str = None, is_cube: bool = False, **kwargs
 ) -> xr.Dataset:
-    """
-    Open a dataset from *input_path*.
+    """Open a dataset from *input_path*.
     If *format* is not provided it will be guessed from *output_path*.
-    :param input_path: input path
-    :param format_name: format, e.g. "zarr" or "netcdf4"
-    :param is_cube: Whether a ValueError will be raised, if the dataset read from *input_path* is not a xcube dataset.
-    :param kwargs: format-specific keyword arguments
-    :return: dataset object
+
+    Args:
+        input_path: input path
+        format_name: format, e.g. "zarr" or "netcdf4"
+        is_cube: Whether a ValueError will be raised, if the dataset
+            read from *input_path* is not a xcube dataset.
+        **kwargs: format-specific keyword arguments
+
+    Returns:
+        dataset object
     """
     format_name = format_name if format_name else guess_dataset_format(input_path)
     if format_name is None:
@@ -128,14 +139,17 @@ def open_dataset(
 def write_dataset(
     dataset: xr.Dataset, output_path: str, format_name: str = None, **kwargs
 ) -> xr.Dataset:
-    """
-    Write dataset to *output_path*.
+    """Write dataset to *output_path*.
     If *format* is not provided it will be guessed from *output_path*.
-    :param dataset: Dataset to be written.
-    :param output_path: output path
-    :param format_name: format, e.g. "zarr" or "netcdf4"
-    :param kwargs: format-specific keyword arguments
-    :return: the input dataset
+
+    Args:
+        dataset: Dataset to be written.
+        output_path: output path
+        format_name: format, e.g. "zarr" or "netcdf4"
+        **kwargs: format-specific keyword arguments
+
+    Returns:
+        the input dataset
     """
     format_name = format_name if format_name else guess_dataset_format(output_path)
     if format_name is None:
@@ -149,9 +163,10 @@ def write_dataset(
 
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 class DatasetIO(ExtensionComponent, metaclass=ABCMeta):
-    """
-    An abstract base class that represents dataset input/output.
-    :param name: A unique dataset I/O identifier.
+    """An abstract base class that represents dataset input/output.
+
+    Args:
+        name: A unique dataset I/O identifier.
     """
 
     def __init__(self, name: str):
@@ -159,8 +174,8 @@ class DatasetIO(ExtensionComponent, metaclass=ABCMeta):
 
     @property
     def description(self) -> str:
-        """
-        :return: A description for this input processor
+        """Returns:
+        A description for this input processor
         """
         return self.get_metadata_attr("description", "")
 
@@ -171,20 +186,22 @@ class DatasetIO(ExtensionComponent, metaclass=ABCMeta):
 
     @property
     def modes(self) -> Set[str]:
-        """
-        A set describing the modes of this dataset I/O.
+        """A set describing the modes of this dataset I/O.
         Must be one or more of "r" (read), "w" (write), and "a" (append).
         """
         return self.get_metadata_attr("modes", set())
 
     @abstractmethod
     def fitness(self, path: str, path_type: str = None) -> float:
-        """
-        Compute a fitness of this dataset I/O in the interval [0 to 1]
+        """Compute a fitness of this dataset I/O in the interval [0 to 1]
         for reading/writing from/to the given *path*.
-        :param path: The path or URL.
-        :param path_type: Either "file", "dir", "url", or None.
-        :return: the chance in range [0 to 1]
+
+        Args:
+            path: The path or URL.
+            path_type: Either "file", "dir", "url", or None.
+
+        Returns:
+            the chance in range [0 to 1]
         """
         return 0.0
 
@@ -250,10 +267,13 @@ def find_dataset_io(
 
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 def guess_dataset_format(path: str) -> Optional[str]:
-    """
-    Guess a dataset format for a file system path or URL given by *path*.
-    :param path: A file system path or URL.
-    :return: The name of a dataset format guessed from *path*.
+    """Guess a dataset format for a file system path or URL given by *path*.
+
+    Args:
+        path: A file system path or URL.
+
+    Returns:
+        The name of a dataset format guessed from *path*.
     """
     dataset_io_fitness_list = guess_dataset_ios(path)
     if dataset_io_fitness_list:
@@ -263,13 +283,16 @@ def guess_dataset_format(path: str) -> Optional[str]:
 
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 def guess_dataset_ios(path: str) -> List[Tuple[DatasetIO, float]]:
-    """
-    Guess suitable DatasetIO objects for a file system path or URL given by *path*.
+    """Guess suitable DatasetIO objects for a file system path or URL given by *path*.
     Returns a list of (DatasetIO, fitness) tuples, sorted by descending fitness values.
     Fitness values are in the interval (0, 1].
     The first entry is the most appropriate DatasetIO object.
-    :param path: A file system path or URL.
-    :return: A list of (DatasetIO, fitness) tuples.
+
+    Args:
+        path: A file system path or URL.
+
+    Returns:
+        A list of (DatasetIO, fitness) tuples.
     """
     if os.path.isfile(path):
         input_type = "file"
@@ -308,9 +331,10 @@ def query_dataset_io(filter_fn: Callable[[DatasetIO], bool] = None) -> List[Data
 # noinspection PyAbstractClass
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 class MemDatasetIO(DatasetIO):
-    """
-    An in-memory  dataset I/O. Keeps all datasets in a dictionary.
-    :param datasets: The initial datasets as a path to dataset mapping.
+    """An in-memory  dataset I/O. Keeps all datasets in a dictionary.
+
+    Args:
+        datasets: The initial datasets as a path to dataset mapping.
     """
 
     def __init__(self, datasets: Dict[str, xr.Dataset] = None):
@@ -358,9 +382,7 @@ class MemDatasetIO(DatasetIO):
 
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 class Netcdf4DatasetIO(DatasetIO):
-    """
-    A dataset I/O that reads from / writes to NetCDF files.
-    """
+    """A dataset I/O that reads from / writes to NetCDF files."""
 
     def __init__(self):
         super().__init__(FORMAT_NAME_NETCDF4)
@@ -412,9 +434,7 @@ class Netcdf4DatasetIO(DatasetIO):
 
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 class ZarrDatasetIO(DatasetIO):
-    """
-    A dataset I/O that reads from / writes to Zarr directories or archives.
-    """
+    """A dataset I/O that reads from / writes to Zarr directories or archives."""
 
     def __init__(self):
         super().__init__(FORMAT_NAME_ZARR)
@@ -456,18 +476,26 @@ class ZarrDatasetIO(DatasetIO):
         max_cache_size: int = None,
         **kwargs,
     ) -> xr.Dataset:
-        """
-        Read dataset from some Zarr storage.
-        :param path: File path or object storage URL.
-        :param s3_kwargs: if *path* is an object storage URL, keyword-arguments passed to S3 file system,
-            that is ``s3fs.S3FileSystem(**s3_kwargs, ...)``.
-        :param s3_client_kwargs: if *path* is an object storage URL, keyword-arguments passed to S3 (boto3) client,
-            that is ``s3fs.S3FileSystem(..., client_kwargs=s3_client_kwargs)``.
-        :param max_cache_size: if this is a positive integer, the store will be wrapped in an in-memory cache,
-            that is ``store = zarr.LRUStoreCache(store, max_size=max_cache_size)``.
-        :param kwargs: Keyword-arguments passed to xarray Zarr adapter,
-            that is ``xarray.open_zarr(..., **kwargs)``. In addition, the parameter **
-        :return:
+        """Read dataset from some Zarr storage.
+
+        Args:
+            path: File path or object storage URL.
+            s3_kwargs: if *path* is an object storage URL, keyword-
+                arguments passed to S3 file system, that is
+                ``s3fs.S3FileSystem(**s3_kwargs, ...)``.
+            s3_client_kwargs: if *path* is an object storage URL,
+                keyword-arguments passed to S3 (boto3) client, that is
+                ``s3fs.S3FileSystem(...,
+                client_kwargs=s3_client_kwargs)``.
+            max_cache_size: if this is a positive integer, the store
+                will be wrapped in an in-memory cache, that is ``store =
+                zarr.LRUStoreCache(store, max_size=max_cache_size)``.
+            **kwargs: Keyword-arguments passed to xarray Zarr adapter,
+                that is ``xarray.open_zarr(..., **kwargs)``. In
+                addition, the parameter **
+
+        Returns:
+
         """
         path_or_store = path
         consolidated = False
@@ -572,9 +600,7 @@ class ZarrDatasetIO(DatasetIO):
 # noinspection PyAbstractClass
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 class CsvDatasetIO(DatasetIO):
-    """
-    A dataset I/O that reads from / writes to CSV files.
-    """
+    """A dataset I/O that reads from / writes to CSV files."""
 
     def __init__(self):
         super().__init__(FORMAT_NAME_CSV)
@@ -596,10 +622,11 @@ class CsvDatasetIO(DatasetIO):
 
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 def rimraf(*paths: str):
-    """
-    The UNIX command `rm -rf` for xcube.
+    """The UNIX command `rm -rf` for xcube.
     Recursively remove directory or single file.
-    :param paths: one or more directories or files
+
+    Args:
+        *paths: one or more directories or files
     """
     for path in paths:
         if os.path.isdir(path):
@@ -622,8 +649,7 @@ def get_path_or_s3_store(
     s3_client_kwargs: Mapping[str, Any] = None,
     mode: str = "r",
 ) -> Tuple[Union[str, Dict], bool]:
-    """
-    If *path_or_url* is an object storage URL, return a object storage
+    """If *path_or_url* is an object storage URL, return a object storage
     Zarr store (mapping object) using *s3_client_kwargs* and *mode* and
     a flag indicating whether the Zarr datasets is consolidated.
 
@@ -631,11 +657,14 @@ def get_path_or_s3_store(
     returned as-is plus a flag indicating whether the Zarr datasets
     is consolidated.
 
-    :param path_or_url: A path or a URL.
-    :param s3_kwargs: keyword arguments for S3 file system.
-    :param s3_client_kwargs: keyword arguments for S3 boto3 client.
-    :param mode: access mode "r" or "w". "r" is default.
-    :return: A tuple (path_or_obs_store, consolidated).
+    Args:
+        path_or_url: A path or a URL.
+        s3_kwargs: keyword arguments for S3 file system.
+        s3_client_kwargs: keyword arguments for S3 boto3 client.
+        mode: access mode "r" or "w". "r" is default.
+
+    Returns:
+        A tuple (path_or_obs_store, consolidated).
     """
     if is_s3_url(path_or_url) or s3_kwargs is not None or s3_client_kwargs is not None:
         s3, root = parse_s3_fs_and_root(
@@ -661,8 +690,7 @@ def parse_s3_fs_and_root(
     s3_client_kwargs: Mapping[str, Any] = None,
     mode: str = "r",
 ) -> Tuple[s3fs.S3FileSystem, str]:
-    """
-    Parses *s3_url*, *s3_kwargs*, *s3_client_kwargs* and returns a
+    """Parses *s3_url*, *s3_kwargs*, *s3_client_kwargs* and returns a
     new tuple (*obs_fs*, *root_path*). For example
 
     ```
@@ -670,12 +698,15 @@ def parse_s3_fs_and_root(
     obs_map = s3fs.S3Map(root=root_path, s3=obs_fs)
     ```
 
-    :param s3_url: Object storage URL, e.g. "s3://bucket/root",
-        or "https://bucket.s3.amazonaws.com/root".
-    :param s3_kwargs: keyword arguments for S3 file system.
-    :param s3_client_kwargs: keyword arguments for S3 boto3 client.
-    :param mode: Access mode "r" or "w",  "r" is default.
-    :return: A tuple (*obs_fs*, *root_path*).
+    Args:
+        s3_url: Object storage URL, e.g. "s3://bucket/root", or
+            "https://bucket.s3.amazonaws.com/root".
+        s3_kwargs: keyword arguments for S3 file system.
+        s3_client_kwargs: keyword arguments for S3 boto3 client.
+        mode: Access mode "r" or "w",  "r" is default.
+
+    Returns:
+        A tuple (*obs_fs*, *root_path*).
     """
 
     root, s3_kwargs, s3_client_kwargs = parse_s3_url_and_kwargs(
@@ -696,17 +727,19 @@ def new_s3_file_system(
     s3_config_param_name: str = "s3_kwargs",
     check_path: str = None,
 ) -> s3fs.S3FileSystem:
-    """
-    Wrapper for s3fs.S3FileSystem() constructor that issues warnings
+    """Wrapper for s3fs.S3FileSystem() constructor that issues warnings
     in case the file system can not be created.
 
-    :param s3_kwargs: keyword arguments for S3 file system.
-    :param s3_client_kwargs: keyword arguments for S3 boto3 client.
-    :param s3_config_param_name: the name of the configuration parameter.
-    :param check_path: an optional root path.
-        If given, we call s3.exists(check_path)
-        as a check whether S3 file system is valid.
-    :return: A s3fs.S3FileSystem instance.
+    Args:
+        s3_kwargs: keyword arguments for S3 file system.
+        s3_client_kwargs: keyword arguments for S3 boto3 client.
+        s3_config_param_name: the name of the configuration parameter.
+        check_path: an optional root path. If given, we call
+            s3.exists(check_path) as a check whether S3 file system is
+            valid.
+
+    Returns:
+        A s3fs.S3FileSystem instance.
     """
 
     s3_kwargs = s3_kwargs or {}
@@ -739,18 +772,21 @@ def parse_s3_url_and_kwargs(
     s3_kwargs: Mapping[str, Any] = None,
     s3_client_kwargs: Mapping[str, Any] = None,
 ) -> Tuple[str, Dict[str, Any], Dict[str, Any]]:
-    """
-    Parses *obs_url*, *s3_kwargs*, *s3_client_kwargs* and returns a
+    """Parses *obs_url*, *s3_kwargs*, *s3_client_kwargs* and returns a
     new tuple (*root*, *s3_kwargs*, *s3_client_kwargs*) with updated kwargs whose elements
     can be passed to the s3fs.S3FileSystem and s3fs.S3Map constructors as follows:::
 
         obs_fs = s3fs.S3FileSystem(**s3_kwargs, client_kwargs=s3_client_kwargs)
         obs_map = s3fs.S3Map(root=root, s3=obs_fs)
 
-    :param s3_url: Object storage URL, e.g. "s3://bucket/root", or "https://bucket.s3.amazonaws.com/root".
-    :param s3_kwargs: keyword arguments for S3 file system.
-    :param s3_client_kwargs: keyword arguments for S3 boto3 client.
-    :return: A tuple (root, s3_kwargs, s3_client_kwargs).
+    Args:
+        s3_url: Object storage URL, e.g. "s3://bucket/root", or
+            "https://bucket.s3.amazonaws.com/root".
+        s3_kwargs: keyword arguments for S3 file system.
+        s3_client_kwargs: keyword arguments for S3 boto3 client.
+
+    Returns:
+        A tuple (root, s3_kwargs, s3_client_kwargs).
     """
     endpoint_url, root = split_s3_url(s3_url)
 
@@ -778,9 +814,7 @@ def parse_s3_url_and_kwargs(
 
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 def split_s3_url(path: str) -> Tuple[Optional[str], str]:
-    """
-    If *path* is a URL, return tuple (endpoint_url, root), otherwise (None, *path*)
-    """
+    """If *path* is a URL, return tuple (endpoint_url, root), otherwise (None, *path*)"""
     url = urllib3.util.parse_url(path)
     if all((url.scheme, url.host, url.path)) and url.scheme != "s3":
         if url.port is not None:
@@ -796,11 +830,13 @@ def split_s3_url(path: str) -> Tuple[Optional[str], str]:
 
 @deprecated(_DEPRECATION_REASON, version=_DEPRECATION_VERSION)
 def is_s3_url(path_or_url: str) -> bool:
-    """
-    Test if *path_or_url* is a potential object storage URL.
+    """Test if *path_or_url* is a potential object storage URL.
 
-    :param path_or_url: Path or URL to test.
-    :return: True, if so.
+    Args:
+        path_or_url: Path or URL to test.
+
+    Returns:
+        True, if so.
     """
     return (
         path_or_url.startswith("https://")

--- a/xcube/core/dump.py
+++ b/xcube/core/dump.py
@@ -23,13 +23,15 @@ import xarray as xr
 
 
 def dump_dataset(dataset: xr.Dataset, var_names=None, show_var_encoding=False) -> str:
-    """
-    Dumps a dataset or variables into a text string.
+    """Dumps a dataset or variables into a text string.
 
-    :param dataset: input dataset
-    :param var_names: names of variables to be dumped
-    :param show_var_encoding: also dump variable encodings?
-    :return: the dataset dump
+    Args:
+        dataset: input dataset
+        var_names: names of variables to be dumped
+        show_var_encoding: also dump variable encodings?
+
+    Returns:
+        the dataset dump
     """
     lines = []
     if not var_names:
@@ -60,13 +62,15 @@ def dump_dataset(dataset: xr.Dataset, var_names=None, show_var_encoding=False) -
 
 
 def dump_var_encoding(var: xr.DataArray, header="Encoding:", indent=4) -> str:
-    """
-    Dump the encoding information of a variable into a text string.
+    """Dump the encoding information of a variable into a text string.
 
-    :param var: Dataset variable.
-    :param header: Title/header string.
-    :param indent: Indention in spaces.
-    :return: the variable dump
+    Args:
+        var: Dataset variable.
+        header: Title/header string.
+        indent: Indention in spaces.
+
+    Returns:
+        the variable dump
     """
     lines = [header]
     max_len = 0

--- a/xcube/core/evaluate.py
+++ b/xcube/core/evaluate.py
@@ -36,8 +36,7 @@ def evaluate_dataset(
     processed_variables: NameDictPairList = None,
     errors: str = "raise",
 ) -> xr.Dataset:
-    """
-    Compute new variables or mask existing variables in *dataset*
+    """Compute new variables or mask existing variables in *dataset*
     by the evaluation of Python expressions, that may refer to other
     existing or new variables.
     Returns a new dataset that contains the old and new variables,
@@ -69,12 +68,15 @@ def evaluate_dataset(
 
     Other attributes will be stored as variable metadata as-is.
 
-    :param dataset: A dataset.
-    :param processed_variables: Optional list of variable
-        name-attributes pairs that will processed in the given order.
-    :param errors: How to deal with errors while evaluating expressions.
-           May be be one of "raise", "warn", or "ignore".
-    :return: new dataset with computed variables
+    Args:
+        dataset: A dataset.
+        processed_variables: Optional list of variable name-attributes
+            pairs that will processed in the given order.
+        errors: How to deal with errors while evaluating expressions.
+            May be be one of "raise", "warn", or "ignore".
+
+    Returns:
+        new dataset with computed variables
     """
 
     if processed_variables:

--- a/xcube/core/extract.py
+++ b/xcube/core/extract.py
@@ -35,8 +35,7 @@ def get_cube_values_for_points(
     method: str = DEFAULT_INTERP_POINT_METHOD,
     cube_asserted: bool = False,
 ) -> xr.Dataset:
-    """
-    Extract values from *cube* variables at given
+    """Extract values from *cube* variables at given
     coordinates in *points*.
 
     Returns a new dataset with values of variables from *cube* selected
@@ -44,28 +43,32 @@ def get_cube_values_for_points(
     provided in *points*. All variables will be 1-D and have the same order
     as the rows in points.
 
-    :param cube: The cube dataset.
-    :param points: Dictionary that maps dimension name to coordinate arrays.
-    :param var_names: An optional list of names of data variables in *cube*
-        whose values shall be extracted.
-    :param include_coords: Whether to include the cube coordinates for each
-        point in return value.
-    :param include_bounds: Whether to include the cube coordinate boundaries
-        (if any) for each point in return value.
-    :param include_indexes: Whether to include computed indexes into the cube
-        for each point in return value.
-    :param index_name_pattern: A naming pattern for the computed index columns.
-        Must include "{name}" which will be replaced by the index'
-        dimension name.
-    :param include_refs: Whether to include point (reference) values from
-        *points* in return value.
-    :param ref_name_pattern: A naming pattern for the computed point data
-        columns. Must include "{name}" which will be replaced by the point's
-        attribute name.
-    :param method: "nearest" or "linear".
-    :param cube_asserted: If False, *cube* will be verified, otherwise it
-        is expected to be a valid cube.
-    :return: A new data frame whose columns are values from *cube* variables
+    Args:
+        cube: The cube dataset.
+        points: Dictionary that maps dimension name to coordinate
+            arrays.
+        var_names: An optional list of names of data variables in *cube*
+            whose values shall be extracted.
+        include_coords: Whether to include the cube coordinates for each
+            point in return value.
+        include_bounds: Whether to include the cube coordinate
+            boundaries (if any) for each point in return value.
+        include_indexes: Whether to include computed indexes into the
+            cube for each point in return value.
+        index_name_pattern: A naming pattern for the computed index
+            columns. Must include "{name}" which will be replaced by the
+            index' dimension name.
+        include_refs: Whether to include point (reference) values from
+            *points* in return value.
+        ref_name_pattern: A naming pattern for the computed point data
+            columns. Must include "{name}" which will be replaced by the
+            point's attribute name.
+        method: "nearest" or "linear".
+        cube_asserted: If False, *cube* will be verified, otherwise it
+            is expected to be a valid cube.
+
+    Returns:
+        A new data frame whose columns are values from *cube* variables
         at given *points*.
     """
     if not cube_asserted:
@@ -127,25 +130,27 @@ def get_cube_values_for_indexes(
     method: str = DEFAULT_INTERP_POINT_METHOD,
     cube_asserted: bool = False,
 ) -> xr.Dataset:
-    """
-    Get values from the *cube* at given *indexes*.
+    """Get values from the *cube* at given *indexes*.
 
-    :param cube: A cube dataset.
-    :param indexes: A mapping from column names to index and fraction arrays
-        for all cube dimensions.
-    :param include_coords: Whether to include the cube coordinates for each
-        point in return value.
-    :param include_bounds: Whether to include the cube coordinate boundaries
-        (if any) for each point in return value.
-    :param data_var_names: An optional list of names of data variables in
-        *cube* whose values shall be extracted.
-    :param index_name_pattern: A naming pattern for the computed
-        indexes columns. Must include "{name}" which will be replaced by
-        the dimension name.
-    :param method: "nearest" or "linear".
-    :param cube_asserted: If False, *cube* will be verified, otherwise it
-        is expected to be a valid cube.
-    :return: A new data frame whose columns are values from *cube* variables
+    Args:
+        cube: A cube dataset.
+        indexes: A mapping from column names to index and fraction
+            arrays for all cube dimensions.
+        include_coords: Whether to include the cube coordinates for each
+            point in return value.
+        include_bounds: Whether to include the cube coordinate
+            boundaries (if any) for each point in return value.
+        data_var_names: An optional list of names of data variables in
+            *cube* whose values shall be extracted.
+        index_name_pattern: A naming pattern for the computed indexes
+            columns. Must include "{name}" which will be replaced by the
+            dimension name.
+        method: "nearest" or "linear".
+        cube_asserted: If False, *cube* will be verified, otherwise it
+            is expected to be a valid cube.
+
+    Returns:
+        A new data frame whose columns are values from *cube* variables
         at given *indexes*.
     """
     if not cube_asserted:
@@ -256,27 +261,28 @@ def get_cube_point_indexes(
     index_dtype=np.float64,
     cube_asserted: bool = False,
 ) -> xr.Dataset:
-    """
-    Get indexes of given point coordinates *points* into the given *dataset*.
+    """Get indexes of given point coordinates *points* into the given *dataset*.
 
-    :param cube: The cube dataset.
-    :param points: A mapping from column names to column data arrays, which
-        must all have the same length.
-    :param dim_name_mapping: A mapping from dimension names in *cube* to
-        column names in *points*.
-    :param index_name_pattern: A naming pattern for the computed
-        indexes columns. Must include "{name}" which will be replaced by
-        the dimension name.
-    :param index_dtype: Numpy data type for the indexes. If it is a
-        floating point type (default),
-        then *indexes* will contain fractions, which may be
-        used for interpolation.
-        For out-of-range coordinates in *points*, indexes will be -1
-        if *index_dtype* is an integer type, and NaN,
-        if *index_dtype* is a floating point types.
-    :param cube_asserted: If False, *cube* will be verified, otherwise
-        it is expected to be a valid cube.
-    :return: A dataset containing the index columns.
+    Args:
+        cube: The cube dataset.
+        points: A mapping from column names to column data arrays, which
+            must all have the same length.
+        dim_name_mapping: A mapping from dimension names in *cube* to
+            column names in *points*.
+        index_name_pattern: A naming pattern for the computed indexes
+            columns. Must include "{name}" which will be replaced by the
+            dimension name.
+        index_dtype: Numpy data type for the indexes. If it is a
+            floating point type (default), then *indexes* will contain
+            fractions, which may be used for interpolation. For out-of-
+            range coordinates in *points*, indexes will be -1 if
+            *index_dtype* is an integer type, and NaN, if *index_dtype*
+            is a floating point types.
+        cube_asserted: If False, *cube* will be verified, otherwise it
+            is expected to be a valid cube.
+
+    Returns:
+        A dataset containing the index columns.
     """
     if not cube_asserted:
         assert_cube(cube)
@@ -313,8 +319,7 @@ def get_dataset_indexes(
     coord_values: SeriesLike,
     index_dtype=np.float64,
 ) -> Union[xr.DataArray, np.ndarray]:
-    """
-    Compute the indexes and their fractions into a coordinate variable
+    """Compute the indexes and their fractions into a coordinate variable
     *coord_var_name* of a *dataset* for the given coordinate values
     *coord_values*.
 
@@ -329,17 +334,19 @@ def get_dataset_indexes(
     Returns a tuple of indexes as int64 array and fractions as
     float64 array.
 
-    :param dataset: A cube dataset.
-    :param coord_var_name: Name of a coordinate variable.
-    :param coord_values: Array-like coordinate values.
-    :param index_dtype: Numpy data type for the indexes.
-        If it is floating point type (default), then *indexes*
-        contain fractions, which may be used for interpolation.
-        If *dtype* is an integer type out-of-range coordinates
-        are indicated by index -1, and NaN if it is is a
-        floating point type.
-    :return: The indexes and their fractions as a tuple of
-        numpy int64 and float64 arrays.
+    Args:
+        dataset: A cube dataset.
+        coord_var_name: Name of a coordinate variable.
+        coord_values: Array-like coordinate values.
+        index_dtype: Numpy data type for the indexes. If it is floating
+            point type (default), then *indexes* contain fractions,
+            which may be used for interpolation. If *dtype* is an
+            integer type out-of-range coordinates are indicated by index
+            -1, and NaN if it is is a floating point type.
+
+    Returns:
+        The indexes and their fractions as a tuple of numpy int64 and
+        float64 arrays.
     """
     coord_var = dataset[coord_var_name]
     n1 = coord_var.size

--- a/xcube/core/gen/config.py
+++ b/xcube/core/gen/config.py
@@ -37,10 +37,10 @@ def get_config_dict(
     profile_mode: bool = False,
     no_sort_mode: bool = False,
 ):
-    """
-    Get a configuration dictionary from given (command-line) arguments.
+    """Get a configuration dictionary from given (command-line) arguments.
 
-    :return: Configuration dictionary
+    Returns:
+        Configuration dictionary
     :raise OSError, ValueError
     """
 

--- a/xcube/core/gen/gen.py
+++ b/xcube/core/gen/gen.py
@@ -75,31 +75,39 @@ def gen_cube(
     dry_run: bool = False,
     monitor: Callable[..., None] = None,
 ) -> bool:
-    """
-    Generate a xcube dataset from one or more input files.
+    """Generate a xcube dataset from one or more input files.
 
-    :param no_sort_mode:
-    :param input_paths: The input paths.
-    :param input_processor_name: Name of a registered input processor
-        (xcube.core.gen.inputprocessor.InputProcessor) to be used to transform the inputs.
-    :param input_processor_params: Parameters to be passed to the input processor.
-    :param input_reader_name: Name of a registered input reader (xcube.core.util.dsio.DatasetIO).
-    :param input_reader_params: Parameters passed to the input reader.
-    :param output_region: Output region as tuple of floats: (lon_min, lat_min, lon_max, lat_max).
-    :param output_size: The spatial dimensions of the output as tuple of ints: (width, height).
-    :param output_resampling: The resampling method for the output.
-    :param output_path: The output directory.
-    :param output_writer_name: Name of an output writer
-        (xcube.core.util.dsio.DatasetIO) used to write the cube.
-    :param output_writer_params: Parameters passed to the output writer.
-    :param output_metadata: Extra metadata passed to output cube.
-    :param output_variables: Output variables.
-    :param processed_variables: Processed variables computed on-the-fly.
-    :param profile_mode: Whether profiling should be enabled.
-    :param append_mode: Deprecated. The function will always either insert, replace, or append new time slices.
-    :param dry_run: Doesn't write any data. For testing.
-    :param monitor: A progress monitor.
-    :return: True for success.
+    Args:
+        no_sort_mode
+        input_paths: The input paths.
+        input_processor_name: Name of a registered input processor
+            (xcube.core.gen.inputprocessor.InputProcessor) to be used to
+            transform the inputs.
+        input_processor_params: Parameters to be passed to the input
+            processor.
+        input_reader_name: Name of a registered input reader
+            (xcube.core.util.dsio.DatasetIO).
+        input_reader_params: Parameters passed to the input reader.
+        output_region: Output region as tuple of floats: (lon_min,
+            lat_min, lon_max, lat_max).
+        output_size: The spatial dimensions of the output as tuple of
+            ints: (width, height).
+        output_resampling: The resampling method for the output.
+        output_path: The output directory.
+        output_writer_name: Name of an output writer
+            (xcube.core.util.dsio.DatasetIO) used to write the cube.
+        output_writer_params: Parameters passed to the output writer.
+        output_metadata: Extra metadata passed to output cube.
+        output_variables: Output variables.
+        processed_variables: Processed variables computed on-the-fly.
+        profile_mode: Whether profiling should be enabled.
+        append_mode: Deprecated. The function will always either insert,
+            replace, or append new time slices.
+        dry_run: Doesn't write any data. For testing.
+        monitor: A progress monitor.
+
+    Returns:
+        True for success.
     """
 
     if append_mode is not None:

--- a/xcube/core/gen/iproc.py
+++ b/xcube/core/gen/iproc.py
@@ -38,18 +38,21 @@ from xcube.util.plugin import get_extension_registry
 
 
 class ReprojectionInfo:
-    """
-    Characterize input datasets so we can reproject.
+    """Characterize input datasets so we can reproject.
 
-    :param xy_names: Names of variables providing the spatial x- and y-coordinates,
-           e.g. ('longitude', 'latitude')
-    :param xy_tp_names: Optional names of tie-point variables providing the spatial y- and y-coordinates,
-           e.g. ('TP_longitude', 'TP_latitude')
-    :param xy_crs: Optional spatial reference system, e.g. 'EPSG:4326' or WKT or proj4 mapping
-    :param xy_gcp_step: Optional step size for collecting ground control points from spatial
-           coordinate arrays denoted by *xy_names*.
-    :param xy_tp_gcp_step: Optional step size for collecting ground control points from spatial
-           coordinate arrays denoted by *xy_tp_names*.
+    Args:
+        xy_names: Names of variables providing the spatial x- and
+            y-coordinates, e.g. ('longitude', 'latitude')
+        xy_tp_names: Optional names of tie-point variables providing the
+            spatial y- and y-coordinates, e.g. ('TP_longitude',
+            'TP_latitude')
+        xy_crs: Optional spatial reference system, e.g. 'EPSG:4326' or
+            WKT or proj4 mapping
+        xy_gcp_step: Optional step size for collecting ground control
+            points from spatial coordinate arrays denoted by *xy_names*.
+        xy_tp_gcp_step: Optional step size for collecting ground control
+            points from spatial coordinate arrays denoted by
+            *xy_tp_names*.
     """
 
     def __init__(
@@ -137,14 +140,14 @@ class ReprojectionInfo:
 
 
 class InputProcessor(ExtensionComponent, metaclass=ABCMeta):
-    """
-    Read and process inputs for the gen tool.
+    """Read and process inputs for the gen tool.
 
     An InputProcessor can be configured by the following parameters:
 
     * ``input_reader``: The input format identifier. Required, no default.
 
-    :param name: A unique input processor identifier.
+    Args:
+        name: A unique input processor identifier.
     """
 
     def __init__(self, name: str, **parameters):
@@ -155,8 +158,8 @@ class InputProcessor(ExtensionComponent, metaclass=ABCMeta):
 
     @property
     def description(self) -> str:
-        """
-        :return: A description for this input processor
+        """Returns:
+        A description for this input processor
         """
         return self.get_metadata_attr("description", "")
 
@@ -174,43 +177,52 @@ class InputProcessor(ExtensionComponent, metaclass=ABCMeta):
 
     @property
     def input_reader_params(self) -> dict:
-        """
-        :return: The input reader parameters for this input processor.
+        """Returns:
+        The input reader parameters for this input processor.
         """
         return self.parameters.get("input_reader_params", {})
 
     @abstractmethod
     def get_time_range(self, dataset: xr.Dataset) -> Optional[Tuple[float, float]]:
-        """
-        Return a tuple of two floats representing start/stop time (which may be same) in days since 1970.
-        :param dataset: The dataset.
-        :return: The time-range tuple of the dataset or None.
+        """Return a tuple of two floats representing start/stop time (which may be same) in days since 1970.
+
+        Args:
+            dataset: The dataset.
+
+        Returns:
+            The time-range tuple of the dataset or None.
         """
         raise NotImplementedError()
 
     def get_extra_vars(self, dataset: xr.Dataset) -> Optional[Collection[str]]:
-        """
-        Get a set of names of variables that are required as input for the pre-processing and processing
+        """Get a set of names of variables that are required as input for the pre-processing and processing
         steps and should therefore not be dropped.
         However, the processing or post-processing steps may later remove them.
 
         Returns ``None`` by default.
 
-        :param dataset: The dataset.
-        :return: Collection of names of variables to be prevented from being dropping.
+        Args:
+            dataset: The dataset.
+
+        Returns:
+            Collection of names of variables to be prevented from being
+            dropping.
         """
         return None
 
     def pre_process(self, dataset: xr.Dataset) -> xr.Dataset:
-        """
-        Do any pre-processing before reprojection.
+        """Do any pre-processing before reprojection.
         All variables in the output dataset must be 2D arrays with dimensions "lat" and "lon", in this order.
         For example, perform dataset validation, masking, and/or filtering using provided configuration parameters.
 
         The default implementation returns the unchanged *dataset*.
 
-        :param dataset: The dataset.
-        :return: The pre-processed dataset or the original one, if no pre-processing is required.
+        Args:
+            dataset: The dataset.
+
+        Returns:
+            The pre-processed dataset or the original one, if no pre-
+            processing is required.
         """
         return dataset
 
@@ -228,38 +240,44 @@ class InputProcessor(ExtensionComponent, metaclass=ABCMeta):
         output_resampling: str,
         include_non_spatial_vars=False,
     ) -> xr.Dataset:
-        """
-        Perform spatial transformation into the cube's WGS84 SRS such that all variables in the output dataset
+        """Perform spatial transformation into the cube's WGS84 SRS such that all variables in the output dataset
         * must be 2D arrays with dimensions "lat" and "lon", in this order, and
         * must have shape (*dst_size[-1]*, *dst_size[-2]*), and
         * must have *dst_region* as their bounding box in geographic coordinates.
 
-        :param dataset: The input dataset.
-        :param geo_coding: The input's geo-coding.
-        :param output_geom: The output's spatial image geometry.
-        :param output_resampling: The output's spatial resampling method.
-        :param include_non_spatial_vars: Whether to include non-spatial variables in the output.
-        :return: The transformed output dataset or the original one, if no transformation is required.
+        Args:
+            dataset: The input dataset.
+            geo_coding: The input's geo-coding.
+            output_geom: The output's spatial image geometry.
+            output_resampling: The output's spatial resampling method.
+            include_non_spatial_vars: Whether to include non-spatial
+                variables in the output.
+
+        Returns:
+            The transformed output dataset or the original one, if no
+            transformation is required.
         """
         raise NotImplementedError()
 
     def post_process(self, dataset: xr.Dataset) -> xr.Dataset:
-        """
-        Do any post-processing transformation. The input is a 3D array with dimensions ("time", "lat", "lon").
+        """Do any post-processing transformation. The input is a 3D array with dimensions ("time", "lat", "lon").
         Post-processing may, for example, generate new "wavelength" dimension for variables whose name follow
         a certain pattern.
 
         The default implementation returns the unchanged *dataset*.
 
-        :param dataset: The dataset.
-        :return: The post-processed dataset or the original one, if no post-processing is required.
+        Args:
+            dataset: The dataset.
+
+        Returns:
+            The post-processed dataset or the original one, if no post-
+            processing is required.
         """
         return dataset
 
 
 class XYInputProcessor(InputProcessor, metaclass=ABCMeta):
-    """
-    Read and process inputs for the gen tool.
+    """Read and process inputs for the gen tool.
 
     An XYInputProcessor can be configured by the following parameters:
 
@@ -286,10 +304,13 @@ class XYInputProcessor(InputProcessor, metaclass=ABCMeta):
         return default_parameters
 
     def get_reprojection_info(self, dataset: xr.Dataset) -> ReprojectionInfo:
-        """
-        Information about special fields in input datasets used for reprojection.
-        :param dataset: The dataset.
-        :return: The reprojection information of the dataset or None.
+        """Information about special fields in input datasets used for reprojection.
+
+        Args:
+            dataset: The dataset.
+
+        Returns:
+            The reprojection information of the dataset or None.
         """
         parameters = self.parameters
         return ReprojectionInfo(
@@ -301,8 +322,7 @@ class XYInputProcessor(InputProcessor, metaclass=ABCMeta):
         )
 
     def get_extra_vars(self, dataset: xr.Dataset) -> Optional[Collection[str]]:
-        """
-        Return the names of variables containing spatial coordinates.
+        """Return the names of variables containing spatial coordinates.
         They should not be removed, as they are required for the reprojection.
         """
         reprojection_info = self.get_reprojection_info(dataset)
@@ -323,9 +343,7 @@ class XYInputProcessor(InputProcessor, metaclass=ABCMeta):
         output_resampling: str,
         include_non_spatial_vars=False,
     ) -> xr.Dataset:
-        """
-        Perform reprojection using tie-points / ground control points.
-        """
+        """Perform reprojection using tie-points / ground control points."""
         reprojection_info = self.get_reprojection_info(dataset)
 
         warn_prefix = "unsupported argument in np-GCP rectification mode"
@@ -388,8 +406,7 @@ class XYInputProcessor(InputProcessor, metaclass=ABCMeta):
 
 
 class DefaultInputProcessor(XYInputProcessor):
-    """
-    Default input processor that expects input datasets to have the xcube standard format:
+    """Default input processor that expects input datasets to have the xcube standard format:
 
     * Have dimensions ``lat``, ``lon``, optionally ``time`` of length 1;
     * have coordinate variables ``lat[lat]``, ``lon[lat]``, ``time[time]`` (opt.), ``time_bnds[time, 2]`` (opt.);
@@ -507,11 +524,14 @@ class DefaultInputProcessor(XYInputProcessor):
 
 
 def _normalize_lon_360(dataset: xr.Dataset) -> xr.Dataset:
-    """
-    Fix the longitude of the given dataset ``dataset`` so that it ranges from -180 to +180 degrees.
+    """Fix the longitude of the given dataset ``dataset`` so that it ranges from -180 to +180 degrees.
 
-    :param dataset: The dataset whose longitudes may be given in the range 0 to 360.
-    :return: The fixed dataset or the original dataset.
+    Args:
+        dataset: The dataset whose longitudes may be given in the range
+            0 to 360.
+
+    Returns:
+        The fixed dataset or the original dataset.
     """
 
     if "lon" not in dataset.coords:

--- a/xcube/core/gen2/config.py
+++ b/xcube/core/gen2/config.py
@@ -228,11 +228,14 @@ class CubeConfig(JsonObject):
             self.variable_metadata = dict(variable_metadata)
 
     def drop_props(self, name: Union[str, Iterable[str]]):
-        """
-        Drop one or more named properties from this configuration.
-        :param name: the name of the property to be dropped.
-        :param names: more names of properties to be dropped.
-        :return: a new cube configuration.
+        """Drop one or more named properties from this configuration.
+
+        Args:
+            name: the name of the property to be dropped.
+            names: more names of properties to be dropped.
+
+        Returns:
+            a new cube configuration.
         """
         if not name:
             return self

--- a/xcube/core/gen2/error.py
+++ b/xcube/core/gen2/error.py
@@ -25,18 +25,18 @@ from xcube.util.assertions import assert_instance
 
 
 class CubeGeneratorError(ValueError):
-    """
-    Represent a client or server error that
+    """Represent a client or server error that
     may occur in the data cube generators.
 
-    :param args: arguments passed to base exceptions.
-    :param status_code: Optional status code of the error (an integer).
-        If given, HTTP error codes should be used.
-        The range 400-499 indicates client errors.
-        The range 500-599 indicates server errors.
-    :param remote_traceback: Traceback of an error
-        occurred in a remote process.
-    :param remote_output:  Terminal output of a remote process.
+    Args:
+        args: arguments passed to base exceptions.
+        status_code: Optional status code of the error (an integer). If
+            given, HTTP error codes should be used. The range 400-499
+            indicates client errors. The range 500-599 indicates server
+            errors.
+        remote_traceback: Traceback of an error occurred in a remote
+            process.
+        remote_output: Terminal output of a remote process.
     """
 
     def __init__(
@@ -57,24 +57,21 @@ class CubeGeneratorError(ValueError):
 
     @property
     def status_code(self) -> Optional[int]:
-        """
-        Status code of the error.
+        """Status code of the error.
         May be None.
         """
         return self._status_code
 
     @property
     def remote_traceback(self) -> Optional[List[str]]:
-        """
-        Traceback of an error occurred in a remote process.
+        """Traceback of an error occurred in a remote process.
         May be None.
         """
         return self._remote_traceback
 
     @property
     def remote_output(self) -> Optional[List[str]]:
-        """
-        Terminal output of a remote process.
+        """Terminal output of a remote process.
         May be None.
         """
         return self._remote_output

--- a/xcube/core/gen2/local/generator.py
+++ b/xcube/core/gen2/local/generator.py
@@ -51,21 +51,21 @@ from ..response import CubeReference
 
 
 class LocalCubeGenerator(CubeGenerator):
-    """
-    Generator tool for data cubes.
+    """Generator tool for data cubes.
 
     Creates cube views from one or more cube stores, resamples them to a
     common grid, optionally performs some cube transformation, and writes
     the resulting cube to some target cube store.
 
-    :param store_pool: An optional pool of pre-configured data stores
-        referenced from *gen_config* input/output configurations.
-    :param verbosity: Level of verbosity, 0 means off.
-    :param raise_on_error: Whether to raise a CubeGeneratorError
-        exception on generator failures. If False, the default,
-        the returned result will have the "status" field set to "error"
-        while other fields such as "message", "traceback", "output"
-        provide more failure details.
+    Args:
+        store_pool: An optional pool of pre-configured data stores
+            referenced from *gen_config* input/output configurations.
+        verbosity: Level of verbosity, 0 means off.
+        raise_on_error: Whether to raise a CubeGeneratorError exception
+            on generator failures. If False, the default, the returned
+            result will have the "status" field set to "error" while
+            other fields such as "message", "traceback", "output"
+            provide more failure details.
     """
 
     def __init__(

--- a/xcube/core/gen2/local/informant.py
+++ b/xcube/core/gen2/local/informant.py
@@ -163,15 +163,15 @@ class CubeInformant:
     def _compute_effective_cube_config(
         self,
     ) -> Tuple[CubeConfig, pyproj.crs.CRS, Sequence[pd.Timestamp]]:
-        """
-        Compute the effective cube configuration.
+        """Compute the effective cube configuration.
 
         This method reflects the behaviour of the LocalCubeGenerator
         that would normalize, tailor, and optionally resample a dataset
         based on the dataset descriptor and the cube configuration parameters,
         in the case that a store is not able to do so.
 
-        :return: effective cube configuration.
+        Returns:
+            effective cube configuration.
         """
 
         request = self._request

--- a/xcube/core/gen2/local/transformer.py
+++ b/xcube/core/gen2/local/transformer.py
@@ -54,9 +54,7 @@ class CubeIdentity(CubeTransformer):
     def transform_cube(
         self, cube: xr.Dataset, gm: GridMapping, cube_config: CubeConfig
     ) -> TransformedCube:
-        """
-        Return *cube*, grid mapping *gm*, and parameters without change.
-        """
+        """Return *cube*, grid mapping *gm*, and parameters without change."""
         return cube, gm, cube_config
 
 

--- a/xcube/core/gen2/processor.py
+++ b/xcube/core/gen2/processor.py
@@ -41,29 +41,28 @@ METHOD_NAME_PARAMS_SCHEMA_GETTER = "get_process_params_schema"
 
 
 class DatasetProcessor(ABC):
-    """
-    A generic dataset processor.
-    """
+    """A generic dataset processor."""
 
     @abstractmethod
     def process_dataset(self, dataset: xr.Dataset, **process_params) -> xr.Dataset:
-        """
-        Process *dataset* into a new dataset using the
+        """Process *dataset* into a new dataset using the
         given processing parameters *process_params*.
 
         The passed *process_params* must validate against
         the JSON schema returned by the :meth:get_process_params_schema
         class method.
 
-        :param dataset: The dataset to be processed.
-        :param process_params: The processing parameters.
-        :return: A new dataset.
+        Args:
+            dataset: The dataset to be processed.
+            **process_params: The processing parameters.
+
+        Returns:
+            A new dataset.
         """
 
     @classmethod
     def get_process_params_schema(cls) -> JsonObjectSchema:
-        """
-        Get the JSON Schema for the processing parameters passed
+        """Get the JSON Schema for the processing parameters passed
         to :meth:process_dataset.
 
         The parameters are described by the JSON Object Schema's
@@ -72,6 +71,7 @@ class DatasetProcessor(ABC):
         The default implementation returns a JSON Schema
         that allows for any parameters of any type.
 
-        :return: a JSON Object Schema.
+        Returns:
+            a JSON Object Schema.
         """
         return JsonObjectSchema(additional_properties=True)

--- a/xcube/core/gen2/progress.py
+++ b/xcube/core/gen2/progress.py
@@ -54,15 +54,12 @@ def _format_time(t):
 
 
 class _ThreadedProgressObserver(ProgressObserver):
-    """
-    A threaded Progress observer adapted from Dask's ProgressBar class.
-    """
+    """A threaded Progress observer adapted from Dask's ProgressBar class."""
 
     def __init__(self, minimum: float = 0, dt: float = 1, timeout: float = None):
-        """
-
-        :type dt: float
-        :type minimum: float
+        """Args:
+        dt (float)
+        minimum (float)
         """
         super().__init__()
         assert_true(dt >= 0, "The timer's time step must be >=0")
@@ -139,12 +136,13 @@ class _ThreadedProgressObserver(ProgressObserver):
     def callback(
         self, sender: str, elapsed: float, state_stack: Sequence[ProgressState]
     ):
-        """
+        """Args:
+            sender
+            elapsed
+            state_stack
 
-        :param sender:
-        :param elapsed:
-        :param state_stack:
-        :return:
+        Returns:
+
         """
 
 

--- a/xcube/core/gen2/remote/config.py
+++ b/xcube/core/gen2/remote/config.py
@@ -50,8 +50,7 @@ class ServiceConfig(JsonObject):
 
     @classmethod
     def normalize(cls, service_config: ServiceConfigLike) -> "ServiceConfig":
-        """
-        Normalize given *service_config* to an instance of
+        """Normalize given *service_config* to an instance of
         :class:ServiceConfig.
 
         If *service_config* is already a ServiceConfig it is returned as is.

--- a/xcube/core/gen2/remote/generator.py
+++ b/xcube/core/gen2/remote/generator.py
@@ -51,20 +51,20 @@ R = TypeVar("R", bound=JsonObject)
 
 
 class RemoteCubeGenerator(CubeGenerator):
-    """
-    A cube generator that uses a remote cube generator remote.
+    """A cube generator that uses a remote cube generator remote.
 
     Creates cube views from one or more cube stores, resamples them to a
     common grid, optionally performs some cube transformation, and writes
     the resulting cube to some target cube store.
 
-    :param service_config: An remote configuration object.
-    :param verbosity: Level of verbosity, 0 means off.
-    :param raise_on_error: Whether to raise a CubeGeneratorError
-        exception on generator failures. If False, the default,
-        the returned result will have the "status" field set to "error"
-        while other fields such as "message", "traceback", "output"
-        provide more failure details.
+    Args:
+        service_config: An remote configuration object.
+        verbosity: Level of verbosity, 0 means off.
+        raise_on_error: Whether to raise a CubeGeneratorError exception
+            on generator failures. If False, the default, the returned
+            result will have the "status" field set to "error" while
+            other fields such as "message", "traceback", "output"
+            provide more failure details.
     """
 
     def __init__(
@@ -315,8 +315,7 @@ class RemoteCubeGenerator(CubeGenerator):
 
     @classmethod
     def __dump_json(cls, method, url, request_data, response_data):
-        """
-        Dump debug info as JSON to stdout.
+        """Dump debug info as JSON to stdout.
 
         Used for debugging only.
         """

--- a/xcube/core/geom.py
+++ b/xcube/core/geom.py
@@ -305,40 +305,41 @@ def mask_dataset_by_geometry(
     save_geometry_mask: Union[str, bool] = False,
     save_geometry_wkt: Union[str, bool] = False,
 ) -> Optional[xr.Dataset]:
-    """
-    Mask a dataset according to the given geometry. The cells of
+    """Mask a dataset according to the given geometry. The cells of
     variables of the returned dataset will have NaN-values where their
     spatial coordinates are not intersecting
     the given geometry.
 
-    :param dataset: The dataset
-    :param geometry: A geometry-like object,
-        see py:function:`convert_geometry`.
-    :param tile_size: If given, the unconditional spatial chunk sizes
-        in x- and y-direction in pixels.
-        May be given as integer scalar or x,y-pair of integers.
-    :param excluded_vars: Optional sequence of names of data variables
-        that should not be masked (but still may be clipped).
-    :param no_clip: If True, the function will not clip the dataset
-        before masking, this is, the returned dataset will have the same
-        dimension size as the given *dataset*.
-    :param all_touched: If True, all pixels intersected by geometry outlines
-        will be included in the mask. If False, only pixels whose center is
-        within the polygon or that are selected by Bresenham’s line
-        algorithm will be included in the mask.
-        The default value is set to `False`.
-    :param save_geometry_mask: If the value is a string,
-        the effective geometry mask array is stored as a 2D data variable
-        named by *save_geometry_mask*. If the value is True,
-        the name "geometry_mask" is used.
-    :param save_geometry_wkt: If the value is a string,
-        the effective intersection geometry is stored as
-        a Geometry WKT string in the global attribute named
-        by *save_geometry*.
-        If the value is True, the name "geometry_wkt" is used.
-    :return: The dataset spatial subset, or None if the bounding box
-        of the dataset has a no or a zero area intersection with the
-        bounding box of the geometry.
+    Args:
+        dataset: The dataset
+        geometry: A geometry-like object, see
+            py:function:`convert_geometry`.
+        tile_size: If given, the unconditional spatial chunk sizes in x-
+            and y-direction in pixels. May be given as integer scalar or
+            x,y-pair of integers.
+        excluded_vars: Optional sequence of names of data variables that
+            should not be masked (but still may be clipped).
+        no_clip: If True, the function will not clip the dataset before
+            masking, this is, the returned dataset will have the same
+            dimension size as the given *dataset*.
+        all_touched: If True, all pixels intersected by geometry
+            outlines will be included in the mask. If False, only pixels
+            whose center is within the polygon or that are selected by
+            Bresenham’s line algorithm will be included in the mask.
+            The default value is set to `False`.
+        save_geometry_mask: If the value is a string, the effective
+            geometry mask array is stored as a 2D data variable named by
+            *save_geometry_mask*. If the value is True, the name
+            "geometry_mask" is used.
+        save_geometry_wkt: If the value is a string, the effective
+            intersection geometry is stored as a Geometry WKT string in
+            the global attribute named by *save_geometry*. If the value
+            is True, the name "geometry_wkt" is used.
+
+    Returns:
+        The dataset spatial subset, or None if the bounding box of the
+        dataset has a no or a zero area intersection with the bounding
+        box of the geometry.
     """
     geometry = normalize_geometry(geometry)
     xy_var_names = get_dataset_xy_var_names(dataset, must_exist=True)
@@ -453,21 +454,22 @@ def clip_dataset_by_geometry(
     geometry: GeometryLike,
     save_geometry_wkt: Union[str, bool] = False,
 ) -> Optional[xr.Dataset]:
-    """
-    Spatially clip a dataset according to the bounding box of a
+    """Spatially clip a dataset according to the bounding box of a
     given geometry.
 
-    :param dataset: The dataset
-    :param geometry: A geometry-like object,
-        see py:function:`convert_geometry`.
-    :param save_geometry_wkt: If the value is a string,
-        the effective intersection geometry is stored as
-        a Geometry WKT string in the global attribute named
-        by *save_geometry*. If the value is True, the name
-        "geometry_wkt" is used.
-    :return: The dataset spatial subset, or None if the bounding
-        box of the dataset has a no or a zero area
-        intersection with the bounding box of the geometry.
+    Args:
+        dataset: The dataset
+        geometry: A geometry-like object, see
+            py:function:`convert_geometry`.
+        save_geometry_wkt: If the value is a string, the effective
+            intersection geometry is stored as a Geometry WKT string in
+            the global attribute named by *save_geometry*. If the value
+            is True, the name "geometry_wkt" is used.
+
+    Returns:
+        The dataset spatial subset, or None if the bounding box of the
+        dataset has a no or a zero area intersection with the bounding
+        box of the geometry.
     """
     xy_var_names = get_dataset_xy_var_names(dataset, must_exist=True)
     intersection_geometry = intersect_geometries(
@@ -556,8 +558,7 @@ def intersect_geometries(
 def normalize_geometry(
     geometry: Optional[GeometryLike],
 ) -> Optional[shapely.geometry.base.BaseGeometry]:
-    """
-    Convert a geometry-like object into a shapely geometry
+    """Convert a geometry-like object into a shapely geometry
     object (``shapely.geometry.BaseGeometry``).
 
     A geometry-like object may be any shapely geometry object,
@@ -577,8 +578,11 @@ def normalize_geometry(
     * In all other cases, 2D geometries are assumed to _not cross
       the anti-meridian at all_.
 
-    :param geometry: A geometry-like object
-    :return: Shapely geometry object or None.
+    Args:
+        geometry: A geometry-like object
+
+    Returns:
+        Shapely geometry object or None.
     """
 
     if isinstance(geometry, shapely.geometry.base.BaseGeometry):

--- a/xcube/core/gridmapping/base.py
+++ b/xcube/core/gridmapping/base.py
@@ -60,8 +60,7 @@ DEFAULT_TOLERANCE = 1.0e-5
 
 
 class GridMapping(abc.ABC):
-    """
-    An abstract base class for grid mappings that define an image grid and
+    """An abstract base class for grid mappings that define an image grid and
     a transformation from image pixel coordinates to spatial Earth coordinates
     defined in a well-known coordinate reference system (CRS).
 
@@ -164,14 +163,16 @@ class GridMapping(abc.ABC):
         tile_size: Union[int, Tuple[int, int]] = None,
         is_j_axis_up: bool = None,
     ):
-        """
-        Derive a new grid mapping from this one with some properties changed.
+        """Derive a new grid mapping from this one with some properties changed.
 
-        :param xy_var_names: The new x-, and y-variable names.
-        :param xy_dim_names: The new x-, and y-dimension names.
-        :param tile_size: The new tile size
-        :param is_j_axis_up: Whether j-axis points up.
-        :return: A new, derived grid mapping.
+        Args:
+            xy_var_names: The new x-, and y-variable names.
+            xy_dim_names: The new x-, and y-dimension names.
+            tile_size: The new tile size
+            is_j_axis_up: Whether j-axis points up.
+
+        Returns:
+            A new, derived grid mapping.
         """
         other = copy.copy(self)
         if xy_var_names is not None:
@@ -206,8 +207,7 @@ class GridMapping(abc.ABC):
         xy_scale: Union[Number, Tuple[Number, Number]],
         tile_size: Union[int, Tuple[int, int]] = None,
     ) -> "GridMapping":
-        """
-        Derive a scaled version of this regular grid mapping.
+        """Derive a scaled version of this regular grid mapping.
 
         Scaling factors lower than one correspond to up-scaling
         (pixels sizes decrease, image size increases).
@@ -215,10 +215,13 @@ class GridMapping(abc.ABC):
         Scaling factors larger than one correspond to down-scaling.
         (pixels sizes increase, image size decreases).
 
-        :param xy_scale: The x-, and y-scaling factors.
-            May be a single number or tuple.
-        :param tile_size: The new tile size
-        :return: A new, scaled grid mapping.
+        Args:
+            xy_scale: The x-, and y-scaling factors. May be a single
+                number or tuple.
+            tile_size: The new tile size
+
+        Returns:
+            A new, scaled grid mapping.
         """
         self._assert_regular()
         x_scale, y_scale = _normalize_number_pair(xy_scale)
@@ -303,8 +306,7 @@ class GridMapping(abc.ABC):
 
     @property
     def xy_coords(self) -> xr.DataArray:
-        """
-        The x,y coordinates as data array of shape (2, height, width).
+        """The x,y coordinates as data array of shape (2, height, width).
         Coordinates are given in units of the CRS.
         """
         xy_coords = self._get_computed_attribute("_xy_coords", self._new_xy_coords)
@@ -338,16 +340,14 @@ class GridMapping(abc.ABC):
 
     @property
     def xy_var_names(self) -> Tuple[str, str]:
-        """
-        The variable names of the x,y coordinates as
+        """The variable names of the x,y coordinates as
         tuple (x_var_name, y_var_name).
         """
         return self._xy_var_names
 
     @property
     def xy_dim_names(self) -> Tuple[str, str]:
-        """
-        The dimension names of the x,y coordinates as
+        """The dimension names of the x,y coordinates as
         tuple (x_dim_name, y_dim_name).
         """
         return self._xy_dim_names
@@ -403,8 +403,7 @@ class GridMapping(abc.ABC):
 
     @property
     def is_lon_360(self) -> Optional[bool]:
-        """
-        Check whether *x_max* is greater than 180 degrees.
+        """Check whether *x_max* is greater than 180 degrees.
         Effectively tests whether the range *x_min*, *x_max* crosses
         the anti-meridian at 180 degrees.
         Works only for geographical coordinate reference systems.
@@ -413,8 +412,7 @@ class GridMapping(abc.ABC):
 
     @property
     def is_regular(self) -> Optional[bool]:
-        """
-        Do the x,y coordinates for a regular grid?
+        """Do the x,y coordinates for a regular grid?
         A regular grid has a constant delta in both
         x- and y-directions of the x- and y-coordinates.
         :return None, if this property cannot be determined,
@@ -424,8 +422,7 @@ class GridMapping(abc.ABC):
 
     @property
     def is_j_axis_up(self) -> Optional[bool]:
-        """
-        Does the positive image j-axis point up?
+        """Does the positive image j-axis point up?
         By default, the positive image j-axis points down.
          :return None, if this property cannot be determined,
             True or False otherwise.
@@ -434,8 +431,7 @@ class GridMapping(abc.ABC):
 
     @property
     def ij_to_xy_transform(self) -> AffineTransformMatrix:
-        """
-        The affine transformation matrix from image to CRS coordinates.
+        """The affine transformation matrix from image to CRS coordinates.
         Defined only for grid mappings with rectified x,y coordinates.
         """
         self._assert_regular()
@@ -452,23 +448,24 @@ class GridMapping(abc.ABC):
 
     @property
     def xy_to_ij_transform(self) -> AffineTransformMatrix:
-        """
-        The affine transformation matrix from CRS to image coordinates.
+        """The affine transformation matrix from CRS to image coordinates.
         Defined only for grid mappings with rectified x,y coordinates.
         """
         self._assert_regular()
         return _from_affine(~_to_affine(self.ij_to_xy_transform))
 
     def ij_transform_to(self, other: "GridMapping") -> AffineTransformMatrix:
-        """
-        Get the affine transformation matrix that transforms
+        """Get the affine transformation matrix that transforms
         image coordinates of *other* into image coordinates
         of this image geometry.
 
         Defined only for grid mappings with rectified x,y coordinates.
 
-        :param other: The other image geometry
-        :return: Affine transformation matrix
+        Args:
+            other: The other image geometry
+
+        Returns:
+            Affine transformation matrix
         """
         self._assert_regular()
         self.assert_regular(other, name="other")
@@ -477,15 +474,17 @@ class GridMapping(abc.ABC):
         return _from_affine(b * a)
 
     def ij_transform_from(self, other: "GridMapping") -> AffineTransformMatrix:
-        """
-        Get the affine transformation matrix that transforms
+        """Get the affine transformation matrix that transforms
         image coordinates of this image geometry to image
         coordinates of *other*.
 
         Defined only for grid mappings with rectified x,y coordinates.
 
-        :param other: The other image geometry
-        :return: Affine transformation matrix
+        Args:
+            other: The other image geometry
+
+        Returns:
+            Affine transformation matrix
         """
         self._assert_regular()
         self.assert_regular(other, name="other")
@@ -535,19 +534,21 @@ class GridMapping(abc.ABC):
         xy_border: float = 0.0,
         ij_border: int = 0,
     ) -> Tuple[int, int, int, int]:
-        """
-        Compute bounding box in i,j pixel coordinates given a
+        """Compute bounding box in i,j pixel coordinates given a
         bounding box *xy_bbox* in x,y coordinates.
 
-        :param xy_bbox: Box (x_min, y_min, x_max, y_max) given in
-            the same CS as x and y.
-        :param xy_border: If non-zero, grows the bounding box *xy_bbox*
-            before using it for comparisons. Defaults to 0.
-        :param ij_border: If non-zero, grows the returned i,j
-            bounding box and clips it to size. Defaults to 0.
-        :return: Bounding box in (i_min, j_min, i_max, j_max)
-            in pixel coordinates. Returns ``(-1, -1, -1, -1)``
-            if *xy_bbox* isn't intersecting any of the x,y coordinates.
+        Args:
+            xy_bbox: Box (x_min, y_min, x_max, y_max) given in the same
+                CS as x and y.
+            xy_border: If non-zero, grows the bounding box *xy_bbox*
+                before using it for comparisons. Defaults to 0.
+            ij_border: If non-zero, grows the returned i,j bounding box
+                and clips it to size. Defaults to 0.
+
+        Returns:
+            Bounding box in (i_min, j_min, i_max, j_max) in pixel
+            coordinates. Returns ``(-1, -1, -1, -1)`` if *xy_bbox* isn't
+            intersecting any of the x,y coordinates.
         """
         xy_bboxes = np.array([xy_bbox], dtype=np.float64)
         ij_bboxes = np.full_like(xy_bboxes, -1, dtype=np.int64)
@@ -564,8 +565,7 @@ class GridMapping(abc.ABC):
         ij_border: int = 0,
         ij_bboxes: np.ndarray = None,
     ) -> np.ndarray:
-        """
-        Compute bounding boxes in pixel coordinates given bounding boxes
+        """Compute bounding boxes in pixel coordinates given bounding boxes
         *xy_bboxes* [[x_min, y_min, x_max, y_max], ...] in x,y coordinates.
 
         The returned array in i,j pixel coordinates
@@ -577,18 +577,20 @@ class GridMapping(abc.ABC):
 
         so the i,j pixel coordinates can be used as array index slices.
 
-        :param xy_bboxes: Numpy array of x,y bounding boxes
-            [[x_min, y_min, x_max, y_max], ...] given in the same
-            CS as x and y.
-        :param xy_border: If non-zero, grows the bounding box *xy_bbox*
-            before using it for comparisons. Defaults to 0.
-        :param ij_border: If non-zero, grows the returned i,j
-            bounding box and clips it to size. Defaults to 0.
-        :param ij_bboxes: Numpy array of pixel i,j bounding boxes
-            [[x_min, y_min, x_max, y_max], ...]. If given, must have
-            same shape as *xy_bboxes*.
-        :return: Bounding boxes in [[i_min, j_min, i_max, j_max], ..]]
-            in pixel coordinates.
+        Args:
+            xy_bboxes: Numpy array of x,y bounding boxes [[x_min, y_min,
+                x_max, y_max], ...] given in the same CS as x and y.
+            xy_border: If non-zero, grows the bounding box *xy_bbox*
+                before using it for comparisons. Defaults to 0.
+            ij_border: If non-zero, grows the returned i,j bounding box
+                and clips it to size. Defaults to 0.
+            ij_bboxes: Numpy array of pixel i,j bounding boxes [[x_min,
+                y_min, x_max, y_max], ...]. If given, must have same
+                shape as *xy_bboxes*.
+
+        Returns:
+            Bounding boxes in [[i_min, j_min, i_max, j_max], ..]] in
+            pixel coordinates.
         """
         from .bboxes import compute_ij_bboxes
 
@@ -603,11 +605,11 @@ class GridMapping(abc.ABC):
         return ij_bboxes
 
     def to_dataset_attrs(self) -> Mapping[str, Any]:
-        """
-        Get spatial dataset attributes as recommended by
+        """Get spatial dataset attributes as recommended by
         https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3#Recommended
 
-        :return: dictionary with dataset coordinate attributes.
+        Returns:
+            dictionary with dataset coordinate attributes.
         """
 
         x1, y1, x2, y2 = self.xy_bbox
@@ -664,22 +666,23 @@ class GridMapping(abc.ABC):
         exclude_bounds: bool = False,
         reuse_coords: bool = False,
     ) -> Mapping[str, xr.DataArray]:
-        """
-        Get CF-compliant axis coordinate variables and cell boundary
+        """Get CF-compliant axis coordinate variables and cell boundary
         coordinate variables.
 
         Defined only for grid mappings with regular x,y coordinates.
 
-        :param xy_var_names: Optional coordinate variable
-            names (x_var_name, y_var_name).
-        :param xy_dim_names: Optional coordinate dimensions
-            names (x_dim_name, y_dim_name).
-        :param exclude_bounds: If True, do not create bounds
-            coordinates. Defaults to False.
-        :param reuse_coords: Whether to either reuse target
-            coordinate arrays from target_gm or to compute
-            new ones.
-        :return: dictionary with coordinate variables
+        Args:
+            xy_var_names: Optional coordinate variable names
+                (x_var_name, y_var_name).
+            xy_dim_names: Optional coordinate dimensions names
+                (x_dim_name, y_dim_name).
+            exclude_bounds: If True, do not create bounds coordinates.
+                Defaults to False.
+            reuse_coords: Whether to either reuse target coordinate
+                arrays from target_gm or to compute new ones.
+
+        Returns:
+            dictionary with coordinate variables
         """
         self._assert_regular()
         from .coords import grid_mapping_to_coords
@@ -700,17 +703,19 @@ class GridMapping(abc.ABC):
         xy_var_names: Tuple[str, str] = None,
         tolerance: float = DEFAULT_TOLERANCE,
     ) -> "GridMapping":
-        """
-        Transform this grid mapping so it uses the given
+        """Transform this grid mapping so it uses the given
         spatial coordinate reference system into another *crs*.
 
-        :param crs: The new spatial coordinate reference system.
-        :param tile_size: Optional new tile size.
-        :param xy_var_names: Optional new coordinate names.
-        :param tolerance: Absolute tolerance used when comparing
-            coordinates with each other. Must be in the units
-            of the *crs* and must be greater zero.
-        :return: A new grid mapping that uses *crs*.
+        Args:
+            crs: The new spatial coordinate reference system.
+            tile_size: Optional new tile size.
+            xy_var_names: Optional new coordinate names.
+            tolerance: Absolute tolerance used when comparing
+                coordinates with each other. Must be in the units of the
+                *crs* and must be greater zero.
+
+        Returns:
+            A new grid mapping that uses *crs*.
         """
         from .transform import transform_grid_mapping
 
@@ -733,17 +738,19 @@ class GridMapping(abc.ABC):
         tile_size: Union[int, Tuple[int, int]] = None,
         is_j_axis_up: bool = False,
     ) -> "GridMapping":
-        """
-        Create a new regular grid mapping.
+        """Create a new regular grid mapping.
 
-        :param size: Size in pixels.
-        :param xy_min: Minimum x- and y-coordinates.
-        :param xy_res: Resolution in x- and y-directions.
-        :param crs: Spatial coordinate reference system.
-        :param tile_size: Optional tile size.
-        :param is_j_axis_up: Whether positive j-axis points up.
-            Defaults to false.
-        :return: A new regular grid mapping.
+        Args:
+            size: Size in pixels.
+            xy_min: Minimum x- and y-coordinates.
+            xy_res: Resolution in x- and y-directions.
+            crs: Spatial coordinate reference system.
+            tile_size: Optional tile size.
+            is_j_axis_up: Whether positive j-axis points up. Defaults to
+                false.
+
+        Returns:
+            A new regular grid mapping.
         """
         from .regular import new_regular_grid_mapping
 
@@ -759,14 +766,16 @@ class GridMapping(abc.ABC):
     def to_regular(
         self, tile_size: Union[int, Tuple[int, int]] = None, is_j_axis_up: bool = False
     ) -> "GridMapping":
-        """
-        Transform this grid mapping into one that is regular.
+        """Transform this grid mapping into one that is regular.
 
-        :param tile_size: Optional tile size.
-        :param is_j_axis_up: Whether positive j-axis points up.
-            Defaults to false.
-        :return: A new regular grid mapping or this grid mapping,
-            if it is already regular.
+        Args:
+            tile_size: Optional tile size.
+            is_j_axis_up: Whether positive j-axis points up. Defaults to
+                false.
+
+        Returns:
+            A new regular grid mapping or this grid mapping, if it is
+            already regular.
         """
         from .regular import to_regular_grid_mapping
 
@@ -786,22 +795,24 @@ class GridMapping(abc.ABC):
         emit_warnings: bool = False,
         tolerance: float = DEFAULT_TOLERANCE,
     ) -> "GridMapping":
-        """
-        Create a grid mapping for the given *dataset*.
+        """Create a grid mapping for the given *dataset*.
 
-        :param dataset: The dataset.
-        :param crs: Optional spatial coordinate reference system.
-        :param tile_size: Optional tile size
-        :param prefer_is_regular: Whether to prefer a regular
-            grid mapping if multiple found. Default is True.
-        :param prefer_crs: The preferred CRS of a grid mapping
-            if multiple found.
-        :param emit_warnings: Whether to emit warning for
-            non-CF compliant datasets.
-        :param tolerance: Absolute tolerance used when comparing
-            coordinates with each other. Must be in the units
-            of the *crs* and must be greater zero.
-        :return: a new grid mapping instance.
+        Args:
+            dataset: The dataset.
+            crs: Optional spatial coordinate reference system.
+            tile_size: Optional tile size
+            prefer_is_regular: Whether to prefer a regular grid mapping
+                if multiple found. Default is True.
+            prefer_crs: The preferred CRS of a grid mapping if multiple
+                found.
+            emit_warnings: Whether to emit warning for non-CF compliant
+                datasets.
+            tolerance: Absolute tolerance used when comparing
+                coordinates with each other. Must be in the units of the
+                *crs* and must be greater zero.
+
+        Returns:
+            a new grid mapping instance.
         """
         from .dataset import new_grid_mapping_from_dataset
 
@@ -825,19 +836,21 @@ class GridMapping(abc.ABC):
         tile_size: Union[int, Tuple[int, int]] = None,
         tolerance: float = DEFAULT_TOLERANCE,
     ) -> "GridMapping":
-        """
-        Create a grid mapping from given x- and y-coordinates
+        """Create a grid mapping from given x- and y-coordinates
         *x_coords*, *y_coords* and spatial coordinate reference
         system *crs*.
 
-        :param x_coords: The x-coordinates.
-        :param y_coords: The y-coordinates.
-        :param crs: The spatial coordinate reference system.
-        :param tile_size: Optional tile size.
-        :param tolerance: Absolute tolerance used when comparing
-            coordinates with each other. Must be in the units
-            of the *crs* and must be greater zero.
-        :return: A new grid mapping.
+        Args:
+            x_coords: The x-coordinates.
+            y_coords: The y-coordinates.
+            crs: The spatial coordinate reference system.
+            tile_size: Optional tile size.
+            tolerance: Absolute tolerance used when comparing
+                coordinates with each other. Must be in the units of the
+                *crs* and must be greater zero.
+
+        Returns:
+            A new grid mapping.
         """
         from .coords import new_grid_mapping_from_coords
 
@@ -852,14 +865,16 @@ class GridMapping(abc.ABC):
     def is_close(
         self, other: "GridMapping", tolerance: float = DEFAULT_TOLERANCE
     ) -> bool:
-        """
-        Tests whether this grid mapping is close to *other*.
+        """Tests whether this grid mapping is close to *other*.
 
-        :param other: The other grid mapping.
-        :param tolerance: Absolute tolerance used when comparing
-            coordinates with each other. Must be in the units
-            of the *crs* and must be greater zero.
-        :return: True, if so, False otherwise.
+        Args:
+            other: The other grid mapping.
+            tolerance: Absolute tolerance used when comparing
+                coordinates with each other. Must be in the units of the
+                *crs* and must be greater zero.
+
+        Returns:
+            True, if so, False otherwise.
         """
         if self is other:
             return True

--- a/xcube/core/gridmapping/bboxes.py
+++ b/xcube/core/gridmapping/bboxes.py
@@ -35,25 +35,22 @@ def compute_ij_bboxes(
     ij_border: int,
     ij_boxes: np.ndarray,
 ):
-    """
-    Compute bounding boxes in the image's i,j coordinates from given
+    """Compute bounding boxes in the image's i,j coordinates from given
     x,y coordinates *x_image*, *y_image* and bounding boxes
     in x,y coordinates *xy_boxes*.
 
     *ij_boxes* must be pre-allocated to match shape of
     *xy_boxes* and initialised with negative integers.
 
-    :param x_image: The x coordinates image.
-        A 2D array of shape (height, width).
-    :param y_image: The y coordinates image.
-        A 2D array of shape (height, width).
-    :param xy_boxes: The x,y bounding boxes.
-    :param xy_border: A border added to the
-        x,y bounding boxes.
-    :param ij_border: A border added to the resulting
-        i,j bounding boxes.
-    :param ij_boxes: The resulting
-        i,j bounding boxes.
+    Args:
+        x_image: The x coordinates image. A 2D array of shape (height,
+            width).
+        y_image: The y coordinates image. A 2D array of shape (height,
+            width).
+        xy_boxes: The x,y bounding boxes.
+        xy_border: A border added to the x,y bounding boxes.
+        ij_border: A border added to the resulting i,j bounding boxes.
+        ij_boxes: The resulting i,j bounding boxes.
     """
     h = x_image.shape[0]
     w = x_image.shape[1]

--- a/xcube/core/gridmapping/cfconv.py
+++ b/xcube/core/gridmapping/cfconv.py
@@ -35,8 +35,7 @@ from .base import CRS_WGS84
 
 
 class GridCoords:
-    """
-    Grid coordinates comprising x and y of
+    """Grid coordinates comprising x and y of
     type xarray.DataArray.
     """
 
@@ -46,8 +45,7 @@ class GridCoords:
 
 
 class GridMappingProxy:
-    """
-    Grid mapping comprising *crs* of type pyproj.crs.CRS,
+    """Grid mapping comprising *crs* of type pyproj.crs.CRS,
     grid coordinates, an optional name, coordinates, and a
     tile size (= spatial chunk sizes).
     """
@@ -73,17 +71,19 @@ def get_dataset_grid_mapping_proxies(
     missing_projected_crs: pyproj.crs.CRS = None,
     emit_warnings: bool = False,
 ) -> Dict[Union[Hashable, None], GridMappingProxy]:
-    """
-    Find grid mappings encoded as described in the CF conventions
+    """Find grid mappings encoded as described in the CF conventions
     [Horizontal Coordinate Reference Systems, Grid Mappings, and Projections]
     (http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#grid-mappings-and-projections).
 
-    :param dataset:
-    :param missing_latitude_longitude_crs:
-    :param missing_rotated_latitude_longitude_crs:
-    :param missing_projected_crs:
-    :param emit_warnings:
-    :return:
+    Args:
+        dataset
+        missing_latitude_longitude_crs
+        missing_rotated_latitude_longitude_crs
+        missing_projected_crs
+        emit_warnings
+
+    Returns:
+
     """
     grid_mapping_proxies: Dict[Union[Hashable, None], GridMappingProxy] = dict()
 
@@ -264,8 +264,7 @@ def _complement_grid_mapping_coords(
 
 
 def _find_potential_coord_vars(dataset: xr.Dataset) -> List[Hashable]:
-    """
-    Find potential coordinate variables.
+    """Find potential coordinate variables.
 
     We need this function as we can not rely on xarray.Dataset.coords,
     because 2D coordinate arrays are most likely not indicated as such
@@ -336,16 +335,16 @@ def add_spatial_ref(
     crs_var_name: Optional[str] = "spatial_ref",
     xy_dim_names: Optional[Tuple[str, str]] = None,
 ):
-    """
-    Helper function that allows adding a spatial reference to an
+    """Helper function that allows adding a spatial reference to an
     existing Zarr dataset.
 
-    :param dataset_store: The dataset's existing Zarr store or path.
-    :param crs: The spatial coordinate reference system.
-    :param crs_var_name: The name of the variable that will hold the
-        spatial reference. Defaults to "spatial_ref".
-    :param xy_dim_names: The names of the x and y dimensions.
-        Defaults to ("x", "y").
+    Args:
+        dataset_store: The dataset's existing Zarr store or path.
+        crs: The spatial coordinate reference system.
+        crs_var_name: The name of the variable that will hold the
+            spatial reference. Defaults to "spatial_ref".
+        xy_dim_names: The names of the x and y dimensions. Defaults to
+            ("x", "y").
     """
     assert_instance(dataset_store, (MutableMapping, str), name="group_store")
     assert_instance(crs_var_name, str, name="crs_var_name")

--- a/xcube/core/gridmapping/coords.py
+++ b/xcube/core/gridmapping/coords.py
@@ -70,8 +70,7 @@ class CoordsGridMapping(GridMapping, abc.ABC):
 
 
 class Coords1DGridMapping(CoordsGridMapping):
-    """
-    Grid mapping constructed from
+    """Grid mapping constructed from
     1D coordinate variables and a CRS.
     """
 
@@ -81,8 +80,7 @@ class Coords1DGridMapping(CoordsGridMapping):
 
 
 class Coords2DGridMapping(CoordsGridMapping):
-    """
-    Grid mapping constructed from
+    """Grid mapping constructed from
     2D coordinate variables and a CRS.
     """
 
@@ -313,24 +311,24 @@ def grid_mapping_to_coords(
     reuse_coords: bool = False,
     exclude_bounds: bool = False,
 ) -> Dict[str, xr.DataArray]:
-    """
-    Get CF-compliant axis coordinate variables and cell
+    """Get CF-compliant axis coordinate variables and cell
     boundary coordinate variables.
 
     Defined only for grid mappings with regular x,y coordinates.
 
-    :param grid_mapping: A regular grid mapping.
-    :param xy_var_names: Optional coordinate variable
-        names (x_var_name, y_var_name).
-    :param xy_dim_names: Optional coordinate dimensions
-        names (x_dim_name, y_dim_name).
-    :param reuse_coords: Whether to either reuse target
-        coordinate arrays from target_gm or to compute
-        new ones.
-    :param exclude_bounds: If True, do not create
-        bounds coordinates. Defaults to False. Ignored if
-        *reuse_coords* is True.
-    :return: dictionary with coordinate variables
+    Args:
+        grid_mapping: A regular grid mapping.
+        xy_var_names: Optional coordinate variable names (x_var_name,
+            y_var_name).
+        xy_dim_names: Optional coordinate dimensions names (x_dim_name,
+            y_dim_name).
+        reuse_coords: Whether to either reuse target coordinate arrays
+            from target_gm or to compute new ones.
+        exclude_bounds: If True, do not create bounds coordinates.
+            Defaults to False. Ignored if *reuse_coords* is True.
+
+    Returns:
+        dictionary with coordinate variables
     """
 
     if xy_var_names:

--- a/xcube/core/gridmapping/helpers.py
+++ b/xcube/core/gridmapping/helpers.py
@@ -42,8 +42,7 @@ AffineTransformMatrix = Tuple[
 
 
 def _to_int_or_float(x: Number) -> Number:
-    """
-    If x is an int or is close to an int return it
+    """If x is an int or is close to an int return it
     as int otherwise as float. Helps avoiding errors
     introduced by inaccurate floating point ops.
     """
@@ -156,17 +155,19 @@ _RESOLUTION_SET = set(k / 100 for k in _RESOLUTIONS.keys())
 
 
 def round_to_fraction(value: float, digits: int = 2, resolution: float = 1) -> Fraction:
-    """
-    Round *value* at position given by significant
+    """Round *value* at position given by significant
     *digits* and return result as fraction.
 
-    :param value: The value
-    :param digits: The number of significant digits.
-        Must be an integer >= 1. Default is 2.
-    :param resolution: The rounding resolution
-        for the least significant digit.
-        Must be one of (0.1, 0.2, 0.25, 0.5, 1). Default is 1.
-    :return: The rounded value as fraction.Fraction instance.
+    Args:
+        value: The value
+        digits: The number of significant digits. Must be an integer >=
+            1. Default is 2.
+        resolution: The rounding resolution for the least significant
+            digit. Must be one of (0.1, 0.2, 0.25, 0.5, 1). Default is
+            1.
+
+    Returns:
+        The rounded value as fraction.Fraction instance.
     """
     if digits < 1:
         raise ValueError("digits must be a positive integer")
@@ -195,8 +196,7 @@ def round_to_fraction(value: float, digits: int = 2, resolution: float = 1) -> F
 def scale_xy_res_and_size(
     xy_res: Tuple[float, float], size: Tuple[int, int], xy_scale: Tuple[float, float]
 ) -> Tuple[Tuple[float, float], Tuple[int, int]]:
-    """
-    Scale given *xy_res* and *size* using *xy_scale*.
+    """Scale given *xy_res* and *size* using *xy_scale*.
     Make sure, size components are not less than 2.
     """
     x_res, y_res = xy_res

--- a/xcube/core/level.py
+++ b/xcube/core/level.py
@@ -155,25 +155,27 @@ def write_levels(
     progress_monitor: PyramidLevelCallback = None,
     **kwargs,
 ) -> List[xr.Dataset]:
-    """
-    Transform the given dataset given by a *dataset* instance
+    """Transform the given dataset given by a *dataset* instance
     or *input_path* string into the levels of a multi-level pyramid
     with spatial resolution decreasing by a factor of two in both
     spatial dimensions and write them to *output_path*.
 
     One of *dataset* and *input_path* must be given.
 
-    :param output_path: Output path
-    :param dataset: Dataset to be converted and written as levels.
-    :param input_path: Input path to a dataset to be transformed
-        and written as levels.
-    :param link_input: Just link the dataset at level zero
-        instead of writing it.
-    :param progress_monitor: An optional progress monitor.
-    :param kwargs: Keyword-arguments accepted by the
-        ``compute_levels()`` function.
-    :return: A list of dataset instances representing
-        the multi-level pyramid.
+    Args:
+        output_path: Output path
+        dataset: Dataset to be converted and written as levels.
+        input_path: Input path to a dataset to be transformed and
+            written as levels.
+        link_input: Just link the dataset at level zero instead of
+            writing it.
+        progress_monitor: An optional progress monitor.
+        **kwargs: Keyword-arguments accepted by the ``compute_levels()``
+            function.
+
+    Returns:
+        A list of dataset instances representing the multi-level
+        pyramid.
     """
     if dataset is None and input_path is None:
         raise ValueError("at least one of dataset or input_path must be given")
@@ -216,14 +218,16 @@ def write_levels(
 def read_levels(
     dir_path: str, progress_monitor: PyramidLevelCallback = None
 ) -> List[xr.Dataset]:
-    """
-    Read the of a multi-level pyramid with spatial resolution
+    """Read the of a multi-level pyramid with spatial resolution
     decreasing by a factor of two in both spatial dimensions.
 
-    :param dir_path: The directory path.
-    :param progress_monitor: An optional progress monitor.
-    :return: A list of dataset instances representing
-        the multi-level pyramid.
+    Args:
+        dir_path: The directory path.
+        progress_monitor: An optional progress monitor.
+
+    Returns:
+        A list of dataset instances representing the multi-level
+        pyramid.
     """
     file_paths = os.listdir(dir_path)
     level_paths = {}

--- a/xcube/core/maskset.py
+++ b/xcube/core/maskset.py
@@ -32,8 +32,7 @@ import xarray as xr
 
 
 class MaskSet:
-    """
-    A set of mask variables derived from a variable *flag_var* with the following
+    """A set of mask variables derived from a variable *flag_var* with the following
     CF attributes:
 
       - One or both of `flag_masks` and `flag_values`
@@ -45,9 +44,10 @@ class MaskSet:
     Each mask is represented by an `xarray.DataArray`, has the name of the flag,
     is of type `numpy.unit8`, and has the dimensions of the given *flag_var*.
 
-    :param flag_var: an `xarray.DataArray` that defines flag values.
-           The CF attributes `flag_meanings` and one or both of
-           `flag_masks` and `flag_values` are expected to exist and be valid.
+    Args:
+        flag_var: an `xarray.DataArray` that defines flag values. The CF
+            attributes `flag_meanings` and one or both of `flag_masks`
+            and `flag_values` are expected to exist and be valid.
     """
 
     def __init__(self, flag_var: xr.DataArray):
@@ -94,13 +94,15 @@ class MaskSet:
 
     @classmethod
     def get_mask_sets(cls, dataset: xr.Dataset) -> Dict[str, "MaskSet"]:
-        """
-        For each "flag" variable in given *dataset*, turn it into a ``MaskSet``,
+        """For each "flag" variable in given *dataset*, turn it into a ``MaskSet``,
         store it in a dictionary.
 
-        :param dataset: The dataset
-        :return: A mapping of flag names to ``MaskSet``.
-            Will be empty if there are no flag variables in *dataset*.
+        Args:
+            dataset: The dataset
+
+        Returns:
+            A mapping of flag names to ``MaskSet``. Will be empty if
+            there are no flag variables in *dataset*.
         """
         masks = {}
         for var_name in dataset.variables:

--- a/xcube/core/mldataset/abc.py
+++ b/xcube/core/mldataset/abc.py
@@ -33,8 +33,7 @@ from xcube.util.types import normalize_scalar_or_pair
 
 
 class MultiLevelDataset(metaclass=ABCMeta):
-    """
-    A multi-level dataset of decreasing spatial resolutions
+    """A multi-level dataset of decreasing spatial resolutions
     (a multi-resolution pyramid).
 
     The pyramid level at index zero provides the original spatial dimensions.
@@ -51,37 +50,34 @@ class MultiLevelDataset(metaclass=ABCMeta):
     @property
     @abstractmethod
     def ds_id(self) -> str:
-        """
-        :return: the dataset identifier.
+        """Returns:
+        the dataset identifier.
         """
 
     @ds_id.setter
     @abstractmethod
     def ds_id(self, ds_id: str):
-        """
-        Set the dataset identifier.
-        """
+        """Set the dataset identifier."""
 
     @property
     @abstractmethod
     def grid_mapping(self) -> GridMapping:
-        """
-        :return: the CF-conformal grid mapping
+        """Returns:
+        the CF-conformal grid mapping
         """
 
     @property
     @abstractmethod
     def num_levels(self) -> int:
-        """
-        :return: the number of pyramid levels.
+        """Returns:
+        the number of pyramid levels.
         """
 
     @cached_property
     def resolutions(self) -> Sequence[Tuple[float, float]]:
-        """
-        :return: the x,y resolutions for each level given in the
-            spatial units of the dataset's CRS
-            (i.e. ``self.grid_mapping.crs``).
+        """Returns:
+        the x,y resolutions for each level given in the spatial
+        units of the dataset's CRS (i.e. ``self.grid_mapping.crs``).
         """
         x_res_0, y_res_0 = self.grid_mapping.xy_res
         return [
@@ -91,10 +87,10 @@ class MultiLevelDataset(metaclass=ABCMeta):
 
     @cached_property
     def avg_resolutions(self) -> Sequence[float]:
-        """
-        :return: the average x,y resolutions for each level given in the
-            spatial units of the dataset's CRS
-            (i.e. ``self.grid_mapping.crs``).
+        """Returns:
+        the average x,y resolutions for each level given in the
+        spatial units of the dataset's CRS (i.e.
+        ``self.grid_mapping.crs``).
         """
         x_res_0, y_res_0 = self.grid_mapping.xy_res
         xy_res_0 = math.sqrt(x_res_0 * y_res_0)
@@ -102,27 +98,29 @@ class MultiLevelDataset(metaclass=ABCMeta):
 
     @property
     def base_dataset(self) -> xr.Dataset:
-        """
-        :return: the base dataset for lowest level at index 0.
+        """Returns:
+        the base dataset for lowest level at index 0.
         """
         return self.get_dataset(0)
 
     @property
     def datasets(self) -> Sequence[xr.Dataset]:
-        """
-        Get datasets for all levels.
+        """Get datasets for all levels.
 
         Calling this method will trigger any lazy dataset instantiation.
 
-        :return: the datasets for all levels.
+        Returns:
+            the datasets for all levels.
         """
         return [self.get_dataset(index) for index in range(self.num_levels)]
 
     @abstractmethod
     def get_dataset(self, index: int) -> xr.Dataset:
-        """
-        :param index: the level index
-        :return: the dataset for the level at *index*.
+        """Args:
+            index: the level index
+
+        Returns:
+            the dataset for the level at *index*.
         """
 
     def close(self):
@@ -144,8 +142,7 @@ class MultiLevelDataset(metaclass=ABCMeta):
         )
 
     def derive_tiling_scheme(self, tiling_scheme: TilingScheme):
-        """
-        Derive a new tiling scheme for the given one with defined
+        """Derive a new tiling scheme for the given one with defined
         minimum and maximum level indices.
         """
         min_level, max_level = tiling_scheme.get_levels_for_resolutions(
@@ -154,11 +151,13 @@ class MultiLevelDataset(metaclass=ABCMeta):
         return tiling_scheme.derive(min_level=min_level, max_level=max_level)
 
     def get_level_for_resolution(self, xy_res: ScalarOrPair[float]) -> int:
-        """
-        Get the index of the level that best represents the given resolution.
+        """Get the index of the level that best represents the given resolution.
 
-        :param xy_res: the resolution in x- and y-direction
-        :return: a level ranging from 0 to self.num_levels - 1
+        Args:
+            xy_res: the resolution in x- and y-direction
+
+        Returns:
+            a level ranging from 0 to self.num_levels - 1
         """
         given_x_res, given_y_res = normalize_scalar_or_pair(xy_res, item_type=float)
         for level, (x_res, y_res) in enumerate(self.resolutions):

--- a/xcube/core/mldataset/base.py
+++ b/xcube/core/mldataset/base.py
@@ -38,16 +38,17 @@ class BaseMultiLevelDataset(LazyMultiLevelDataset):
     """A multi-level dataset whose level datasets are
     created by down-sampling a base dataset.
 
-    :param base_dataset: The base dataset for the level at index zero.
-    :param grid_mapping: Optional grid mapping for *base_dataset*.
-    :param num_levels: Optional number of levels.
-    :param ds_id: Optional dataset identifier.
-    :param agg_methods: Optional aggregation methods.
-        May be given as string or as mapping from variable name pattern
-        to aggregation method. Valid aggregation methods are
-        None, "first", "min", "max", "mean", "median".
-        If None, the default, "first" is used for integer variables
-        and "mean" for floating point variables.
+    Args:
+        base_dataset: The base dataset for the level at index zero.
+        grid_mapping: Optional grid mapping for *base_dataset*.
+        num_levels: Optional number of levels.
+        ds_id: Optional dataset identifier.
+        agg_methods: Optional aggregation methods. May be given as
+            string or as mapping from variable name pattern to
+            aggregation method. Valid aggregation methods are None,
+            "first", "min", "max", "mean", "median". If None, the
+            default, "first" is used for integer variables and "mean"
+            for floating point variables.
     """
 
     def __init__(
@@ -84,14 +85,16 @@ class BaseMultiLevelDataset(LazyMultiLevelDataset):
         return get_num_levels(gm.size, gm.tile_size)
 
     def _get_dataset_lazily(self, index: int, parameters: Dict[str, Any]) -> xr.Dataset:
-        """
-        Compute the dataset at level *index*: If *index* is zero, return
+        """Compute the dataset at level *index*: If *index* is zero, return
         the base image passed to constructor, otherwise down-sample the
         dataset for the level at given *index*.
 
-        :param index: the level index
-        :param parameters: currently unused
-        :return: the dataset for the level at *index*.
+        Args:
+            index: the level index
+            parameters: currently unused
+
+        Returns:
+            the dataset for the level at *index*.
         """
         assert_instance(index, int, name="index")
         if index < 0:

--- a/xcube/core/mldataset/combined.py
+++ b/xcube/core/mldataset/combined.py
@@ -31,19 +31,19 @@ class CombinedMultiLevelDataset(LazyMultiLevelDataset):
     """A multi-level dataset that is a combination of other
     multi-level datasets.
 
-    :param ml_datasets: The multi-level datasets to be combined.
-        At least two must be provided.
-    :param ds_id: Optional dataset identifier.
-    :param combiner_function: An optional function used to combine the
-        datasets, for example ``xarray.merge``.
-        If given, it receives a list of datasets
-        (``xarray.Dataset`` instances) and *combiner_params* as keyword
-        arguments.
-        If not given or ``None`` is passed, a copy of the first dataset
-        is made, which is then subsequently updated by the remaining datasets
-        using ``xarray.Dataset.update()``.
-    :param combiner_params: Parameters to the *combiner_function*
-        passed as keyword arguments.
+    Args:
+        ml_datasets: The multi-level datasets to be combined. At least
+            two must be provided.
+        ds_id: Optional dataset identifier.
+        combiner_function: An optional function used to combine the
+            datasets, for example ``xarray.merge``. If given, it
+            receives a list of datasets (``xarray.Dataset`` instances)
+            and *combiner_params* as keyword arguments. If not given or
+            ``None`` is passed, a copy of the first dataset is made,
+            which is then subsequently updated by the remaining datasets
+            using ``xarray.Dataset.update()``.
+        combiner_params: Parameters to the *combiner_function* passed as
+            keyword arguments.
     """
 
     def __init__(

--- a/xcube/core/mldataset/lazy.py
+++ b/xcube/core/mldataset/lazy.py
@@ -36,9 +36,10 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
     i.e. read or computed by the abstract method
     ``get_dataset_lazily(index, **kwargs)``.
 
-    :param ds_id: Optional dataset identifier.
-    :param parameters: Optional keyword arguments that will be
-        passed to the ``get_dataset_lazily`` method.
+    Args:
+        ds_id: Optional dataset identifier.
+        parameters: Optional keyword arguments that will be passed to
+            the ``get_dataset_lazily`` method.
     """
 
     def __init__(
@@ -95,8 +96,11 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
     def get_dataset(self, index: int) -> xr.Dataset:
         """Get or compute the dataset for the level at given *index*.
 
-        :param index: the level index
-        :return: the dataset for the level at *index*.
+        Args:
+            index: the level index
+
+        Returns:
+            the dataset for the level at *index*.
         """
         if index not in self._level_datasets:
             with self._lock:
@@ -113,8 +117,9 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
         has the correct spatial dimension sizes for the
         given level at *index*.
 
-        :param index: the level index
-        :param level_dataset: the dataset for the level at *index*.
+        Args:
+            index: the level index
+            level_dataset: the dataset for the level at *index*.
         """
         with self._lock:
             self._level_datasets[index] = level_dataset
@@ -123,7 +128,8 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
     def _get_num_levels_lazily(self) -> int:
         """Retrieve, i.e. read or compute, the number of levels.
 
-        :return: the number of dataset levels.
+        Returns:
+            the number of dataset levels.
         """
 
     @abstractmethod
@@ -131,17 +137,21 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
         """Retrieve, i.e. read or compute, the dataset for the
         level at given *index*.
 
-        :param index: the level index
-        :param parameters: *parameters* keyword argument that
-            was passed to constructor.
-        :return: the dataset for the level at *index*.
+        Args:
+            index: the level index
+            parameters: *parameters* keyword argument that was passed to
+                constructor.
+
+        Returns:
+            the dataset for the level at *index*.
         """
 
     def _get_grid_mapping_lazily(self) -> GridMapping:
         """Retrieve, i.e. read or compute, the tile grid used
         by the multi-level dataset.
 
-        :return: the dataset for the level at *index*.
+        Returns:
+            the dataset for the level at *index*.
         """
         return GridMapping.from_dataset(self.get_dataset(0))
 

--- a/xcube/core/mldataset/mapped.py
+++ b/xcube/core/mldataset/mapped.py
@@ -35,7 +35,7 @@ class MappedMultiLevelDataset(LazyMultiLevelDataset):
         ds_id: str = None,
         mapper_params: Dict[str, Any] = None,
     ):
-        """ """
+        """"""
         super().__init__(ds_id=ds_id, parameters=mapper_params)
         self._ml_dataset = ml_dataset
         self._mapper_function = mapper_function

--- a/xcube/core/new.py
+++ b/xcube/core/new.py
@@ -56,8 +56,7 @@ def new_cube(
     crs_name=None,
     time_encoding_dtype="int64",
 ):
-    """
-    Create a new empty cube. Useful for creating cubes templates with
+    """Create a new empty cube. Useful for creating cubes templates with
     predefined coordinate variables and metadata. The function is also
     heavily used by xcube's unit tests.
 
@@ -67,47 +66,53 @@ def new_cube(
 
         def my_func(time: int, y: int, x: int) -> Union[bool, int, float]
 
-    :param title: A title. Defaults to 'Test Cube'.
-    :param width: Horizontal number of grid cells. Defaults to 360.
-    :param height: Vertical number of grid cells. Defaults to 180.
-    :param x_name: Name of the x coordinate variable. Defaults to 'lon'.
-    :param y_name: Name of the y coordinate variable. Defaults to 'lat'.
-    :param x_dtype: Data type of x coordinates. Defaults to 'float64'.
-    :param y_dtype: Data type of y coordinates. Defaults to 'float64'.
-    :param x_units: Units of the x coordinates. Defaults to 'degrees_east'.
-    :param y_units: Units of the y coordinates. Defaults to 'degrees_north'.
-    :param x_start: Minimum x value. Defaults to -180.
-    :param y_start: Minimum y value. Defaults to -90.
-    :param x_res: Spatial resolution in x-direction. Defaults to 1.0.
-    :param y_res: Spatial resolution in y-direction. Defaults to 1.0.
-    :param inverse_y: Whether to create an inverse y axis. Defaults to False.
-    :param time_name: Name of the time coordinate variable. Defaults to 'time'.
-    :param time_periods: Number of time steps. Defaults to 5.
-    :param time_freq: Duration of each time step. Defaults to `1D'.
-    :param time_start: First time value. Defaults to '2010-01-01T00:00:00'.
-    :param time_dtype: Numpy data type for time coordinates.
-        Defaults to 'datetime64[s]'.
-        If used, parameter 'use_cftime' must be False.
-    :param time_units: Units for time coordinates.
-        Defaults to 'seconds since 1970-01-01T00:00:00'.
-    :param time_calendar: Calender for time coordinates.
-        Defaults to 'proleptic_gregorian'.
-    :param use_cftime: If True, the time will be given as data types
-        according to the 'cftime' package. If used, the time_calendar
-        parameter must be also be given with an appropriate value
-        such as 'gregorian' or 'julian'. If used, parameter 'time_dtype'
-        must be None.
-    :param drop_bounds: If True, coordinate bounds variables are not created.
-        Defaults to False.
-    :param variables: Dictionary of data variables to be added.
-        None by default.
-    :param crs: pyproj-compatible CRS string or instance
-        of pyproj.CRS or None
-    :param crs_name: Name of the variable that will
-        hold the CRS information. Ignored, if *crs* is not given.
-    :param time_encoding_dtype: data type used to encode the time variable when
-        serializing the dataset
-    :return: A cube instance
+    Args:
+        title: A title. Defaults to 'Test Cube'.
+        width: Horizontal number of grid cells. Defaults to 360.
+        height: Vertical number of grid cells. Defaults to 180.
+        x_name: Name of the x coordinate variable. Defaults to 'lon'.
+        y_name: Name of the y coordinate variable. Defaults to 'lat'.
+        x_dtype: Data type of x coordinates. Defaults to 'float64'.
+        y_dtype: Data type of y coordinates. Defaults to 'float64'.
+        x_units: Units of the x coordinates. Defaults to 'degrees_east'.
+        y_units: Units of the y coordinates. Defaults to
+            'degrees_north'.
+        x_start: Minimum x value. Defaults to -180.
+        y_start: Minimum y value. Defaults to -90.
+        x_res: Spatial resolution in x-direction. Defaults to 1.0.
+        y_res: Spatial resolution in y-direction. Defaults to 1.0.
+        inverse_y: Whether to create an inverse y axis. Defaults to
+            False.
+        time_name: Name of the time coordinate variable. Defaults to
+            'time'.
+        time_periods: Number of time steps. Defaults to 5.
+        time_freq: Duration of each time step. Defaults to `1D'.
+        time_start: First time value. Defaults to '2010-01-01T00:00:00'.
+        time_dtype: Numpy data type for time coordinates. Defaults to
+            'datetime64[s]'. If used, parameter 'use_cftime' must be
+            False.
+        time_units: Units for time coordinates. Defaults to 'seconds
+            since 1970-01-01T00:00:00'.
+        time_calendar: Calender for time coordinates. Defaults to
+            'proleptic_gregorian'.
+        use_cftime: If True, the time will be given as data types
+            according to the 'cftime' package. If used, the
+            time_calendar parameter must be also be given with an
+            appropriate value such as 'gregorian' or 'julian'. If used,
+            parameter 'time_dtype' must be None.
+        drop_bounds: If True, coordinate bounds variables are not
+            created. Defaults to False.
+        variables: Dictionary of data variables to be added. None by
+            default.
+        crs: pyproj-compatible CRS string or instance of pyproj.CRS or
+            None
+        crs_name: Name of the variable that will hold the CRS
+            information. Ignored, if *crs* is not given.
+        time_encoding_dtype: data type used to encode the time variable
+            when serializing the dataset
+
+    Returns:
+        A cube instance
     """
     y_dtype = y_dtype if y_dtype is not None else y_dtype
     y_res = y_res if y_res is not None else x_res

--- a/xcube/core/normalize.py
+++ b/xcube/core/normalize.py
@@ -39,8 +39,7 @@ Datetime = Union[np.datetime64, cftime.datetime, datetime]
 
 
 class DatasetIsNotACubeError(BaseException):
-    """
-    Raised, if at least a subset of a dataset's variables
+    """Raised, if at least a subset of a dataset's variables
     have data cube dimensions ('time' , [...], y_dim_name, x_dim_name),
     where y_dim_name and x_dim_name are determined by a dataset's
     :class:GridMapping.
@@ -50,8 +49,7 @@ class DatasetIsNotACubeError(BaseException):
 
 
 def cubify_dataset(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Normalize the geo- and time-coding upon opening the given
+    """Normalize the geo- and time-coding upon opening the given
     dataset w.r.t. a common (CF-compatible) convention.
 
     Will throw a value error if the dataset could not not be
@@ -64,8 +62,7 @@ def cubify_dataset(ds: xr.Dataset) -> xr.Dataset:
 def normalize_dataset(
     ds: xr.Dataset, reverse_decreasing_lat: bool = False
 ) -> xr.Dataset:
-    """
-    Normalize the geo- and time-coding upon opening the given
+    """Normalize the geo- and time-coding upon opening the given
     dataset w.r.t. a common (CF-compatible) convention.
 
     That is,
@@ -86,10 +83,13 @@ def normalize_dataset(
     Finally, it will be ensured that a "time" coordinate variable will
     be of type *datetime*.
 
-    :param ds: The dataset to normalize.
-    :param reverse_decreasing_lat: Whether decreasing latitude values
-        shall be normalized so they are increasing
-    :return: The normalized dataset, or the original dataset, if it is
+    Args:
+        ds: The dataset to normalize.
+        reverse_decreasing_lat: Whether decreasing latitude values shall
+            be normalized so they are increasing
+
+    Returns:
+        The normalized dataset, or the original dataset, if it is
         already "normal".
     """
     ds = _normalize_zonal_lat_lon(ds)
@@ -110,8 +110,7 @@ def encode_cube(
     grid_mapping: Optional[GridMapping] = None,
     non_cube_subset: Optional[xr.Dataset] = None,
 ) -> xr.Dataset:
-    """
-    Encode a *cube* with its *grid_mapping*, and additional variables in
+    """Encode a *cube* with its *grid_mapping*, and additional variables in
     *non_cube_subset* into a new dataset.
 
     This is the inverse of the operation :func:decode_cube:
@@ -128,12 +127,15 @@ def encode_cube(
     cube's spatial CRS. *non_cube_subset*, if given may be used
     to add non-cube variables the to resulting dataset.
 
-    :param cube: data cube dataset, whose dimensions should
-        be ("time" , [...], y_dim_name, x_dim_name)
-    :param grid_mapping: Optional grid mapping for *cube*.
-    :param non_cube_subset: An optional dataset providing
-        non-cube data variables.
-    :return:
+    Args:
+        cube: data cube dataset, whose dimensions should be ("time" ,
+            [...], y_dim_name, x_dim_name)
+        grid_mapping: Optional grid mapping for *cube*.
+        non_cube_subset: An optional dataset providing non-cube data
+            variables.
+
+    Returns:
+
     """
     if non_cube_subset is not None:
         dataset = cube.assign(**non_cube_subset.data_vars)
@@ -162,8 +164,7 @@ def decode_cube(
     force_non_empty: bool = False,
     force_geographic: bool = False,
 ) -> Tuple[xr.Dataset, GridMapping, xr.Dataset]:
-    """
-    Decode a *dataset* into a cube variable subset, a grid mapping, and
+    """Decode a *dataset* into a cube variable subset, a grid mapping, and
     the non-cube variables of *dataset*.
 
     This is the inverse of the operation :func:encode_cube:
@@ -176,22 +177,26 @@ def decode_cube(
     Here y_dim_name and x_dim_name are determined by the
     :class:GridMapping derived from *dataset*.
 
-    :param dataset: The dataset.
-    :param normalize: Whether to normalize the *dataset*,
-        before the cube subset is determined.
-        If normalisation fails, the cube subset is created from *dataset*.
-    :param force_copy: whether to create a copy of this dataset
-        even if this dataset is identical to its cube subset.
-    :param force_non_empty: whether the resulting cube
-        must have at least one data variable.
-        If True, a :class:DatasetIsNotACubeError may be raised.
-    :param force_geographic: whether a geographic grid mapping
-        is required.
-        If True, a :class:DatasetIsNotACubeError may be raised.
-    :return: A 3-tuple comprising the data cube subset of *dataset*
-        the cube's grid mapping, and the remaining variables.
-    :raise DatasetIsNotACubeError: If it is not possible to
-        determine a data cube subset from *dataset*.
+    Args:
+        dataset: The dataset.
+        normalize: Whether to normalize the *dataset*, before the cube
+            subset is determined. If normalisation fails, the cube
+            subset is created from *dataset*.
+        force_copy: whether to create a copy of this dataset even if
+            this dataset is identical to its cube subset.
+        force_non_empty: whether the resulting cube must have at least
+            one data variable. If True, a :class:DatasetIsNotACubeError
+            may be raised.
+        force_geographic: whether a geographic grid mapping is required.
+            If True, a :class:DatasetIsNotACubeError may be raised.
+
+    Returns:
+        A 3-tuple comprising the data cube subset of *dataset* the
+        cube's grid mapping, and the remaining variables.
+
+    Raises:
+        DatasetIsNotACubeError: If it is not possible to determine a
+            data cube subset from *dataset*.
     """
     if normalize:
         try:
@@ -247,11 +252,14 @@ def decode_cube(
 
 
 def _normalize_zonal_lat_lon(ds: xr.Dataset) -> xr.Dataset:
-    """
-    In case that the dataset only contains lat_centers and is a zonal mean dataset,
+    """In case that the dataset only contains lat_centers and is a zonal mean dataset,
     the longitude dimension created and filled with the variable value of certain latitude.
-    :param ds: some xarray dataset
-    :return: a normalized xarray dataset
+
+    Args:
+        ds: some xarray dataset
+
+    Returns:
+        a normalized xarray dataset
     """
 
     if "latitude_centers" not in ds.coords or "lon" in ds.coords:
@@ -313,10 +321,13 @@ def _normalize_zonal_lat_lon(ds: xr.Dataset) -> xr.Dataset:
 
 
 def _normalize_lat_lon(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Rename variables named 'longitude' or 'long' to 'lon', and 'latitude' to 'lon'.
-    :param ds: some xarray dataset
-    :return: a normalized xarray dataset, or the original one
+    """Rename variables named 'longitude' or 'long' to 'lon', and 'latitude' to 'lon'.
+
+    Args:
+        ds: some xarray dataset
+
+    Returns:
+        a normalized xarray dataset, or the original one
     """
     lat_name = get_lat_dim_name_impl(ds)
     lon_name = get_lon_dim_name_impl(ds)
@@ -335,14 +346,17 @@ def _normalize_lat_lon(ds: xr.Dataset) -> xr.Dataset:
 
 
 def _normalize_lat_lon_2d(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Detect 2D 'lat', 'lon' variables that span a equi-rectangular grid. Then:
+    """Detect 2D 'lat', 'lon' variables that span a equi-rectangular grid. Then:
     Drop original 'lat', 'lon' variables
     Rename original dimensions names of 'lat', 'lon' variables, usually ('y', 'x'), to
     ('lat', 'lon').
     Insert new 1D 'lat', 'lon' coordinate variables with dimensions 'lat' and 'lon', respectively.
-    :param ds: some xarray dataset
-    :return: a normalized xarray dataset, or the original one
+
+    Args:
+        ds: some xarray dataset
+
+    Returns:
+        a normalized xarray dataset, or the original one
     """
     if not ("lat" in ds and "lon" in ds):
         return ds
@@ -391,11 +405,14 @@ def _normalize_lat_lon_2d(ds: xr.Dataset) -> xr.Dataset:
 
 
 def _normalize_lon_360(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Fix the longitude of the given dataset ``ds`` so that it ranges from -180 to +180 degrees.
+    """Fix the longitude of the given dataset ``ds`` so that it ranges from -180 to +180 degrees.
 
-    :param ds: The dataset whose longitudes may be given in the range 0 to 360.
-    :return: The fixed dataset or the original dataset.
+    Args:
+        ds: The dataset whose longitudes may be given in the range 0 to
+            360.
+
+    Returns:
+        The fixed dataset or the original dataset.
     """
 
     if "lon" not in ds.coords:
@@ -443,10 +460,13 @@ def _normalize_lon_360(ds: xr.Dataset) -> xr.Dataset:
 
 
 def _reverse_decreasing_lat(ds: xr.Dataset) -> xr.Dataset:
-    """
-    In case the latitude decreases, invert it
-    :param ds: some xarray dataset
-    :return: a normalized xarray dataset
+    """In case the latitude decreases, invert it
+
+    Args:
+        ds: some xarray dataset
+
+    Returns:
+        a normalized xarray dataset
     """
     try:
         if _is_lat_decreasing(ds.lat):
@@ -461,11 +481,11 @@ def _reverse_decreasing_lat(ds: xr.Dataset) -> xr.Dataset:
 
 
 def _normalize_jd2datetime(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Convert the time dimension of the given dataset from Julian date to
+    """Convert the time dimension of the given dataset from Julian date to
     datetime.
 
-    :param ds: Dataset on which to run conversion
+    Args:
+        ds: Dataset on which to run conversion
     """
 
     try:
@@ -508,8 +528,7 @@ def _normalize_jd2datetime(ds: xr.Dataset) -> xr.Dataset:
 
 
 def normalize_coord_vars(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Turn potential coordinate variables from data variables into coordinate variables.
+    """Turn potential coordinate variables from data variables into coordinate variables.
 
     Any data variable is considered a coordinate variable
 
@@ -517,9 +536,12 @@ def normalize_coord_vars(ds: xr.Dataset) -> xr.Dataset:
     * whose number of dimensions is two and where the first dimension name is also a variable name
         and whose last dimension is named "bnds".
 
-    :param ds: The dataset
-    :return: The same dataset or a shallow copy with potential coordinate
-             variables turned into coordinate variables.
+    Args:
+        ds: The dataset
+
+    Returns:
+        The same dataset or a shallow copy with potential coordinate
+        variables turned into coordinate variables.
     """
 
     if "bnds" not in ds.dims:
@@ -547,8 +569,7 @@ def normalize_coord_vars(ds: xr.Dataset) -> xr.Dataset:
 
 
 def normalize_missing_time(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Add a time coordinate variable and their associated bounds coordinate variables
+    """Add a time coordinate variable and their associated bounds coordinate variables
     if either temporal CF attributes ``time_coverage_start`` and ``time_coverage_end``
     are given or time information can be extracted from the file name but the time dimension is
     missing.
@@ -561,8 +582,11 @@ def normalize_missing_time(ds: xr.Dataset) -> xr.Dataset:
     with dimensions ['time', 'bnds'] and shape [1,2].
     Both are of data type ``datetime64``.
 
-    :param ds: Dataset to adjust
-    :return: Adjusted dataset
+    Args:
+        ds: Dataset to adjust
+
+    Returns:
+        Adjusted dataset
     """
     time_coverage_start, time_coverage_end = _get_time_coverage_from_ds(ds)
 
@@ -666,8 +690,7 @@ def _get_time_coverage_from_ds(ds: xr.Dataset) -> (pd.Timestamp, pd.Timestamp):
 
 
 def adjust_spatial_attrs(ds: xr.Dataset, allow_point: bool = False) -> xr.Dataset:
-    """
-    Adjust the global spatial attributes of the dataset by doing some
+    """Adjust the global spatial attributes of the dataset by doing some
     introspection of the dataset and adjusting the appropriate attributes
     accordingly.
 
@@ -678,9 +701,12 @@ def adjust_spatial_attrs(ds: xr.Dataset, allow_point: bool = False) -> xr.Datase
     `Attribute Convention for Data Discovery
     <http://wiki.esipfed.org/index.php/Attribute_Convention_for_Data_Discovery>`_
 
-    :param ds: Dataset to adjust
-    :param allow_point: Whether to accept single point cells
-    :return: Adjusted dataset
+    Args:
+        ds: Dataset to adjust
+        allow_point: Whether to accept single point cells
+
+    Returns:
+        Adjusted dataset
     """
 
     copied = False
@@ -743,16 +769,18 @@ def is_bounds_var(ds: xr.Dataset, var: xr.DataArray):
 def get_geo_spatial_attrs_from_var(
     ds: xr.Dataset, var_name: str, allow_point: bool = False
 ) -> Optional[dict]:
-    """
-    Get spatial boundaries, resolution and units of the given dimension of the given
+    """Get spatial boundaries, resolution and units of the given dimension of the given
     dataset. If the 'bounds' are explicitly defined, these will be used for
     boundary calculation, otherwise it will rest purely on information gathered
     from 'dim' itself.
 
-    :param ds: The dataset
-    :param var_name: The variable/dimension name.
-    :param allow_point: True, if it is ok to have no actual spatial extent.
-    :return: A dictionary {'attr_name': attr_value}
+    Args:
+        ds: The dataset
+        var_name: The variable/dimension name.
+        allow_point: True, if it is ok to have no actual spatial extent.
+
+    Returns:
+        A dictionary {'attr_name': attr_value}
     """
 
     if var_name not in ds:
@@ -851,19 +879,25 @@ def get_geo_spatial_attrs_from_var(
 
 
 def get_lon_dim_name_impl(ds: Union[xr.Dataset, xr.DataArray]) -> Optional[str]:
-    """
-    Get the name of the longitude dimension.
-    :param ds: An xarray Dataset
-    :return: the name or None
+    """Get the name of the longitude dimension.
+
+    Args:
+        ds: An xarray Dataset
+
+    Returns:
+        the name or None
     """
     return _get_dim_name(ds, ["lon", "longitude", "long"])
 
 
 def get_lat_dim_name_impl(ds: Union[xr.Dataset, xr.DataArray]) -> Optional[str]:
-    """
-    Get the name of the latitude dimension.
-    :param ds: An xarray Dataset
-    :return: the name or None
+    """Get the name of the latitude dimension.
+
+    Args:
+        ds: An xarray Dataset
+
+    Returns:
+        the name or None
     """
     return _get_dim_name(ds, ["lat", "latitude"])
 
@@ -878,9 +912,7 @@ def _get_dim_name(
 
 
 def _is_lat_decreasing(lat: xr.DataArray) -> bool:
-    """
-    Determine if the latitude is decreasing
-    """
+    """Determine if the latitude is decreasing"""
     if lat[0] > lat[-1]:
         return True
 

--- a/xcube/core/optimize.py
+++ b/xcube/core/optimize.py
@@ -35,8 +35,7 @@ def optimize_dataset(
     unchunk_coords: Union[bool, str, Sequence[str]] = False,
     exception_type: Type[Exception] = ValueError,
 ):
-    """
-    Optimize a dataset for faster access.
+    """Optimize a dataset for faster access.
 
     Reduces the number of metadata and coordinate data files in xcube dataset given by given by *dataset_path*.
     Consolidated cubes open much faster from remote locations, e.g. in object storage,
@@ -50,14 +49,18 @@ def optimize_dataset(
     *unchunk_coords* can be a name, or list of names of the coordinate variable(s) to be consolidated.
     If boolean ``True`` is used, coordinate all variables will be consolidated.
 
-    :param input_path: Path to input dataset with ZARR format.
-    :param output_path: Path to output dataset with ZARR format. May contain "{input}" template string,
-           which is replaced by the input path's file name without file name extension.
-    :param in_place: Whether to modify the dataset in place.
-           If False, a copy is made and *output_path* must be given.
-    :param unchunk_coords: The name of a coordinate variable or a list of coordinate variables whose chunks should
-           be consolidated. Pass ``True`` to consolidate chunks of all coordinate variables.
-    :param exception_type: Type of exception to be used on value errors.
+    Args:
+        input_path: Path to input dataset with ZARR format.
+        output_path: Path to output dataset with ZARR format. May
+            contain "{input}" template string, which is replaced by the
+            input path's file name without file name extension.
+        in_place: Whether to modify the dataset in place. If False, a
+            copy is made and *output_path* must be given.
+        unchunk_coords: The name of a coordinate variable or a list of
+            coordinate variables whose chunks should be consolidated.
+            Pass ``True`` to consolidate chunks of all coordinate
+            variables.
+        exception_type: Type of exception to be used on value errors.
     """
 
     if not os.path.isfile(os.path.join(input_path, ".zgroup")):

--- a/xcube/core/resampling/affine.py
+++ b/xcube/core/resampling/affine.py
@@ -45,29 +45,30 @@ def affine_transform_dataset(
     gm_name: Optional[str] = None,
     reuse_coords: bool = False,
 ) -> xr.Dataset:
-    """
-    Resample dataset according to an affine transformation.
+    """Resample dataset according to an affine transformation.
 
     The affine transformation will be applied only if the CRS of
     *source_gm* and the CRS of *target_gm* are both geographic or equal.
     Otherwise, a ``ValueError`` will be raised.
 
-    :param dataset: The source dataset
-    :param source_gm: Source grid mapping of *dataset*.
-        Must be regular. Must have same CRS as *target_gm*.
-    :param target_gm: Target grid mapping.
-        Must be regular. Must have same CRS as *source_gm*.
-    :param var_configs: Optional resampling configurations
-        for individual variables.
-    :param encode_cf: Whether to encode the target grid mapping
-        into the resampled dataset in a CF-compliant way.
-        Defaults to ``True``.
-    :param gm_name: Name for the grid mapping variable.
-        Defaults to "crs". Used only if *encode_cf* is ``True``.
-    :param reuse_coords: Whether to either reuse target
-        coordinate arrays from target_gm or to compute
-        new ones.
-    :return: The resampled target dataset.
+    Args:
+        dataset: The source dataset
+        source_gm: Source grid mapping of *dataset*. Must be regular.
+            Must have same CRS as *target_gm*.
+        target_gm: Target grid mapping. Must be regular. Must have same
+            CRS as *source_gm*.
+        var_configs: Optional resampling configurations for individual
+            variables.
+        encode_cf: Whether to encode the target grid mapping into the
+            resampled dataset in a CF-compliant way. Defaults to
+            ``True``.
+        gm_name: Name for the grid mapping variable. Defaults to "crs".
+            Used only if *encode_cf* is ``True``.
+        reuse_coords: Whether to either reuse target coordinate arrays
+            from target_gm or to compute new ones.
+
+    Returns:
+        The resampled target dataset.
     """
     # Are source and target both geographic grid mappings?
     both_geographic = source_gm.crs.is_geographic and target_gm.crs.is_geographic
@@ -109,17 +110,19 @@ def resample_dataset(
     xy_dim_names: Tuple[str, str],
     var_configs: Mapping[Hashable, Mapping[str, Any]] = None,
 ) -> xr.Dataset:
-    """
-    Resample dataset according to an affine transformation.
+    """Resample dataset according to an affine transformation.
 
-    :param dataset: The source dataset
-    :param matrix: Affine transformation matrix.
-    :param size: Target image size.
-    :param tile_size: Target image tile size.
-    :param xy_dim_names: Names of the spatial dimensions.
-    :param var_configs: Optional resampling configurations
-        for individual variables.
-    :return: The resampled target dataset.
+    Args:
+        dataset: The source dataset
+        matrix: Affine transformation matrix.
+        size: Target image size.
+        tile_size: Target image tile size.
+        xy_dim_names: Names of the spatial dimensions.
+        var_configs: Optional resampling configurations for individual
+            variables.
+
+    Returns:
+        The resampled target dataset.
     """
     ((i_scale, _, i_off), (_, j_scale, j_off)) = matrix
     width, height = size
@@ -233,17 +236,19 @@ def _transform_array(
     spline_order: int,
     recover_nan: bool,
 ) -> da.Array:
-    """
-    Apply affine transformation to ND-image.
+    """Apply affine transformation to ND-image.
 
-    :param image: ND-image with shape (..., size_y, size_x)
-    :param scale: Scaling factors (1, ..., 1, sy, sx)
-    :param offset: Offset values (0, ..., 0, oy, ox)
-    :param shape: (..., size_y, size_x)
-    :param chunks: (..., chunk_size_y, chunk_size_x)
-    :param spline_order: 0 ... 5
-    :param recover_nan: True/False
-    :return: Transformed ND-image.
+    Args:
+        image: ND-image with shape (..., size_y, size_x)
+        scale: Scaling factors (1, ..., 1, sy, sx)
+        offset: Offset values (0, ..., 0, oy, ox)
+        shape: (..., size_y, size_x)
+        chunks: (..., chunk_size_y, chunk_size_x)
+        spline_order: 0 ... 5
+        recover_nan: True/False
+
+    Returns:
+        Transformed ND-image.
     """
     assert_true(len(scale) == image.ndim, "invalid scale")
     assert_true(len(offset) == image.ndim, "invalid offset")

--- a/xcube/core/resampling/cf.py
+++ b/xcube/core/resampling/cf.py
@@ -46,15 +46,17 @@ def encode_grid_mapping(
     the function sets the attribute "grid_mapping" to *gm_name*.
     The grid mapping CRS is encoded in a new 0-D variable named *gm_name*.
 
-    :param ds: The dataset.
-    :param gm: The dataset's grid mapping.
-    :param gm_name: Name for the grid mapping variable.
-        Defaults to "crs".
-    :param force: Whether to force encoding of grid mapping even
-        if CRS is geographic and spatial dimension names are "lon", "lat".
-        Optional value, if not provided, *force* will be assumed ``True``
-        if a former grid mapping was encoded in *ds*.
-    :return: A copy of *ds* with *gm* encoded into it.
+    Args:
+        ds: The dataset.
+        gm: The dataset's grid mapping.
+        gm_name: Name for the grid mapping variable. Defaults to "crs".
+        force: Whether to force encoding of grid mapping even if CRS is
+            geographic and spatial dimension names are "lon", "lat".
+            Optional value, if not provided, *force* will be assumed
+            ``True`` if a former grid mapping was encoded in *ds*.
+
+    Returns:
+        A copy of *ds* with *gm* encoded into it.
     """
     assert_instance(ds, xr.Dataset, "ds")
     assert_instance(gm, GridMapping, "gm")

--- a/xcube/core/resampling/rectify.py
+++ b/xcube/core/resampling/rectify.py
@@ -47,8 +47,7 @@ def rectify_dataset(
     compute_subset: bool = True,
     uv_delta: float = 1e-3,
 ) -> Optional[xr.Dataset]:
-    """
-    Reproject dataset *source_ds* using its per-pixel
+    """Reproject dataset *source_ds* using its per-pixel
     x,y coordinates or the given *source_gm*.
 
     The function expects *source_ds* or the given
@@ -73,36 +72,37 @@ def rectify_dataset(
     arrays. Otherwise, the returned dataset will be composed
     of ordinary numpy arrays.
 
-    :param source_ds: Source dataset grid mapping.
-    :param var_names: Optional variable name or sequence of
-        variable names.
-    :param source_gm: Source dataset grid mapping.
-    :param xy_var_names: Optional tuple of the x- and y-coordinate
-        variables in *source_ds*. Ignored if *source_gm* is given.
-    :param target_gm: Optional target geometry. If not given,
-        output geometry will be computed to spatially fit *dataset*
-        and to retain its spatial resolution.
-    :param encode_cf: Whether to encode the target grid mapping
-        into the resampled dataset in a CF-compliant way.
-        Defaults to ``True``.
-    :param gm_name: Name for the grid mapping variable.
-        Defaults to "crs". Used only if *encode_cf* is ``True``.
-    :param tile_size: Optional tile size for the output.
-    :param is_j_axis_up: Whether y coordinates are increasing with
-        positive image j axis.
-    :param output_ij_names: If given, a tuple of variable names in
-        which to store the computed source pixel coordinates in
-        the returned output.
-    :param compute_subset: Whether to compute a spatial subset
-        from *dataset* using *output_geom*. If set, the function
-        may return ``None`` in case there is no overlap.
-    :param uv_delta: A normalized value that is used to determine
-        whether x,y coordinates in the output are contained
-        in the triangles defined by the input x,y coordinates.
-        The higher this value, the more inaccurate the rectification
-        will be.
-    :return: a reprojected dataset, or None if the requested output
-        does not intersect with *dataset*.
+    Args:
+        source_ds: Source dataset grid mapping.
+        var_names: Optional variable name or sequence of variable names.
+        source_gm: Source dataset grid mapping.
+        xy_var_names: Optional tuple of the x- and y-coordinate
+            variables in *source_ds*. Ignored if *source_gm* is given.
+        target_gm: Optional target geometry. If not given, output
+            geometry will be computed to spatially fit *dataset* and to
+            retain its spatial resolution.
+        encode_cf: Whether to encode the target grid mapping into the
+            resampled dataset in a CF-compliant way. Defaults to
+            ``True``.
+        gm_name: Name for the grid mapping variable. Defaults to "crs".
+            Used only if *encode_cf* is ``True``.
+        tile_size: Optional tile size for the output.
+        is_j_axis_up: Whether y coordinates are increasing with positive
+            image j axis.
+        output_ij_names: If given, a tuple of variable names in which to
+            store the computed source pixel coordinates in the returned
+            output.
+        compute_subset: Whether to compute a spatial subset from
+            *dataset* using *output_geom*. If set, the function may
+            return ``None`` in case there is no overlap.
+        uv_delta: A normalized value that is used to determine whether
+            x,y coordinates in the output are contained in the triangles
+            defined by the input x,y coordinates. The higher this value,
+            the more inaccurate the rectification will be.
+
+    Returns:
+        a reprojected dataset, or None if the requested output does not
+        intersect with *dataset*.
     """
     if source_gm is None:
         source_gm = GridMapping.from_dataset(source_ds)
@@ -193,15 +193,16 @@ def _select_variables(
     source_gm: GridMapping,
     var_names: Union[None, str, Sequence[str]],
 ) -> Mapping[str, xr.DataArray]:
-    """
-    Select variables from *dataset*.
+    """Select variables from *dataset*.
 
-    :param source_ds: Source dataset.
-    :param source_gm: Optional dataset geo-coding.
-    :param var_names: Optional variable name
-        or sequence of variable names.
-    :return: The selected variables as a variable name
-        to ``xr.DataArray`` mapping
+    Args:
+        source_ds: Source dataset.
+        source_gm: Optional dataset geo-coding.
+        var_names: Optional variable name or sequence of variable names.
+
+    Returns:
+        The selected variables as a variable name to ``xr.DataArray``
+        mapping
     """
     spatial_var_names = source_gm.xy_var_names
     spatial_shape = tuple(reversed(source_gm.size))
@@ -238,8 +239,7 @@ def _is_2d_spatial_var(var: xr.DataArray, shape, dims) -> bool:
 def _compute_ij_images_xarray_numpy(
     src_geo_coding: GridMapping, output_geom: GridMapping, uv_delta: float
 ) -> np.ndarray:
-    """
-    Compute numpy.ndarray destination image with source
+    """Compute numpy.ndarray destination image with source
     pixel i,j coords from xarray.DataArray x,y sources.
     """
     dst_width = output_geom.width
@@ -270,8 +270,7 @@ def _compute_ij_images_xarray_numpy(
 def _compute_ij_images_xarray_dask(
     src_geo_coding: GridMapping, output_geom: GridMapping, uv_delta: float
 ) -> da.Array:
-    """
-    Compute dask.array.Array destination image
+    """Compute dask.array.Array destination image
     with source pixel i,j coords from xarray.DataArray x,y sources.
     """
     dst_width = output_geom.width
@@ -345,8 +344,7 @@ def _compute_ij_images_xarray_dask_block(
     dst_is_j_axis_up: bool,
     uv_delta: float,
 ) -> np.ndarray:
-    """
-    Compute dask.array.Array destination block with source
+    """Compute dask.array.Array destination block with source
     pixel i,j coords from xarray.DataArray x,y sources.
     """
     dst_src_ij_block = np.full(block_shape, np.nan, dtype=dtype)
@@ -393,8 +391,7 @@ def _compute_ij_images_numpy_parallel(
     dst_y_scale: float,
     uv_delta: float,
 ):
-    """
-    Compute numpy.ndarray destination image with source
+    """Compute numpy.ndarray destination image with source
     pixel i,j coords from numpy.ndarray x,y sources in
     parallel mode.
     """
@@ -431,8 +428,7 @@ def _compute_ij_images_numpy_sequential(
     dst_y_scale: float,
     uv_delta: float,
 ):
-    """
-    Compute numpy.ndarray destination image with source pixel i,j coords
+    """Compute numpy.ndarray destination image with source pixel i,j coords
     from numpy.ndarray x,y sources NOT in parallel mode.
     """
     src_height = src_x_image.shape[-2]
@@ -467,8 +463,7 @@ def _compute_ij_images_for_source_line(
     dst_y_scale: float,
     uv_delta: float,
 ):
-    """
-    Compute numpy.ndarray destination image with source
+    """Compute numpy.ndarray destination image with source
     pixel i,j coords from a numpy.ndarray x,y source line.
     """
     src_width = src_x_image.shape[-1]
@@ -565,8 +560,7 @@ def _compute_var_image_xarray_numpy(
     dst_src_ij_images: np.ndarray,
     fill_value: Union[int, float, complex] = np.nan,
 ) -> np.ndarray:
-    """
-    Extract source pixels from xarray.DataArray source
+    """Extract source pixels from xarray.DataArray source
     with numpy.ndarray data.
     """
     return _compute_var_image_numpy(src_var.values, dst_src_ij_images, fill_value)
@@ -577,8 +571,7 @@ def _compute_var_image_xarray_dask(
     dst_src_ij_images: np.ndarray,
     fill_value: Union[int, float, complex] = np.nan,
 ) -> da.Array:
-    """
-    Extract source pixels from xarray.DataArray source
+    """Extract source pixels from xarray.DataArray source
     with dask.array.Array data.
     """
     return da.map_blocks(
@@ -597,8 +590,7 @@ def _compute_var_image_numpy(
     dst_src_ij_images: np.ndarray,
     fill_value: Union[int, float, complex] = np.nan,
 ) -> np.ndarray:
-    """
-    Extract source pixels from numpy.ndarray source
+    """Extract source pixels from numpy.ndarray source
     with numba in parallel mode.
     """
     dst_width = dst_src_ij_images.shape[-1]
@@ -615,8 +607,7 @@ def _compute_var_image_xarray_dask_block(
     dst_src_ij_images: np.ndarray,
     fill_value: Union[int, float, complex] = np.nan,
 ) -> np.ndarray:
-    """
-    Extract source pixels from np.ndarray source
+    """Extract source pixels from np.ndarray source
     and return a block of a dask array.
     """
     dst_width = dst_src_ij_images.shape[-1]
@@ -631,8 +622,7 @@ def _compute_var_image_xarray_dask_block(
 def _compute_var_image_numpy_parallel(
     src_var_image: np.ndarray, dst_src_ij_images: np.ndarray, dst_var_image: np.ndarray
 ):
-    """
-    Extract source pixels from np.ndarray source
+    """Extract source pixels from np.ndarray source
     using numba parallel mode.
     """
     dst_height = dst_var_image.shape[-2]
@@ -648,8 +638,7 @@ def _compute_var_image_numpy_parallel(
 def _compute_var_image_numpy_sequential(
     src_var_image: np.ndarray, dst_src_ij_images: np.ndarray, dst_var_image: np.ndarray
 ):
-    """
-    Extract source pixels from np.ndarray source
+    """Extract source pixels from np.ndarray source
     NOT using numba parallel mode.
     """
     dst_height = dst_var_image.shape[-2]
@@ -666,8 +655,7 @@ def _compute_var_image_for_dest_line(
     dst_src_ij_images: np.ndarray,
     dst_var_image: np.ndarray,
 ):
-    """
-    Extract source pixels from *src_values* np.ndarray
+    """Extract source pixels from *src_values* np.ndarray
     and write into dst_values np.ndarray.
     """
     src_width = src_var_image.shape[-1]

--- a/xcube/core/resampling/temporal.py
+++ b/xcube/core/resampling/temporal.py
@@ -43,8 +43,7 @@ def resample_in_time(
     metadata: Dict[str, Any] = None,
     cube_asserted: bool = False,
 ) -> xr.Dataset:
-    """
-    Resample a dataset in the time dimension.
+    """Resample a dataset in the time dimension.
 
     The argument *method* may be one or a sequence of
     ``'all'``, ``'any'``,
@@ -64,27 +63,29 @@ def resample_in_time(
     In this case, use the ``compute()`` or ``load()`` method
     to convert dask arrays into numpy arrays.
 
-    :param dataset: The xcube dataset.
-    :param frequency: Temporal aggregation frequency.
-        Use format "<count><offset>" where <offset> is one of
-        'H', 'D', 'W', 'M', 'Q', 'Y'.
-    :param method: Resampling method or sequence of
-        resampling methods.
-    :param offset: Offset used to adjust the resampled time labels.
-        Uses same syntax as *frequency*.
-    :param base: Deprecated since xcube 1.0.4.
-        No longer used as of pandas 2.0.
-    :param time_chunk_size: If not None, the chunk size to be
-        used for the "time" dimension.
-    :param var_names: Variable names to include.
-    :param tolerance: Time tolerance for selective
-        upsampling methods. Defaults to *frequency*.
-    :param interp_kind: Kind of interpolation
-        if *method* is 'interpolation'.
-    :param metadata: Output metadata.
-    :param cube_asserted: If False, *cube* will be verified,
-        otherwise it is expected to be a valid cube.
-    :return: A new xcube dataset resampled in time.
+    Args:
+        dataset: The xcube dataset.
+        frequency: Temporal aggregation frequency. Use format
+            "<count><offset>" where <offset> is one of 'H', 'D', 'W',
+            'M', 'Q', 'Y'.
+        method: Resampling method or sequence of resampling methods.
+        offset: Offset used to adjust the resampled time labels. Uses
+            same syntax as *frequency*.
+        base: Deprecated since xcube 1.0.4. No longer used as of pandas
+            2.0.
+        time_chunk_size: If not None, the chunk size to be used for the
+            "time" dimension.
+        var_names: Variable names to include.
+        tolerance: Time tolerance for selective upsampling methods.
+            Defaults to *frequency*.
+        interp_kind: Kind of interpolation if *method* is
+            'interpolation'.
+        metadata: Output metadata.
+        cube_asserted: If False, *cube* will be verified, otherwise it
+            is expected to be a valid cube.
+
+    Returns:
+        A new xcube dataset resampled in time.
     """
     if not cube_asserted:
         assert_cube(dataset)

--- a/xcube/core/schema.py
+++ b/xcube/core/schema.py
@@ -28,14 +28,16 @@ from xcube.core.gridmapping import GridMapping
 
 
 class CubeSchema:
-    """
-    A schema that can be used to create new xcube datasets.
+    """A schema that can be used to create new xcube datasets.
     The given *shape*, *dims*, and *chunks*, *coords* apply to all data variables.
 
-    :param shape: A tuple of dimension sizes.
-    :param coords: A dictionary of coordinate variables. Must have values for all *dims*.
-    :param dims: A sequence of dimension names. Defaults to ``('time', 'lat', 'lon')``.
-    :param chunks: A tuple of chunk sizes in each dimension.
+    Args:
+        shape: A tuple of dimension sizes.
+        coords: A dictionary of coordinate variables. Must have values
+            for all *dims*.
+        dims: A sequence of dimension names. Defaults to ``('time',
+            'lat', 'lon')``.
+        chunks: A tuple of chunk sizes in each dimension.
     """
 
     def __init__(
@@ -216,11 +218,13 @@ class CubeSchema:
 
 # TODO (forman): code duplication with xcube.core.verify._check_data_variables(), line 76
 def get_cube_schema(cube: xr.Dataset) -> CubeSchema:
-    """
-    Derive cube schema from given *cube*.
+    """Derive cube schema from given *cube*.
 
-    :param cube: The data cube.
-    :return: The cube schema.
+    Args:
+        cube: The data cube.
+
+    Returns:
+        The cube schema.
     """
 
     xy_var_names = get_dataset_xy_var_names(
@@ -393,15 +397,16 @@ def get_dataset_bounds_var_name(
 
 
 def get_dataset_chunks(dataset: xr.Dataset) -> Dict[Hashable, int]:
-    """
-    Get the most common chunk sizes for each
+    """Get the most common chunk sizes for each
     chunked dimension of *dataset*.
 
     Note: Only data variables are considered.
 
-    :param dataset: A dataset.
-    :return: A dictionary that maps dimension names
-        to common chunk sizes.
+    Args:
+        dataset: A dataset.
+
+    Returns:
+        A dictionary that maps dimension names to common chunk sizes.
     """
 
     # Record the frequencies of chunk sizes for
@@ -448,20 +453,22 @@ def rechunk_cube(
     chunks: Optional[Dict[str, int]] = None,
     tile_size: Optional[Tuple[int, int]] = None,
 ) -> Tuple[xr.Dataset, GridMapping]:
-    """
-    Re-chunk data variables of *cube* so they all share the same chunk
+    """Re-chunk data variables of *cube* so they all share the same chunk
     sizes for their dimensions.
 
     This functions rechunks *cube* for maximum compatibility with
     the Zarr format. Therefore it removes the "chunks" encoding
     from all variables.
 
-    :param cube: A data cube
-    :param gm: The cube's grid mapping
-    :param chunks: Optional mapping of dimension names to chunk sizes
-    :param tile_size: Optional tile sizes, i.e. chunk size of
-        spatial dimensions, given as (width, height)
-    :return: A potentially rechunked *cube* and adjusted grid mapping.
+    Args:
+        cube: A data cube
+        gm: The cube's grid mapping
+        chunks: Optional mapping of dimension names to chunk sizes
+        tile_size: Optional tile sizes, i.e. chunk size of spatial
+            dimensions, given as (width, height)
+
+    Returns:
+        A potentially rechunked *cube* and adjusted grid mapping.
     """
 
     # get initial, common cube chunk sizes from given cube

--- a/xcube/core/select.py
+++ b/xcube/core/select.py
@@ -48,8 +48,7 @@ def select_subset(
     time_range: Optional[TimeRange] = None,
     grid_mapping: Optional[GridMapping] = None,
 ):
-    """
-    Create a subset from *dataset* given *var_names*,
+    """Create a subset from *dataset* given *var_names*,
     *bbox*, *time_range*.
 
     This is a high-level convenience function that may invoke
@@ -58,14 +57,17 @@ def select_subset(
     * :func:select_spatial_subset
     * :func:select_temporal_subset
 
-    :param dataset: The dataset.
-    :param var_names: Optional variable names.
-    :param bbox: Optional bounding box in the dataset's
-        CRS coordinate units.
-    :param time_range: Optional time range
-    :param grid_mapping: Optional dataset grid mapping.
-    :return: a subset of *dataset*, or unchanged *dataset*
-        if no keyword-arguments are used.
+    Args:
+        dataset: The dataset.
+        var_names: Optional variable names.
+        bbox: Optional bounding box in the dataset's CRS coordinate
+            units.
+        time_range: Optional time range
+        grid_mapping: Optional dataset grid mapping.
+
+    Returns:
+        a subset of *dataset*, or unchanged *dataset* if no keyword-
+        arguments are used.
     """
     if var_names is not None:
         dataset = select_variables_subset(dataset, var_names=var_names)
@@ -81,13 +83,15 @@ def select_subset(
 def select_variables_subset(
     dataset: xr.Dataset, var_names: Optional[Collection[str]] = None
 ) -> xr.Dataset:
-    """
-    Select data variable from given *dataset* and create new dataset.
+    """Select data variable from given *dataset* and create new dataset.
 
-    :param dataset: The dataset from which to select variables.
-    :param var_names: The names of data variables to select.
-    :return: A new dataset. It is empty, if *var_names* is empty.
-        It is *dataset*, if *var_names* is None.
+    Args:
+        dataset: The dataset from which to select variables.
+        var_names: The names of data variables to select.
+
+    Returns:
+        A new dataset. It is empty, if *var_names* is empty. It is
+        *dataset*, if *var_names* is None.
     """
     if var_names is None:
         return dataset
@@ -105,23 +109,22 @@ def select_spatial_subset(
     xy_border: float = 0.0,
     grid_mapping: Optional[GridMapping] = None,
 ) -> Optional[xr.Dataset]:
-    """
-    Select a spatial subset of *dataset* for the
+    """Select a spatial subset of *dataset* for the
     bounding box *ij_bbox* or *xy_bbox*.
 
     *ij_bbox* or *xy_bbox* must not be given both.
 
-    :param xy_bbox: Bounding box in coordinates of the dataset's CRS.
-    :param xy_border: Extra border added to *xy_bbox*.
-    :param dataset: Source dataset.
-    :param ij_bbox: Bounding box (i_min, i_min, j_max, j_max)
-        in pixel coordinates.
-    :param ij_border: Extra border added to *ij_bbox*
-        in number of pixels
-    :param xy_bbox: The bounding box in x,y coordinates.
-    :param xy_border: Border in units of the x,y coordinates.
-    :param grid_mapping: Optional dataset grid mapping.
-    :return: Spatial dataset subset
+    Args:
+        xy_bbox: The bounding box in x,y coordinates.
+        xy_border: Border in units of the x,y coordinates.
+        dataset: Source dataset.
+        ij_bbox: Bounding box (i_min, i_min, j_max, j_max) in pixel
+            coordinates.
+        ij_border: Extra border added to *ij_bbox* in number of pixels
+        grid_mapping: Optional dataset grid mapping.
+
+    Returns:
+        Spatial dataset subset
     """
 
     if ij_bbox is None and xy_bbox is None:
@@ -180,15 +183,17 @@ def select_spatial_subset(
 def select_temporal_subset(
     dataset: xr.Dataset, time_range: TimeRange, time_name: str = "time"
 ) -> xr.Dataset:
-    """
-    Select a temporal subset from *dataset* given *time_range*.
+    """Select a temporal subset from *dataset* given *time_range*.
 
-    :param dataset: The dataset. Must include time
-    :param time_range: Time range given as two time stamps
-        (start, end) that may be (ISO) strings or datetime objects.
-    :param time_name: optional name of the time coordinate variable.
-        Defaults to "time".
-    :return:
+    Args:
+        dataset: The dataset. Must include time
+        time_range: Time range given as two time stamps (start, end)
+            that may be (ISO) strings or datetime objects.
+        time_name: optional name of the time coordinate variable.
+            Defaults to "time".
+
+    Returns:
+
     """
     assert_given(time_range, "time_range")
     time_name = time_name or "time"
@@ -287,20 +292,20 @@ def select_label_subset(
     >>>                                 predicate={"CHL": is_valid_slice})
     ```
 
-    :param dataset: The dataset.
-    :param dim: The name of the dimension
-        from which to select the labels.
-    :param predicate: The predicate function
-        or a mapping from variable names
-        to variable-specific predicate functions.
-    :param use_dask: Whether to use a Dask graph that will
-        compute the validity of labels in parallel.
-        For a large number of labels, very complex Dask
-        graphs will result (every label is a node)
-        whose overhead may compensate the performance gain.
-    :return: A new dataset with labels along *dim*
-        selected by the *predicate*.
-        If all labels are selected, *dataset* is returned without change.
+    Args:
+        dataset: The dataset.
+        dim: The name of the dimension from which to select the labels.
+        predicate: The predicate function or a mapping from variable
+            names to variable-specific predicate functions.
+        use_dask: Whether to use a Dask graph that will compute the
+            validity of labels in parallel. For a large number of
+            labels, very complex Dask graphs will result (every label is
+            a node) whose overhead may compensate the performance gain.
+
+    Returns:
+        A new dataset with labels along *dim* selected by the
+        *predicate*. If all labels are selected, *dataset* is returned
+        without change.
     """
     if callable(predicate):
         predicate_lookup = {

--- a/xcube/core/sentinel3.py
+++ b/xcube/core/sentinel3.py
@@ -9,14 +9,16 @@ def open_sentinel3_product(
     var_names: Set[str] = None,
     chunks: Mapping[str, Union[int, Tuple[int, ...]]] = None,
 ) -> xr.Dataset:
-    """
-    Open a Sentinel-3 product from given path.
+    """Open a Sentinel-3 product from given path.
 
-    :param chunks:
-    :param path: Sentinel-3 product path
-    :param var_names: Optional variable names to be included.
-    :param chunks: Optional mapping from dimension name to chunk sizes or chunk size tuples.
-    :return: A dataset representation of the Sentinel-3 product.
+    Args:
+        chunks: Optional mapping from dimension name to chunk sizes or
+            chunk size tuples.
+        path: Sentinel-3 product path
+        var_names: Optional variable names to be included.
+
+    Returns:
+        A dataset representation of the Sentinel-3 product.
     """
     x_name = "longitude"
     y_name = "latitude"
@@ -79,11 +81,13 @@ def _open_dataset(dataset_path, chunks=None) -> xr.Dataset:
 
 
 def is_sentinel3_product(path: str) -> bool:
-    """
-    Test if given *path* is likely a Sentinel-3 product path.
+    """Test if given *path* is likely a Sentinel-3 product path.
 
-    :param path: (directory) path
-    :return: True, if so
+    Args:
+        path: (directory) path
+
+    Returns:
+        True, if so
     """
     return os.path.isdir(path) and os.path.isfile(
         os.path.join(path, "geo_coordinates.nc")

--- a/xcube/core/store/accessor.py
+++ b/xcube/core/store/accessor.py
@@ -47,18 +47,20 @@ def new_data_opener(
     extension_registry: Optional[ExtensionRegistry] = None,
     **opener_params,
 ) -> "DataOpener":
-    """
-    Get an instance of the data opener identified by *opener_id*.
+    """Get an instance of the data opener identified by *opener_id*.
 
     The optional, extra opener parameters *opener_params* may
     be used by data store (``xcube.core.store.DataStore``)
     implementations so they can share their internal state with the opener.
 
-    :param opener_id: The data opener identifier.
-    :param extension_registry: Optional extension registry.
-        If not given, the global extension registry will be used.
-    :param opener_params: Extra opener parameters.
-    :return: A data opener instance.
+    Args:
+        opener_id: The data opener identifier.
+        extension_registry: Optional extension registry. If not given,
+            the global extension registry will be used.
+        **opener_params: Extra opener parameters.
+
+    Returns:
+        A data opener instance.
     """
     assert_given(opener_id, "opener_id")
     extension_registry = extension_registry or get_extension_registry()
@@ -74,18 +76,20 @@ def new_data_writer(
     extension_registry: Optional[ExtensionRegistry] = None,
     **writer_params,
 ) -> "DataWriter":
-    """
-    Get an instance of the data writer identified by *writer_id*.
+    """Get an instance of the data writer identified by *writer_id*.
 
     The optional, extra writer parameters *writer_params* may be used by
     data store (``xcube.core.store.DataStore``) implementations so they
     can share their internal state with the writer.
 
-    :param writer_id: The data writer identifier.
-    :param extension_registry: Optional extension registry.
-        If not given, the global extension registry will be used.
-    :param writer_params: Extra writer parameters.
-    :return: A data writer instance.
+    Args:
+        writer_id: The data writer identifier.
+        extension_registry: Optional extension registry. If not given,
+            the global extension registry will be used.
+        **writer_params: Extra writer parameters.
+
+    Returns:
+        A data writer instance.
     """
     assert_given(writer_id, "writer_id")
     extension_registry = extension_registry or get_extension_registry()
@@ -100,14 +104,16 @@ def find_data_opener_extensions(
     predicate: ExtensionPredicate = None,
     extension_registry: Optional[ExtensionRegistry] = None,
 ) -> List[Extension]:
-    """
-    Get registered data opener extensions using the optional
+    """Get registered data opener extensions using the optional
     filter function *predicate*.
 
-    :param predicate: An optional filter function.
-    :param extension_registry: Optional extension registry.
-        If not given, the global extension registry will be used.
-    :return: List of matching extensions.
+    Args:
+        predicate: An optional filter function.
+        extension_registry: Optional extension registry. If not given,
+            the global extension registry will be used.
+
+    Returns:
+        List of matching extensions.
     """
     extension_registry = extension_registry or get_extension_registry()
     return extension_registry.find_extensions(
@@ -119,14 +125,16 @@ def find_data_writer_extensions(
     predicate: ExtensionPredicate = None,
     extension_registry: Optional[ExtensionRegistry] = None,
 ) -> List[Extension]:
-    """
-    Get registered data writer extensions using the optional filter
+    """Get registered data writer extensions using the optional filter
     function *predicate*.
 
-    :param predicate: An optional filter function.
-    :param extension_registry: Optional extension registry.
-        If not given, the global extension registry will be used.
-    :return: List of matching extensions.
+    Args:
+        predicate: An optional filter function.
+        extension_registry: Optional extension registry. If not given,
+            the global extension registry will be used.
+
+    Returns:
+        List of matching extensions.
     """
     extension_registry = extension_registry or get_extension_registry()
     return extension_registry.find_extensions(
@@ -137,17 +145,20 @@ def find_data_writer_extensions(
 def get_data_accessor_predicate(
     data_type: DataTypeLike = None, format_id: str = None, storage_id: str = None
 ) -> ExtensionPredicate:
-    """
-    Get a predicate that checks if a data accessor extensions's name is
+    """Get a predicate that checks if a data accessor extensions's name is
     compliant with *data_type*, *format_id*, *storage_id*.
 
-    :param data_type: Optional data data type to be supported.
-        May be given as type alias name, as a type,
-        or as a DataType instance.
-    :param format_id: Optional data format identifier to be supported.
-    :param storage_id: Optional data storage identifier to be supported.
-    :return: A filter function.
-    :raise DataStoreError: If an error occurs.
+    Args:
+        data_type: Optional data data type to be supported. May be given
+            as type alias name, as a type, or as a DataType instance.
+        format_id: Optional data format identifier to be supported.
+        storage_id: Optional data storage identifier to be supported.
+
+    Returns:
+        A filter function.
+
+    Raises:
+        DataStoreError: If an error occurs.
     """
     if any((data_type, format_id, storage_id)):
         data_type = DataType.normalize(data_type) if data_type is not None else None
@@ -182,8 +193,7 @@ def get_data_accessor_predicate(
 
 
 class DataOpener(ABC):
-    """
-    An interface that specifies a parameterized `open_data()` operation.
+    """An interface that specifies a parameterized `open_data()` operation.
 
     Possible open parameters are implementation-specific and
     are described by a JSON Schema.
@@ -196,8 +206,7 @@ class DataOpener(ABC):
 
     @abstractmethod
     def get_open_data_params_schema(self, data_id: str = None) -> JsonObjectSchema:
-        """
-        Get the schema for the parameters passed as *open_params* to
+        """Get the schema for the parameters passed as *open_params* to
         :meth:open_data(data_id, open_params).
         If *data_id* is given, the returned schema will be tailored
         to the constraints implied by the identified data resource.
@@ -205,29 +214,37 @@ class DataOpener(ABC):
         is optional, and if it is omitted, the returned schema will be
         less restrictive.
 
-        :param data_id: An optional data resource identifier.
-        :return: The schema for the parameters in *open_params*.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: An optional data resource identifier.
+
+        Returns:
+            The schema for the parameters in *open_params*.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def open_data(self, data_id: str, **open_params) -> Any:
-        """
-        Open the data resource given by the data resource identifier
+        """Open the data resource given by the data resource identifier
         *data_id* using the supplied *open_params*.
 
         Raises if *data_id* does not exist.
 
-        :param data_id: The data resource identifier.
-        :param open_params: Opener-specific parameters.
-        :return: An xarray.Dataset instance.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: The data resource identifier.
+            **open_params: Opener-specific parameters.
+
+        Returns:
+            An xarray.Dataset instance.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
 
 class DataDeleter(ABC):
-    """
-    An interface that specifies a parameterized `delete_data()` operation.
+    """An interface that specifies a parameterized `delete_data()` operation.
 
     Possible delete parameters are implementation-specific and
     are described by a JSON Schema.
@@ -235,8 +252,7 @@ class DataDeleter(ABC):
 
     @abstractmethod
     def get_delete_data_params_schema(self, data_id: str = None) -> JsonObjectSchema:
-        """
-        Get the schema for the parameters passed as *delete_params*
+        """Get the schema for the parameters passed as *delete_params*
         to :meth:delete_data.
         If *data_id* is given, the returned schema will be tailored to
         the constraints implied by the identified data resource.
@@ -244,25 +260,31 @@ class DataDeleter(ABC):
         is optional, and if it is omitted, the returned schema will
         be less restrictive.
 
-        :param data_id: An optional data resource identifier.
-        :return: The schema for the parameters in *delete_params*.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: An optional data resource identifier.
+
+        Returns:
+            The schema for the parameters in *delete_params*.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def delete_data(self, data_id: str, **delete_params):
-        """
-        Delete a data resource. Raises if *data_id* does not exist.
+        """Delete a data resource. Raises if *data_id* does not exist.
 
-        :param data_id: A data resource identifier known to exist.
-        :param delete_params: Deleter-specific parameters.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: A data resource identifier known to exist.
+            **delete_params: Deleter-specific parameters.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
 
 class DataWriter(DataDeleter, ABC):
-    """
-    An interface that specifies a parameterized `write_data()` operation.
+    """An interface that specifies a parameterized `write_data()` operation.
 
     Possible write parameters are implementation-specific and
     are described by a JSON Schema.
@@ -270,67 +292,78 @@ class DataWriter(DataDeleter, ABC):
 
     @abstractmethod
     def get_write_data_params_schema(self) -> JsonObjectSchema:
-        """
-        Get the schema for the parameters passed as *write_params* to
+        """Get the schema for the parameters passed as *write_params* to
         :meth:write_data(data resource, data_id, open_params).
 
-        :return: The schema for the parameters in *write_params*.
-        :raise DataStoreError: If an error occurs.
+        Returns:
+            The schema for the parameters in *write_params*.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def write_data(
         self, data: Any, data_id: str, replace: bool = False, **write_params
     ) -> str:
-        """
-        Write a data resource using the supplied *data_id* and *write_params*.
+        """Write a data resource using the supplied *data_id* and *write_params*.
 
-        :param data: The data resource's in-memory representation
-            to be written.
-        :param data_id: A unique data resource identifier.
-        :param replace: Whether to replace an existing data resource.
-        :param write_params: Writer-specific parameters.
-        :return: The data resource identifier used to write the data resource.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data: The data resource's in-memory representation to be
+                written.
+            data_id: A unique data resource identifier.
+            replace: Whether to replace an existing data resource.
+            **write_params: Writer-specific parameters.
+
+        Returns:
+            The data resource identifier used to write the data
+            resource.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
 
 class DataTimeSliceUpdater(DataWriter, ABC):
-    """
-    An interface that specifies writing of time slice data.
-    """
+    """An interface that specifies writing of time slice data."""
 
     @abstractmethod
     def append_data_time_slice(self, data_id: str, time_slice: xr.Dataset):
-        """
-        Append a time slice to the identified data resource.
+        """Append a time slice to the identified data resource.
 
-        :param data_id: The data resource identifier.
-        :param time_slice: The time slice data to be inserted.
-            Must be compatible with the data resource.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: The data resource identifier.
+            time_slice: The time slice data to be inserted. Must be
+                compatible with the data resource.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def insert_data_time_slice(self, data_id: str, time_slice: Any, time_index: int):
-        """
-        Insert a time slice into the identified data resource at given index.
+        """Insert a time slice into the identified data resource at given index.
 
-        :param data_id: The data resource identifier.
-        :param time_slice: The time slice data to be inserted.
-            Must be compatible with the data resource.
-        :param time_index: The time index.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: The data resource identifier.
+            time_slice: The time slice data to be inserted. Must be
+                compatible with the data resource.
+            time_index: The time index.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def replace_data_time_slice(self, data_id: str, time_slice: Any, time_index: int):
-        """
-        Replace a time slice in the identified data resource at given index.
+        """Replace a time slice in the identified data resource at given index.
 
-        :param data_id: The data resource identifier.
-        :param time_slice: The time slice data to be inserted.
-            Must be compatible with the data resource.
-        :param time_index: The time index.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: The data resource identifier.
+            time_slice: The time slice data to be inserted. Must be
+                compatible with the data resource.
+            time_index: The time index.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """

--- a/xcube/core/store/assertions.py
+++ b/xcube/core/store/assertions.py
@@ -33,13 +33,13 @@ def assert_valid_params(
     schema: Optional[JsonObjectSchema] = None,
     name: str = "params",
 ):
-    """
-    Assert that constructor/method parameters *params* are valid.
+    """Assert that constructor/method parameters *params* are valid.
 
-    :param params: Dictionary of keyword arguments
-        passed to a constructor/method.
-    :param schema: The JSON Schema that *params* must adhere to.
-    :param name: Name of the *params* variable.
+    Args:
+        params: Dictionary of keyword arguments passed to a
+            constructor/method.
+        schema: The JSON Schema that *params* must adhere to.
+        name: Name of the *params* variable.
     """
     _assert_valid(params, schema, name, "parameterization", _validate_params)
 
@@ -49,12 +49,12 @@ def assert_valid_config(
     schema: Optional[JsonObjectSchema] = None,
     name: str = "config",
 ):
-    """
-    Assert that JSON object *config* is valid.
+    """Assert that JSON object *config* is valid.
 
-    :param config: JSON object used for configuration.
-    :param schema: The JSON Schema that *config* must adhere to.
-    :param name: Name of the *config* variable.
+    Args:
+        config: JSON object used for configuration.
+        schema: The JSON Schema that *config* must adhere to.
+        name: Name of the *config* variable.
     """
     _assert_valid(config, schema, name, "configuration", _validate_config)
 

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -113,21 +113,21 @@ def _get_common_dataset_descriptor_props(
 
 
 class DataDescriptor(JsonObject):
-    """
-    A generic descriptor for any data.
+    """A generic descriptor for any data.
     Also serves as a base class for more specific data descriptors.
 
-    :param data_id: An identifier for the data
-    :param data_type: A type specifier for the data
-    :param crs: A coordinate reference system identifier,
-        as an EPSG, PROJ or WKT string
-    :param bbox: A bounding box of the data
-    :param time_range: Start and end time delimiting this
-        data's temporal extent
-    :param time_period: The data's periodicity if it is
-        evenly temporally resolved.
-    :param open_params_schema: A JSON schema describing the
-        parameters that may be used to open this data.
+    Args:
+        data_id: An identifier for the data
+        data_type: A type specifier for the data
+        crs: A coordinate reference system identifier, as an EPSG, PROJ
+            or WKT string
+        bbox: A bounding box of the data
+        time_range: Start and end time delimiting this data's temporal
+            extent
+        time_period: The data's periodicity if it is evenly temporally
+            resolved.
+        open_params_schema: A JSON schema describing the parameters that
+            may be used to open this data.
     """
 
     def __init__(
@@ -182,32 +182,32 @@ class DataDescriptor(JsonObject):
 
 
 class DatasetDescriptor(DataDescriptor):
-    """
-    A descriptor for a gridded, N-dimensional dataset represented
+    """A descriptor for a gridded, N-dimensional dataset represented
     by xarray.Dataset. Comprises a description of the data variables
     contained in the dataset.
 
     Regrading *time_range* and *time_period* parameters, please refer to
     https://github.com/dcs4cop/xcube/blob/main/docs/source/storeconv.md#date-time-and-duration-specifications
 
-    :param data_id: An identifier for the data
-    :param data_type: The data type of the data described
-    :param crs: A coordinate reference system identifier,
-        as an EPSG, PROJ or WKT string
-    :param bbox: A bounding box of the data
-    :param time_range: Start and end time delimiting this data's
-        temporal extent
-    :param time_period: The data's periodicity
-        if it is evenly temporally resolved
-    :param spatial_res: The spatial extent of a pixel in crs units
-    :param dims: A mapping of the dataset's dimensions to their sizes
-    :param coords: mapping of the dataset's data coordinate names
-        to instances of :class:VariableDescriptor
-    :param data_vars: A mapping of the dataset's variable names
-        to instances of :class:VariableDescriptor
-    :param attrs: A mapping containing arbitrary attributes of the dataset
-    :param open_params_schema: A JSON schema describing the parameters
-        that may be used to open this data
+    Args:
+        data_id: An identifier for the data
+        data_type: The data type of the data described
+        crs: A coordinate reference system identifier, as an EPSG, PROJ
+            or WKT string
+        bbox: A bounding box of the data
+        time_range: Start and end time delimiting this data's temporal
+            extent
+        time_period: The data's periodicity if it is evenly temporally
+            resolved
+        spatial_res: The spatial extent of a pixel in crs units
+        dims: A mapping of the dataset's dimensions to their sizes
+        coords: mapping of the dataset's data coordinate names to
+            instances of :class:VariableDescriptor
+        data_vars: A mapping of the dataset's variable names to
+            instances of :class:VariableDescriptor
+        attrs: A mapping containing arbitrary attributes of the dataset
+        open_params_schema: A JSON schema describing the parameters that
+            may be used to open this data
     """
 
     def __init__(
@@ -275,18 +275,18 @@ class DatasetDescriptor(DataDescriptor):
 
 
 class VariableDescriptor(JsonObject):
-    """
-    A descriptor for dataset variable represented by
+    """A descriptor for dataset variable represented by
     xarray.DataArray instances.
     They are part of dataset descriptor for an gridded, N-dimensional
     dataset represented by
     xarray.Dataset.
 
-    :param name: The variable name
-    :param dtype: The data type of the variable.
-    :param dims: A list of the names of the variable's dimensions.
-    :param chunks: A list of the chunk sizes of the variable's dimensions
-    :param attrs: A mapping containing arbitrary attributes of the variable
+    Args:
+        name: The variable name
+        dtype: The data type of the variable.
+        dims: A list of the names of the variable's dimensions.
+        chunks: A list of the chunk sizes of the variable's dimensions
+        attrs: A mapping containing arbitrary attributes of the variable
     """
 
     def __init__(
@@ -335,14 +335,14 @@ class VariableDescriptor(JsonObject):
 
 
 class MultiLevelDatasetDescriptor(DatasetDescriptor):
-    """
-    A descriptor for a gridded, N-dimensional, multi-level,
+    """A descriptor for a gridded, N-dimensional, multi-level,
     multi-resolution dataset represented by
     xcube.core.mldataset.MultiLevelDataset.
 
-    :param data_id: An identifier of the multi-level dataset
-    :param num_levels: The number of levels of this multi-level dataset
-    :param data_type: A type specifier for the multi-level dataset
+    Args:
+        data_id: An identifier of the multi-level dataset
+        num_levels: The number of levels of this multi-level dataset
+        data_type: A type specifier for the multi-level dataset
     """
 
     def __init__(
@@ -376,14 +376,14 @@ class MultiLevelDatasetDescriptor(DatasetDescriptor):
 
 
 class GeoDataFrameDescriptor(DataDescriptor):
-    """
-    A descriptor for a geo-vector dataset represented by a
+    """A descriptor for a geo-vector dataset represented by a
     geopandas.GeoDataFrame instance.
 
-    :param data_id: An identifier of the geopandas.GeoDataFrame
-    :param feature_schema: A schema describing the properties
-        of the vector data
-    :param kwargs: Parameters passed to super :class:DataDescriptor
+    Args:
+        data_id: An identifier of the geopandas.GeoDataFrame
+        feature_schema: A schema describing the properties of the vector
+            data
+        kwargs: Parameters passed to super :class:DataDescriptor
     """
 
     def __init__(

--- a/xcube/core/store/error.py
+++ b/xcube/core/store/error.py
@@ -21,10 +21,10 @@
 
 
 class DataStoreError(Exception):
-    """
-    Raised on error in any of the data store, opener, or writer methods.
+    """Raised on error in any of the data store, opener, or writer methods.
 
-    :param message: The error message.
+    Args:
+        message: The error message.
     """
 
     def __init__(self, message: str):

--- a/xcube/core/store/fs/accessor.py
+++ b/xcube/core/store/fs/accessor.py
@@ -168,8 +168,7 @@ class FsAccessor:
 
 
 class FsDataAccessor(DataOpener, DataWriter, FsAccessor, ABC):
-    """
-    Abstract base class for data accessors that
+    """Abstract base class for data accessors that
     use an underlying filesystem.
 
     A ``FsDataAccessor`` is responsible for exactly one data type
@@ -185,15 +184,12 @@ class FsDataAccessor(DataOpener, DataWriter, FsAccessor, ABC):
     @classmethod
     @abstractmethod
     def get_data_type(cls) -> DataType:
-        """
-        Get the supported data type.
-        """
+        """Get the supported data type."""
 
     @classmethod
     @abstractmethod
     def get_format_id(cls) -> str:
-        """
-        Get the format identifier,
+        """Get the format identifier,
         for example "zarr" or "geojson".
         """
 

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -142,9 +142,7 @@ ZARR_WRITE_DATA_PARAMS_SCHEMA = JsonObjectSchema(
 
 
 class DatasetFsDataAccessor(FsDataAccessor, ABC):
-    """
-    Opener/writer extension name: "dataset:<format>:<protocol>"
-    """
+    """Opener/writer extension name: 'dataset:<format>:<protocol>'."""
 
     @classmethod
     def get_data_type(cls) -> DataType:
@@ -152,9 +150,7 @@ class DatasetFsDataAccessor(FsDataAccessor, ABC):
 
 
 class DatasetZarrFsDataAccessor(DatasetFsDataAccessor):
-    """
-    Opener/writer extension name: "dataset:zarr:<protocol>"
-    """
+    """Opener/writer extension name: 'dataset:zarr:<protocol>'."""
 
     @classmethod
     def get_format_id(cls) -> str:
@@ -233,9 +229,7 @@ NETCDF_WRITE_DATA_PARAMS_SCHEMA = JsonObjectSchema(
 
 
 class DatasetNetcdfFsDataAccessor(DatasetFsDataAccessor):
-    """
-    Opener/writer extension name: "dataset:netcdf:<protocol>"
-    """
+    """Opener/writer extension name: 'dataset:netcdf:<protocol>'."""
 
     @classmethod
     def get_format_id(cls) -> str:
@@ -314,7 +308,7 @@ GEOTIFF_OPEN_DATA_PARAMS_SCHEMA = JsonObjectSchema(
 
 class DatasetGeoTiffFsDataAccessor(DatasetFsDataAccessor):
     """
-    Opener/writer extension name: "dataset:geotiff:<protocol>"
+    Opener/writer extension name: 'dataset:geotiff:<protocol>'.
     """
 
     @classmethod

--- a/xcube/core/store/fs/impl/geodataframe.py
+++ b/xcube/core/store/fs/impl/geodataframe.py
@@ -34,9 +34,7 @@ from ...datatype import GEO_DATA_FRAME_TYPE
 
 
 class GeoDataFrameFsDataAccessor(FsDataAccessor):
-    """
-    Extension name: "geodataframe:<format_id>:<protocol>"
-    """
+    """Extension name: 'geodataframe:<format_id>:<protocol>'."""
 
     @classmethod
     def get_data_type(cls) -> DataType:
@@ -92,9 +90,7 @@ class GeoDataFrameFsDataAccessor(FsDataAccessor):
 
 
 class GeoDataFrameShapefileFsDataAccessor(GeoDataFrameFsDataAccessor):
-    """
-    Extension name: "geodataframe:shapefile:<protocol>"
-    """
+    """Extension name: 'geodataframe:shapefile:<protocol>'."""
 
     @classmethod
     def get_format_id(cls) -> str:
@@ -106,9 +102,7 @@ class GeoDataFrameShapefileFsDataAccessor(GeoDataFrameFsDataAccessor):
 
 
 class GeoDataFrameGeoJsonFsDataAccessor(GeoDataFrameFsDataAccessor):
-    """
-    Extension name: "geodataframe:geojson:<protocol>"
-    """
+    """Extension name: 'geodataframe:geojson:<protocol>'."""
 
     @classmethod
     def get_format_id(cls) -> str:

--- a/xcube/core/store/fs/impl/geotiff.py
+++ b/xcube/core/store/fs/impl/geotiff.py
@@ -38,13 +38,13 @@ from .dataset import DatasetGeoTiffFsDataAccessor
 
 
 class GeoTIFFMultiLevelDataset(LazyMultiLevelDataset):
-    """
-    A multi-level dataset for GeoTIFF format
+    """A multi-level dataset for GeoTIFF format.
 
-    @param fs: fsspec.AbstractFileSystem object.
-    @param root: Optional root path identifier.
-    @param data_id: dataset identifier.
-    @param open_params: keyword arguments.
+    Args:
+        fs: fsspec.AbstractFileSystem object.
+        root: Optional root path identifier.
+        data_id: dataset identifier.
+        open_params: keyword arguments.
     """
 
     def __init__(

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -48,9 +48,7 @@ from ...datatype import MULTI_LEVEL_DATASET_TYPE
 
 
 class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
-    """
-    Opener/writer extension name "mldataset:levels:<protocol>".
-    """
+    """Opener/writer extension name 'mldataset:levels:<protocol>'."""
 
     @classmethod
     def get_data_type(cls) -> DataType:
@@ -153,9 +151,7 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
 
 
 class DatasetLevelsFsDataAccessor(MultiLevelDatasetLevelsFsDataAccessor):
-    """
-    Opener/writer extension name "dataset:levels:<protocol>".
-    """
+    """Opener/writer extension name 'dataset:levels:<protocol>'."""
 
     @classmethod
     def get_data_type(cls) -> DataType:

--- a/xcube/core/store/fs/registry.py
+++ b/xcube/core/store/fs/registry.py
@@ -49,11 +49,11 @@ _FS_ACCESSOR_CLASSES: Dict[str, Type[FsAccessor]] = {}
 
 
 def register_fs_accessor_class(fs_accessor_class: Type[FsAccessor]):
-    """
-    Register a concrete filesystem accessor class.
+    """Register a concrete filesystem accessor class.
 
-    :param fs_accessor_class: a concrete class
-        that extends :class:FsAccessor.
+    Args:
+        fs_accessor_class: a concrete class that extends
+            :class:FsAccessor.
     """
     protocol = fs_accessor_class.get_protocol()
     _FS_ACCESSOR_CLASSES[protocol] = fs_accessor_class
@@ -70,12 +70,14 @@ for cls in (
 
 
 def get_fs_accessor_class(protocol: str) -> Type[FsAccessor]:
-    """
-    Get the class for a filesystem accessor.
+    """Get the class for a filesystem accessor.
 
-    :param protocol: The filesystem protocol,
-        for example "file", "s3", "memory".
-    :return: A class that derives from :class:FsAccessor
+    Args:
+        protocol: The filesystem protocol, for example "file", "s3",
+            "memory".
+
+    Returns:
+        A class that derives from :class:FsAccessor
     """
     fs_accessor_class = _FS_ACCESSOR_CLASSES.get(protocol)
     if fs_accessor_class is None:
@@ -107,15 +109,15 @@ _FS_DATA_ACCESSOR_CLASSES: Dict[str, Type[FsDataAccessor]] = {}
 
 
 def register_fs_data_accessor_class(fs_data_accessor_class: Type[FsDataAccessor]):
-    """
-    Register an abstract filesystem data accessor class.
+    """Register an abstract filesystem data accessor class.
 
     Such data accessor classes are used to dynamically
     construct concrete data store classes by combining
     them with a concrete :class:FsAccessor.
 
-    :param fs_data_accessor_class: an abstract class
-        that extends :class:FsDataAccessor.
+    Args:
+        fs_data_accessor_class: an abstract class that extends
+            :class:FsDataAccessor.
     """
     data_type = fs_data_accessor_class.get_data_type()
     format_id = fs_data_accessor_class.get_format_id()
@@ -139,16 +141,17 @@ for cls in (
 def get_fs_data_accessor_class(
     protocol: str, data_type_alias: str, format_id: str
 ) -> Type[FsDataAccessor]:
-    """
-    Get the class for a filesystem data accessor.
+    """Get the class for a filesystem data accessor.
 
-    :param protocol: The filesystem protocol,
-        for example "file", "s3", "memory".
-    :param data_type_alias: The data type alias name,
-        for example "dataset", "geodataframe".
-    :param format_id: The format identifier,
-        for example "zarr", "geojson".
-    :return: A class that derives from :class:FsAccessor
+    Args:
+        protocol: The filesystem protocol, for example "file", "s3",
+            "memory".
+        data_type_alias: The data type alias name, for example
+            "dataset", "geodataframe".
+        format_id: The format identifier, for example "zarr", "geojson".
+
+    Returns:
+        A class that derives from :class:FsAccessor
     """
     accessor_id = f"{data_type_alias}:{format_id}"
     data_accessor_class = _FS_DATA_ACCESSOR_CLASSES.get(accessor_id)
@@ -173,12 +176,14 @@ def get_fs_data_accessor_class(
 
 
 def get_fs_data_store_class(protocol: str) -> Type[FsDataStore]:
-    """
-    Get the class for of a filesystem-based data store.
+    """Get the class for of a filesystem-based data store.
 
-    :param protocol: The filesystem protocol,
-        for example "file", "s3", "memory".
-    :return: A class that derives from :class:FsDataStore
+    Args:
+        protocol: The filesystem protocol, for example "file", "s3",
+            "memory".
+
+    Returns:
+        A class that derives from :class:FsDataStore
     """
     fs_accessor_class = get_fs_accessor_class(protocol)
 
@@ -199,8 +204,7 @@ def new_fs_data_store(
     excludes: Optional[Sequence[str]] = None,
     storage_options: Dict[str, Any] = None,
 ) -> FsDataStore:
-    """
-    Create a new instance of a filesystem-based data store.
+    """Create a new instance of a filesystem-based data store.
 
     The data store is capable of filtering the data identifiers reported
     by ``get_data_ids()``. For this purpose the optional keywords
@@ -212,24 +216,27 @@ def new_fs_data_store(
     * ``includes``: if not given or if any pattern matches the identifier,
       the identifier is reported.
 
-    :param protocol: The filesystem protocol,
-        for example "file", "s3", "memory".
-    :param root: Root or base directory.
-        Defaults to "".
-    :param max_depth: Maximum recursion depth. None means limitless.
-        Defaults to 1.
-    :param read_only: Whether this is a read-only store.
-        Defaults to False.
-    :param includes: Optional sequence of wildcards that include
-        certain filesystem paths. Affects the data identifiers (paths)
-        returned by `get_data_ids()`. By default, all paths are included.
-    :param excludes: Optional sequence of wildcards that exclude
-        certain filesystem paths. Affects the data identifiers (paths)
-        returned by `get_data_ids()`. By default, no paths are excluded.
-    :param storage_options: Options specific to the underlying filesystem
-        identified by *protocol*.
-        Used to instantiate the filesystem.
-    :return: A new data store instance of type :class:FsDataStore.
+    Args:
+        protocol: The filesystem protocol, for example "file", "s3",
+            "memory".
+        root: Root or base directory. Defaults to "".
+        max_depth: Maximum recursion depth. None means limitless.
+            Defaults to 1.
+        read_only: Whether this is a read-only store. Defaults to False.
+        includes: Optional sequence of wildcards that include certain
+            filesystem paths. Affects the data identifiers (paths)
+            returned by `get_data_ids()`. By default, all paths are
+            included.
+        excludes: Optional sequence of wildcards that exclude certain
+            filesystem paths. Affects the data identifiers (paths)
+            returned by `get_data_ids()`. By default, no paths are
+            excluded.
+        storage_options: Options specific to the underlying filesystem
+            identified by *protocol*. Used to instantiate the
+            filesystem.
+
+    Returns:
+        A new data store instance of type :class:FsDataStore.
     """
     fs_data_store_class = get_fs_data_store_class(protocol)
     store_params_schema = fs_data_store_class.get_data_store_params_schema()

--- a/xcube/core/store/fs/store.py
+++ b/xcube/core/store/fs/store.py
@@ -693,8 +693,7 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
 
 
 class FsDataStore(BaseFsDataStore, FsAccessor):
-    """
-    Specialization of a :class:BaseFsDataStore that
+    """Specialization of a :class:BaseFsDataStore that
     also implements a :class:FsAccessor which serves
     the filesystem.
 
@@ -708,20 +707,21 @@ class FsDataStore(BaseFsDataStore, FsAccessor):
     * ``includes``: if not given or if any pattern matches the identifier,
       the identifier is reported.
 
-    :param root: Root or base directory.
-        Defaults to "".
-    :param max_depth: Maximum recursion depth. None means limitless.
-        Defaults to 1.
-    :param read_only: Whether this is a read-only store.
-        Defaults to False.
-    :param includes: Optional sequence of wildcards that include
-        certain filesystem paths. Affects the data identifiers (paths)
-        returned by `get_data_ids()`. By default, all paths are included.
-    :param excludes: Optional sequence of wildcards that exclude
-        certain filesystem paths. Affects the data identifiers (paths)
-        returned by `get_data_ids()`. By default, no paths are excluded.
-    :param storage_options: Parameters specific to the underlying filesystem.
-        Used to instantiate the filesystem.
+    Args:
+        root: Root or base directory. Defaults to "".
+        max_depth: Maximum recursion depth. None means limitless.
+            Defaults to 1.
+        read_only: Whether this is a read-only store. Defaults to False.
+        includes: Optional sequence of wildcards that include certain
+            filesystem paths. Affects the data identifiers (paths)
+            returned by `get_data_ids()`. By default, all paths are
+            included.
+        excludes: Optional sequence of wildcards that exclude certain
+            filesystem paths. Affects the data identifiers (paths)
+            returned by `get_data_ids()`. By default, no paths are
+            excluded.
+        storage_options: Parameters specific to the underlying
+            filesystem. Used to instantiate the filesystem.
     """
 
     def __init__(

--- a/xcube/core/store/ref/store.py
+++ b/xcube/core/store/ref/store.py
@@ -39,33 +39,33 @@ class ReferenceDataStore(DataStore):
     """A data store that uses kerchunk reference files to
     open referred NetCDF datasets as if they were Zarr datasets.
 
-    :param refs: The list of reference JSON files to use for this
-        instance. Files (URLs or local paths) are used in
-        conjunction with target_options and target_protocol
-        to open and parse JSON at this location.
-    :param target_protocol: Used for loading the reference files.
-        If not given, protocol will be derived from the given path.
-    :param target_options: Extra filesystem options for loading
-        the reference files.
-    :param remote_protocol: The protocol of the filesystem on which
-        the references will be evaluated. If not given, will be derived
-        from the first URL in the references that has a protocol.
-    :param remote_options: Extra filesystem options for loading the
-        referenced data.
-    :param max_gap: See ``max_block``.
-    :param max_block: For merging multiple concurrent requests to the same
-        remote file. Neighboring byte ranges will only be
-        merged when their inter-range gap is <= `max_gap`.
-        Default is 64KB. Set to 0 to only merge when it
-        requires no extra bytes. Pass a negative number to
-        disable merging, appropriate for local target files.
-        Neighboring byte ranges will only be merged when the
-        size of the aggregated range is <= ``max_block``.
-        Default is 256MB.
-    :param cache_size: Maximum size of LRU cache, where
-        cache_size*record_size denotes the total number of
-        references that can be loaded in memory at once.
-        Only used for lazily loaded references.
+    Args:
+        refs: The list of reference JSON files to use for this instance.
+            Files (URLs or local paths) are used in conjunction with
+            target_options and target_protocol to open and parse JSON at
+            this location.
+        target_protocol: Used for loading the reference files. If not
+            given, protocol will be derived from the given path.
+        target_options: Extra filesystem options for loading the
+            reference files.
+        remote_protocol: The protocol of the filesystem on which the
+            references will be evaluated. If not given, will be derived
+            from the first URL in the references that has a protocol.
+        remote_options: Extra filesystem options for loading the
+            referenced data.
+        max_gap: See ``max_block``.
+        max_block: For merging multiple concurrent requests to the same
+            remote file. Neighboring byte ranges will only be merged
+            when their inter-range gap is <= `max_gap`. Default is 64KB.
+            Set to 0 to only merge when it requires no extra bytes. Pass
+            a negative number to disable merging, appropriate for local
+            target files. Neighboring byte ranges will only be merged
+            when the size of the aggregated range is <= ``max_block``.
+            Default is 256MB.
+        cache_size: Maximum size of LRU cache, where
+            cache_size*record_size denotes the total number of
+            references that can be loaded in memory at once. Only used
+            for lazily loaded references.
     """
 
     def __init__(

--- a/xcube/core/store/search.py
+++ b/xcube/core/store/search.py
@@ -8,33 +8,32 @@ from .descriptor import DataDescriptor
 
 
 class DataSearcher(ABC):
-    """
-    Allow searching data in a data store.
-    """
+    """Allow searching data in a data store."""
 
     @classmethod
     @abstractmethod
     def get_search_params_schema(
         cls, data_type: DataTypeLike = None
     ) -> JsonObjectSchema:
-        """
-        Get the schema for the parameters that can be passed
+        """Get the schema for the parameters that can be passed
         as *search_params* to :meth:search_data().
         Parameters are named and described by the properties of the
         returned JSON object schema.
 
-        :param data_type: If given, the search parameters
-            will be tailored to search for data for the given *data_type*.
-        :return: A JSON object schema whose properties describe
-            this store's search parameters.
+        Args:
+            data_type: If given, the search parameters will be tailored
+                to search for data for the given *data_type*.
+
+        Returns:
+            A JSON object schema whose properties describe this store's
+            search parameters.
         """
 
     @abstractmethod
     def search_data(
         self, data_type: DataTypeLike = None, **search_params
     ) -> Iterator[DataDescriptor]:
-        """
-        Search this store for data resources.
+        """Search this store for data resources.
         If *data_type* is given, the search is restricted
         to data resources of that type.
 
@@ -46,19 +45,23 @@ class DataSearcher(ABC):
         is either None or compatible with the supported data type
         specifier.
 
-        :param data_type: An optional data type
-            that is known to be supported by this data store.
-        :param search_params: The search parameters.
-        :return: An iterator of data descriptors for the found
-            data resources.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_type: An optional data type that is known to be
+                supported by this data store.
+            **search_params: The search parameters.
+
+        Returns:
+            An iterator of data descriptors for the found data
+            resources.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
 
 # noinspection PyUnresolvedReferences
 class DefaultSearchMixin(DataSearcher):
-    """
-    A mixin for data store implementations that implements default
+    """A mixin for data store implementations that implements default
     search behaviour.
 
     It is expected that such data stores have no dedicated search
@@ -70,30 +73,33 @@ class DefaultSearchMixin(DataSearcher):
     def get_search_params_schema(
         cls, data_type: DataTypeLike = None
     ) -> JsonObjectSchema:
-        """
-        Get search parameters JSON object schema.
+        """Get search parameters JSON object schema.
 
         The default implementation returns a schema that does
         not allow for any search parameters.
 
-        :param data_type:
-        :return: a JSON object schema for the search parameters
+        Args:
+            data_type
+
+        Returns:
+            a JSON object schema for the search parameters
         """
         return JsonObjectSchema(additional_properties=False)
 
     def search_data(
         self, data_type: DataTypeLike = None, **search_params
     ) -> Iterator[DataDescriptor]:
-        """
-        Search the data store.
+        """Search the data store.
 
         The default implementation returns all data resources that
         may be filtered using the optional *data_type*.
 
-        :param data_type: Type specifier to filter returned
-            data resources.
-        :param search_params: Not supported (yet)
-        :return: an iterator of :class:DataDescriptor instances
+        Args:
+            data_type: Type specifier to filter returned data resources.
+            **search_params: Not supported (yet)
+
+        Returns:
+            an iterator of :class:DataDescriptor instances
         """
         search_params_schema = self.get_search_params_schema(data_type=data_type)
         assert_valid_params(

--- a/xcube/core/store/store.py
+++ b/xcube/core/store/store.py
@@ -47,15 +47,17 @@ def new_data_store(
     extension_registry: Optional[ExtensionRegistry] = None,
     **data_store_params,
 ) -> Union["DataStore", "MutableDataStore"]:
-    """
-    Create a new data store instance for given
+    """Create a new data store instance for given
     *data_store_id* and *data_store_params*.
 
-    :param data_store_id: A data store identifier.
-    :param extension_registry: Optional extension registry.
-        If not given, the global extension registry will be used.
-    :param data_store_params: Data store specific parameters.
-    :return: A new data store instance
+    Args:
+        data_store_id: A data store identifier.
+        extension_registry: Optional extension registry. If not given,
+            the global extension registry will be used.
+        **data_store_params: Data store specific parameters.
+
+    Returns:
+        A new data store instance
     """
     data_store_class = get_data_store_class(
         data_store_id, extension_registry=extension_registry
@@ -71,13 +73,15 @@ def new_data_store(
 def get_data_store_class(
     data_store_id: str, extension_registry: Optional[ExtensionRegistry] = None
 ) -> Union[Type["DataStore"], Type["MutableDataStore"]]:
-    """
-    Get the class for the data store identified by *data_store_id*.
+    """Get the class for the data store identified by *data_store_id*.
 
-    :param data_store_id: A data store identifier.
-    :param extension_registry: Optional extension registry.
-        If not given, the global extension registry will be used.
-    :return: The class for the data store.
+    Args:
+        data_store_id: A data store identifier.
+        extension_registry: Optional extension registry. If not given,
+            the global extension registry will be used.
+
+    Returns:
+        The class for the data store.
     """
     extension_registry = extension_registry or get_extension_registry()
     if not extension_registry.has_extension(EXTENSION_POINT_DATA_STORES, data_store_id):
@@ -91,14 +95,16 @@ def get_data_store_class(
 def get_data_store_params_schema(
     data_store_id: str, extension_registry: Optional[ExtensionRegistry] = None
 ) -> JsonObjectSchema:
-    """
-    Get the JSON schema for instantiating a new data store
+    """Get the JSON schema for instantiating a new data store
     identified by *data_store_id*.
 
-    :param data_store_id: A data store identifier.
-    :param extension_registry: Optional extension registry.
-        If not given, the global extension registry will be used.
-    :return: The JSON schema for the data store's parameters.
+    Args:
+        data_store_id: A data store identifier.
+        extension_registry: Optional extension registry. If not given,
+            the global extension registry will be used.
+
+    Returns:
+        The JSON schema for the data store's parameters.
     """
     data_store_class = get_data_store_class(
         data_store_id, extension_registry=extension_registry
@@ -110,14 +116,16 @@ def find_data_store_extensions(
     predicate: ExtensionPredicate = None,
     extension_registry: Optional[ExtensionRegistry] = None,
 ) -> List[Extension]:
-    """
-    Find data store extensions using the optional filter
+    """Find data store extensions using the optional filter
     function *predicate*.
 
-    :param predicate: An optional filter function.
-    :param extension_registry: Optional extension registry.
-        If not given, the global extension registry will be used.
-    :return: List of data store extensions.
+    Args:
+        predicate: An optional filter function.
+        extension_registry: Optional extension registry. If not given,
+            the global extension registry will be used.
+
+    Returns:
+        List of data store extensions.
     """
     extension_registry = extension_registry or get_extension_registry()
     return extension_registry.find_extensions(
@@ -131,8 +139,7 @@ def find_data_store_extensions(
 
 
 class DataStore(DataOpener, DataSearcher, ABC):
-    """
-    A data store represents a collection of data resources that
+    """A data store represents a collection of data resources that
     can be enumerated, queried, and opened in order to obtain
     in-memory representations of the data. The same data resource may be
     made available using different data types. Therefore, many methods
@@ -150,8 +157,7 @@ class DataStore(DataOpener, DataSearcher, ABC):
 
     @classmethod
     def get_data_store_params_schema(cls) -> JsonObjectSchema:
-        """
-        Get descriptions of parameters that must or can be used to
+        """Get descriptions of parameters that must or can be used to
         instantiate a new DataStore object.
         Parameters are named and described by the properties of the
         returned JSON object schema.
@@ -163,31 +169,35 @@ class DataStore(DataOpener, DataSearcher, ABC):
     @classmethod
     @abstractmethod
     def get_data_types(cls) -> Tuple[str, ...]:
-        """
-        Get alias names for all data types supported by this store.
+        """Get alias names for all data types supported by this store.
         The first entry in the tuple represents this store's
         default data type.
 
-        :return: The tuple of supported data types.
+        Returns:
+            The tuple of supported data types.
         """
 
     @abstractmethod
     def get_data_types_for_data(self, data_id: str) -> Tuple[str, ...]:
-        """
-        Get alias names for of data types that are supported
+        """Get alias names for of data types that are supported
         by this store for the given *data_id*.
 
-        :param data_id: An identifier of data that is provided by this store
-        :return: A tuple of data types that apply to the given *data_id*.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: An identifier of data that is provided by this
+                store
+
+        Returns:
+            A tuple of data types that apply to the given *data_id*.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def get_data_ids(
         self, data_type: DataTypeLike = None, include_attrs: Container[str] = None
     ) -> Union[Iterator[str], Iterator[Tuple[str, Dict[str, Any]]]]:
-        """
-        Get an iterator over the data resource identifiers for the
+        """Get an iterator over the data resource identifiers for the
         given type *data_type*. If *data_type* is omitted, all data
         resource identifiers are returned.
 
@@ -221,82 +231,93 @@ class DataStore(DataOpener, DataSearcher, ABC):
         ``("ESACCI-L4_GHRSST-SSTdepth-OSTIA-GLOB_CDR2.1-v02.0-fv01.0.zarr",
         {"title": "Level-4 GHRSST Analysed Sea Surface Temperature"})``.
 
-        :param data_type: If given, only data identifiers that are
-            available as this type are returned.
-            If this is omitted, all available data identifiers are returned.
-        :param include_attrs: A sequence of names of attributes to
-            be returned for each dataset identifier.
-            If given, the store will attempt to provide the set of
-            requested dataset attributes in addition to the data ids.
-            (added in xcube 0.8.0)
-        :return: An iterator over the identifiers and titles of data
+        Args:
+            data_type: If given, only data identifiers that are
+                available as this type are returned. If this is omitted,
+                all available data identifiers are returned.
+            include_attrs: A sequence of names of attributes to be
+                returned for each dataset identifier. If given, the
+                store will attempt to provide the set of requested
+                dataset attributes in addition to the data ids. (added
+                in xcube 0.8.0)
+
+        Returns:
+            An iterator over the identifiers and titles of data
             resources provided by this data store.
-        :raise DataStoreError: If an error occurs.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     def list_data_ids(
         self, data_type: DataTypeLike = None, include_attrs: Container[str] = None
     ) -> Union[List[str], List[Tuple[str, Dict[str, Any]]]]:
-        """
-        Convenience version of `get_data_ids()` that returns a list rather
+        """Convenience version of `get_data_ids()` that returns a list rather
         than an iterator.
 
-        :param data_type: If given, only data identifiers that are
-            available as this type are returned.
-            If this is omitted, all available data identifiers are returned.
-        :param include_attrs: A sequence of names of attributes to
-            be returned for each dataset identifier.
-            If given, the store will attempt to provide the set of
-            requested dataset attributes in addition to the data ids.
-            (added in xcube 0.8.0)
-        :return: A list comprising the identifiers and titles of data
+        Args:
+            data_type: If given, only data identifiers that are
+                available as this type are returned. If this is omitted,
+                all available data identifiers are returned.
+            include_attrs: A sequence of names of attributes to be
+                returned for each dataset identifier. If given, the
+                store will attempt to provide the set of requested
+                dataset attributes in addition to the data ids. (added
+                in xcube 0.8.0)
+
+        Returns:
+            A list comprising the identifiers and titles of data
             resources provided by this data store.
-        :raise DataStoreError: If an error occurs.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
         return list(self.get_data_ids(data_type=data_type, include_attrs=include_attrs))
 
     @abstractmethod
     def has_data(self, data_id: str, data_type: DataTypeLike = None) -> bool:
-        """
-        Check if the data resource given by *data_id* is
+        """Check if the data resource given by *data_id* is
         available in this store.
 
-        :param data_id: A data identifier
-        :param data_type: An optional data type.
-            If given, it will also be checked whether the data
-            is available as the specified type.
-            May be given as type alias name, as a type,
-            or as a :class:DataType instance.
-        :return: True, if the data resource is available in this store,
-            False otherwise.
+        Args:
+            data_id: A data identifier
+            data_type: An optional data type. If given, it will also be
+                checked whether the data is available as the specified
+                type. May be given as type alias name, as a type, or as
+                a :class:DataType instance.
+
+        Returns:
+            True, if the data resource is available in this store, False
+            otherwise.
         """
 
     @abstractmethod
     def describe_data(
         self, data_id: str, data_type: DataTypeLike = None
     ) -> DataDescriptor:
-        """
-        Get the descriptor for the data resource given by *data_id*.
+        """Get the descriptor for the data resource given by *data_id*.
 
         Raises a :class:DataStoreError if *data_id* does not
         exist in this store or the data is not available as the
         specified *data_type*.
 
-        :param data_id: An identifier of data provided by this store
-        :param data_type: If given, the descriptor of the data will
-            describe the data as specified by the data type.
-            May be given as type alias name, as a type,
-            or as a :class:DataType instance.
+        Args:
+            data_id: An identifier of data provided by this store
+            data_type: If given, the descriptor of the data will
+                describe the data as specified by the data type. May be
+                given as type alias name, as a type, or as a
+                :class:DataType instance.
         :return a data-type specific data descriptor
-        :raise DataStoreError: If an error occurs.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def get_data_opener_ids(
         self, data_id: str = None, data_type: DataTypeLike = None
     ) -> Tuple[str, ...]:
-        """
-        Get identifiers of data openers that can be used to open data
+        """Get identifiers of data openers that can be used to open data
         resources from this store.
 
         If *data_id* is given, data accessors are restricted to the ones
@@ -310,23 +331,26 @@ class DataStore(DataOpener, DataSearcher, ABC):
         it should verify that *data_type* is either None or equal to
         that single data type.
 
-        :param data_id: An optional data resource identifier that is
-            known to exist in this data store.
-        :param data_type: An optional data type that is known to be
-            supported by this data store.
-            May be given as type alias name, as a type,
-            or as a :class:DataType instance.
-        :return: A tuple of identifiers of data openers that can be
-            used to open data resources.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: An optional data resource identifier that is known
+                to exist in this data store.
+            data_type: An optional data type that is known to be
+                supported by this data store. May be given as type alias
+                name, as a type, or as a :class:DataType instance.
+
+        Returns:
+            A tuple of identifiers of data openers that can be used to
+            open data resources.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def get_open_data_params_schema(
         self, data_id: str = None, opener_id: str = None
     ) -> JsonObjectSchema:
-        """
-        Get the schema for the parameters passed as *open_params* to
+        """Get the schema for the parameters passed as *open_params* to
         :meth:open_data(data_id, open_params).
 
         If *data_id* is given, the returned schema will be tailored
@@ -385,17 +409,21 @@ class DataStore(DataOpener, DataSearcher, ABC):
           * `variable_names == ["<var_1>", "<var_2>", ...]` only
             include data variables named "<var_1>", "<var_2>", ...
 
-        :param data_id: An optional data identifier that is known
-            to exist in this data store.
-        :param opener_id: An optional data opener identifier.
-        :return: The schema for the parameters in *open_params*.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: An optional data identifier that is known to exist
+                in this data store.
+            opener_id: An optional data opener identifier.
+
+        Returns:
+            The schema for the parameters in *open_params*.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def open_data(self, data_id: str, opener_id: str = None, **open_params) -> Any:
-        """
-        Open the data given by the data resource identifier *data_id*
+        """Open the data given by the data resource identifier *data_id*
         using the supplied *open_params*.
 
         The data type of the return value depends on the data opener
@@ -409,19 +437,23 @@ class DataStore(DataOpener, DataSearcher, ABC):
 
         Raises if *data_id* does not exist in this store.
 
-        :param data_id: The data identifier that is known to exist
-            in this data store.
-        :param opener_id: An optional data opener identifier.
-        :param open_params: Opener-specific parameters.
-        :return: An in-memory representation of the data resources
-            identified by *data_id* and *open_params*.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: The data identifier that is known to exist in this
+                data store.
+            opener_id: An optional data opener identifier.
+            **open_params: Opener-specific parameters.
+
+        Returns:
+            An in-memory representation of the data resources identified
+            by *data_id* and *open_params*.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
 
 class MutableDataStore(DataStore, DataWriter, ABC):
-    """
-    A mutable data store is a data store that also allows for adding,
+    """A mutable data store is a data store that also allows for adding,
     updating, and removing data resources.
 
     MutableDataStore is an abstract base class that any mutable data
@@ -430,8 +462,7 @@ class MutableDataStore(DataStore, DataWriter, ABC):
 
     @abstractmethod
     def get_data_writer_ids(self, data_type: DataTypeLike = None) -> Tuple[str, ...]:
-        """
-        Get identifiers of data writers that can be used to write data
+        """Get identifiers of data writers that can be used to write data
         resources to this store.
 
         If *data_type* is given, only writers that support this
@@ -441,19 +472,22 @@ class MutableDataStore(DataStore, DataWriter, ABC):
         it should verify that *data_type* is either None or equal to
         that single data type.
 
-        :param data_type: An optional data type specifier that is
-            known to be supported by this data store.
-            May be given as type alias name, as a type,
-            or as a :class:DataType instance.
-        :return: A tuple of identifiers of data writers that can
-            be used to write data resources.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_type: An optional data type specifier that is known to
+                be supported by this data store. May be given as type
+                alias name, as a type, or as a :class:DataType instance.
+
+        Returns:
+            A tuple of identifiers of data writers that can be used to
+            write data resources.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def get_write_data_params_schema(self, writer_id: str = None) -> JsonObjectSchema:
-        """
-        Get the schema for the parameters passed as *write_params* to
+        """Get the schema for the parameters passed as *write_params* to
         :meth:write_data(data, data_id, open_params).
 
         If *writer_id* is given, the returned schema will be tailored
@@ -470,9 +504,14 @@ class MutableDataStore(DataStore, DataWriter, ABC):
             writer_params_schema = get_writer(writer_id).get_write_data_params_schema()
             return subtract_param_schemas(writer_params_schema, store_params_schema)
 
-        :param writer_id: An optional data writer identifier.
-        :return: The schema for the parameters in *write_params*.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            writer_id: An optional data writer identifier.
+
+        Returns:
+            The schema for the parameters in *write_params*.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
@@ -484,8 +523,7 @@ class MutableDataStore(DataStore, DataWriter, ABC):
         replace: bool = False,
         **write_params,
     ) -> str:
-        """
-        Write a data in-memory instance using the supplied *data_id*
+        """Write a data in-memory instance using the supplied *data_id*
          and *write_params*.
 
         If data identifier *data_id* is not given, a writer-specific default
@@ -508,20 +546,24 @@ class MutableDataStore(DataStore, DataWriter, ABC):
 
         Raises if *data_id* does not exist in this store.
 
-        :param data: The data in-memory instance to be written.
-        :param data_id: An optional data identifier that is known to
-            be unique in this data store.
-        :param writer_id: An optional data writer identifier.
-        :param replace: Whether to replace an existing data resource.
-        :param write_params: Writer-specific parameters.
-        :return: The data identifier used to write the data.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data: The data in-memory instance to be written.
+            data_id: An optional data identifier that is known to be
+                unique in this data store.
+            writer_id: An optional data writer identifier.
+            replace: Whether to replace an existing data resource.
+            **write_params: Writer-specific parameters.
+
+        Returns:
+            The data identifier used to write the data.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def delete_data(self, data_id: str, **delete_params):
-        """
-        Delete the data resource identified by *data_id*.
+        """Delete the data resource identified by *data_id*.
 
         Typically, an implementation would delete the data resource
         from the physical storage and also remove any registered metadata
@@ -529,15 +571,17 @@ class MutableDataStore(DataStore, DataWriter, ABC):
 
         Raises if *data_id* does not exist in this store.
 
-        :param data_id: An data identifier that is known to exist
-            in this data store.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: An data identifier that is known to exist in this
+                data store.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def register_data(self, data_id: str, data: Any):
-        """
-        Register the in-memory representation of a data resource *data*
+        """Register the in-memory representation of a data resource *data*
         using the given data resource identifier *data_id*.
 
         This method can be used to register data resources that are
@@ -549,16 +593,18 @@ class MutableDataStore(DataStore, DataWriter, ABC):
         An implementation should just store the metadata of *data*.
         It should not write *data*.
 
-        :param data_id: A data resource identifier that is known
-            to be unique in this data store.
-        :param data: An in-memory representation of a data resource.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: A data resource identifier that is known to be
+                unique in this data store.
+            data: An in-memory representation of a data resource.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """
 
     @abstractmethod
     def deregister_data(self, data_id: str):
-        """
-        De-register a data resource identified by *data_id* from
+        """De-register a data resource identified by *data_id* from
         this data store.
 
         This method can be used to de-register data resources so it
@@ -572,7 +618,10 @@ class MutableDataStore(DataStore, DataWriter, ABC):
 
         Raises if *data_id* does not exist in this store.
 
-        :param data_id: A data resource identifier that is
-            known to exist in this data store.
-        :raise DataStoreError: If an error occurs.
+        Args:
+            data_id: A data resource identifier that is known to exist
+                in this data store.
+
+        Raises:
+            DataStoreError: If an error occurs.
         """

--- a/xcube/core/store/storepool.py
+++ b/xcube/core/store/storepool.py
@@ -40,21 +40,23 @@ def get_data_store_instance(
     store_params: Dict[str, Any] = None,
     store_pool: "DataStorePool" = None,
 ) -> "DataStoreInstance":
-    """
-    Get a data store instance for identifier *store_id*.
+    """Get a data store instance for identifier *store_id*.
 
     If *store_id* is prefixed by a "@", it is an "instance identifier".
     In this case the store instance is retrieved from
     the expected *store_pool* argument. Otherwise a new store instance
     is created using optional *store_params*.
 
-    :param store_id: Store identifier, may be prefixed by
-        a "@" to indicate a store instance identifier.
-    :param store_params: Store parameters, only valid if *store_id*
-        is not an instance identifier.
-    :param store_pool: A pool of configured store instances used
-        if *store_id* is an instance identifier.
-    :return: a DataStoreInstance object
+    Args:
+        store_id: Store identifier, may be prefixed by a "@" to indicate
+            a store instance identifier.
+        store_params: Store parameters, only valid if *store_id* is not
+            an instance identifier.
+        store_pool: A pool of configured store instances used if
+            *store_id* is an instance identifier.
+
+    Returns:
+        a DataStoreInstance object
     :raise: DataStoreError if a configured store does not exist
     """
     if store_id.startswith("@"):
@@ -105,16 +107,16 @@ DATA_STORE_POOL_SCHEMA = JsonObjectSchema(
 
 
 class DataStoreConfig:
-    """
-    The configuration of a data store.
+    """The configuration of a data store.
     The class is used by :class:DataStorePool to instantiate
     stores in a deferred manner.
 
-    :param store_id: the data store identifier
-    :param store_params: optional store parameters
-    :param title: a human-readable title for the store instance
-    :param description: a human-readable description of the store instance
-    :param user_data: optional user-data
+    Args:
+        store_id: the data store identifier
+        store_params: optional store parameters
+        title: a human-readable title for the store instance
+        description: a human-readable description of the store instance
+        user_data: optional user-data
     """
 
     def __init__(
@@ -178,8 +180,7 @@ class DataStoreConfig:
 
 
 class DataStoreInstance:
-    """
-    Internal class used by DataStorePool to maintain
+    """Internal class used by DataStorePool to maintain
     store configurations + instances.
     """
 

--- a/xcube/core/subsampling.py
+++ b/xcube/core/subsampling.py
@@ -166,8 +166,7 @@ def assert_valid_agg_methods(agg_methods: Optional[AggMethods]):
 def find_agg_method(
     agg_methods: AggMethods, var_name: Hashable, var_dtype: np.dtype
 ) -> str:
-    """
-    Find aggregation method in *agg_methods*
+    """Find aggregation method in *agg_methods*
     for given *var_name* and *var_dtype*.
     """
     assert_valid_agg_methods(agg_methods)

--- a/xcube/core/tilingscheme.py
+++ b/xcube/core/tilingscheme.py
@@ -52,8 +52,7 @@ EARTH_CIRCUMFERENCE_WGS84 = 2 * math.pi * EARTH_EQUATORIAL_RADIUS_WGS84
 
 
 class TilingScheme:
-    """
-    A scheme for subdividing the world into a tiled, multi-resolution
+    """A scheme for subdividing the world into a tiled, multi-resolution
     image pyramid.
 
     Two standard tiling schemes are pre-defined:
@@ -61,15 +60,16 @@ class TilingScheme:
     1. TilingScheme.WEB_MERCATOR
     2. TilingScheme.GEOGRAPHIC
 
-    :param num_level_zero_tiles: The number of tiles
-        in x and y direction at lowest resolution level (zero).
-    :param crs_name: Name of the spatial coordinate reference system.
-    :param map_height: The height of the world map in units of the
-        spatial coordinate reference system.
-    :param tile_size: The tile size to be used for
-        both x and y directions. Defaults to 256.
-    :param min_level: Optional minimum resolution level.
-    :param max_level: Optional maximum resolution level.
+    Args:
+        num_level_zero_tiles: The number of tiles in x and y direction
+            at lowest resolution level (zero).
+        crs_name: Name of the spatial coordinate reference system.
+        map_height: The height of the world map in units of the spatial
+            coordinate reference system.
+        tile_size: The tile size to be used for both x and y directions.
+            Defaults to 256.
+        min_level: Optional minimum resolution level.
+        max_level: Optional maximum resolution level.
     """
 
     # The web mercator tiling schema with 1 x 1 level zero tiles
@@ -125,8 +125,7 @@ class TilingScheme:
 
     @property
     def map_width(self) -> float:
-        """
-        The height of the map in units
+        """The height of the map in units
         of the map's spatial coordinate reference system.
         """
         num_tiles_x0, num_tiles_y0 = self.num_level_zero_tiles
@@ -134,16 +133,14 @@ class TilingScheme:
 
     @property
     def map_height(self) -> float:
-        """
-        The height of the map in units
+        """The height of the map in units
         of the map's spatial coordinate reference system.
         """
         return self._map_height
 
     @property
     def map_extent(self) -> Tuple[float, float, float, float]:
-        """
-        The extent of the map in units
+        """The extent of the map in units
         of the map's spatial coordinate reference system.
         """
         map_width_05 = self.map_width / 2
@@ -152,8 +149,7 @@ class TilingScheme:
 
     @property
     def map_origin(self) -> Tuple[float, float]:
-        """
-        The origin of the map (upper, left pixel of the upper left tile)
+        """The origin of the map (upper, left pixel of the upper left tile)
         in units of the map's spatial coordinate reference system.
         """
         map_extent = self.map_extent
@@ -191,12 +187,14 @@ class TilingScheme:
 
     @classmethod
     def for_crs(cls, crs: Union[pyproj.CRS, str], **kwargs) -> "TilingScheme":
-        """
-        Get a new tiling scheme for the named coordinate reference system.
+        """Get a new tiling scheme for the named coordinate reference system.
 
-        :param crs: The spatial coordinate reference system.
-        :param kwargs: subset of constructor arguments
-        :return: a tiling scheme
+        Args:
+            crs: The spatial coordinate reference system.
+            **kwargs: subset of constructor arguments
+
+        Returns:
+            a tiling scheme
         """
         assert_instance(crs, (pyproj.CRS, str), name="crs")
         crs_name = crs.srs if isinstance(crs, pyproj.CRS) else crs
@@ -209,20 +207,21 @@ class TilingScheme:
         return tiling_scheme.derive(**kwargs) if kwargs else tiling_scheme
 
     def derive(self, **kwargs):
-        """
-        Derive a new tiling scheme using a subset of constructor
+        """Derive a new tiling scheme using a subset of constructor
         arguments *kwargs*.
 
-        :param kwargs: subset of constructor arguments
-        :return: a new tiling scheme
+        Args:
+            **kwargs: subset of constructor arguments
+
+        Returns:
+            a new tiling scheme
         """
         args = self.to_dict()
         args.update({k: v for k, v in kwargs.items() if v is not None})
         return TilingScheme(**args)
 
     def to_dict(self):
-        """
-        Return a JSON-serializable dictionary
+        """Return a JSON-serializable dictionary
         representation of this tiling scheme.
         """
         d = dict(
@@ -241,13 +240,17 @@ class TilingScheme:
         max_level: Optional[int] = None,
         unit_name: Optional[str] = None,
     ) -> List[float]:
-        """
-        Get spatial resolutions for this tiling scheme.
+        """Get spatial resolutions for this tiling scheme.
 
-        :param min_level: Optional minimum level. Defaults to self.min_level.
-        :param max_level: Optional maximum level. Defaults to self.max_level.
-        :param unit_name: The spatial unit for the returned resolutions.
-        :return: List of spatial resolutions.
+        Args:
+            min_level: Optional minimum level. Defaults to
+                self.min_level.
+            max_level: Optional maximum level. Defaults to
+                self.max_level.
+            unit_name: The spatial unit for the returned resolutions.
+
+        Returns:
+            List of spatial resolutions.
         """
         unit_factor = get_unit_factor(
             self.map_unit_name, unit_name or self.map_unit_name
@@ -266,8 +269,7 @@ class TilingScheme:
     def get_levels_for_resolutions(
         self, resolutions: Sequence[float], unit_name: str
     ) -> Tuple[int, int]:
-        """
-        Get the minimum and maximum level indices into this tiling scheme
+        """Get the minimum and maximum level indices into this tiling scheme
         for the given spatial *resolutions*.
 
         The resolutions are typically those of a multi-resolution dataset,
@@ -275,9 +277,12 @@ class TilingScheme:
         hence the smallest resolution value. Subsequent resolution values
         are monotonically increasing.
 
-        :param resolutions: A sequence of spatial resolutions.
-        :param unit_name: The spatial units for *resolutions*.
-        :return: the range of levels in this tiling scheme.
+        Args:
+            resolutions: A sequence of spatial resolutions.
+            unit_name: The spatial units for *resolutions*.
+
+        Returns:
+            the range of levels in this tiling scheme.
         """
         assert_given(resolutions, name="resolutions")
         assert_instance(unit_name, str, name="unit_name")
@@ -295,8 +300,7 @@ class TilingScheme:
     def get_resolutions_level(
         self, level: int, resolutions: Sequence[float], unit_name: str
     ) -> int:
-        """
-        Get the level in the sequence of spatial *resolutions*
+        """Get the level in the sequence of spatial *resolutions*
         for given *map_level*.
 
         The resolutions are typically those of a multi-resolution dataset,
@@ -304,12 +308,15 @@ class TilingScheme:
         hence the smallest resolution value. Subsequent resolution values
         are monotonically increasing.
 
-        :param level: A level within this tiling scheme.
-        :param resolutions: A sequence of spatial resolutions.
-            Values must be monotonically increasing. First entry
-            is the highest resolution at level zero.
-        :param unit_name: The spatial units for *resolutions*.
-        :return: The multi-resolution level.
+        Args:
+            level: A level within this tiling scheme.
+            resolutions: A sequence of spatial resolutions. Values must
+                be monotonically increasing. First entry is the highest
+                resolution at level zero.
+            unit_name: The spatial units for *resolutions*.
+
+        Returns:
+            The multi-resolution level.
         """
         assert_given(resolutions, name="resolutions")
         assert_instance(unit_name, str, name="unit_name")
@@ -345,13 +352,15 @@ class TilingScheme:
     def get_tile_extent(
         self, tile_x: int, tile_y: int, tile_z: int
     ) -> Optional[Tuple[float, float, float, float]]:
-        """
-        Get the extent in units of the CRS for the given tile coordinates.
+        """Get the extent in units of the CRS for the given tile coordinates.
 
-        :param tile_x: The tile's column index
-        :param tile_y: The tile's row index
-        :param tile_z: The tile's level index
-        :return: The tile's extent
+        Args:
+            tile_x: The tile's column index
+            tile_y: The tile's row index
+            tile_z: The tile's level index
+
+        Returns:
+            The tile's extent
         """
         if tile_z < 0:
             return None
@@ -398,8 +407,7 @@ TilingScheme.GEOGRAPHIC = TilingScheme(
 
 
 def get_unit_factor(unit_name_from: str, unit_name_to: str) -> float:
-    """
-    Get the factor to convert from one unit into another
+    """Get the factor to convert from one unit into another
     with units given by *unit_name_from* and *unit_name_to*.
     """
     from_meter = _is_meter_unit(unit_name_from)

--- a/xcube/core/timecoord.py
+++ b/xcube/core/timecoord.py
@@ -96,16 +96,19 @@ def add_time_coords(dataset: xr.Dataset, time_range: Tuple[float, float]) -> xr.
 def get_time_range_from_data(
     dataset: xr.Dataset, maybe_consider_metadata: bool = True
 ) -> Tuple[Optional[float], Optional[float]]:
-    """
-    Determines a time range from a dataset by inspecting its time_bounds or time data arrays.
+    """Determines a time range from a dataset by inspecting its time_bounds or time data arrays.
     In cases where no time bounds are given and no time periodicity can be determined,
     metadata may be considered.
 
-    :param dataset: The dataset of which the time range shall be determined
-    :param maybe_consider_metadata: Whether metadata shall be considered.
+    Args:
+        dataset: The dataset of which the time range shall be determined
+        maybe_consider_metadata: Whether metadata shall be considered.
     Only used when the dataset has no time bounds array and no time periodicity.
     The values will only be set when they do not contradict the values from the data arrays.
-    :return: A tuple with two float values: The first one represents the start time,
+
+    Returns:
+        A tuple with two float values: The first one represents the
+        start time,
     the second the end time. Either may be None.
     """
     time_bounds_names = ["time_bnds", "time_bounds"]
@@ -267,16 +270,20 @@ def timestamp_to_iso_string(
     freq: str = "S",
     round_fn: str = "round",
 ):
-    """
-    Convert a UTC timestamp given as nanos, millis, seconds, etc. since 1970-01-01 00:00:00
+    """Convert a UTC timestamp given as nanos, millis, seconds, etc. since 1970-01-01 00:00:00
     to an ISO-format string.
 
-    :param time: UTC timestamp given as time delta since 1970-01-01 00:00:00 in the units
-        given by the numpy datetime64 type, so it can be as nanos, millis,
-        seconds since 1970-01-01 00:00:00.
-    :param freq: time rounding resolution. See pandas.Timestamp.round().
-    :param round_fn: time rounding function. Defaults to pandas.Timestamp.round().
-    :return: ISO-format string.
+    Args:
+        time: UTC timestamp given as time delta since 1970-01-01
+            00:00:00 in the units given by the numpy datetime64 type, so
+            it can be as nanos, millis, seconds since 1970-01-01
+            00:00:00.
+        freq: time rounding resolution. See pandas.Timestamp.round().
+        round_fn: time rounding function. Defaults to
+            pandas.Timestamp.round().
+
+    Returns:
+        ISO-format string.
     """
     # All times are UTC (Z = Zulu Time Zone = UTC)
     assert_in(round_fn, ("ceil", "floor", "round"), name="round_fn")

--- a/xcube/core/timeseries.py
+++ b/xcube/core/timeseries.py
@@ -72,8 +72,7 @@ def get_time_series(
     use_groupby: bool = False,
     cube_asserted: Optional[bool] = None,
 ) -> Optional[xr.Dataset]:
-    """
-    Get a time series dataset from a data *cube*.
+    """Get a time series dataset from a data *cube*.
 
     *geometry* may be provided as a (shapely) geometry object, a valid
     GeoJSON object, a valid WKT string,
@@ -96,20 +95,22 @@ def get_time_series(
     output variables remain,
     the function returns ``None``.
 
-    :param cube: The xcube dataset
-    :param grid_mapping: Grid mapping of *cube*.
-    :param geometry: Optional geometry
-    :param var_names: Optional sequence of names of variables to be included.
-    :param start_date: Optional start date.
-    :param end_date: Optional end date.
-    :param agg_methods: Aggregation methods. May be single string or
-        sequence of strings. Possible values are
-        'mean', 'median', 'min', 'max', 'std', 'count'. Defaults to 'mean'.
-        Ignored if geometry is a point.
-    :param use_groupby: Use group-by operation. May increase or decrease
-        runtime performance and/or memory consumption.
-    :param cube_asserted: Deprecated and ignored since xcube 0.11.0.
-        No replacement.
+    Args:
+        cube: The xcube dataset
+        grid_mapping: Grid mapping of *cube*.
+        geometry: Optional geometry
+        var_names: Optional sequence of names of variables to be
+            included.
+        start_date: Optional start date.
+        end_date: Optional end date.
+        agg_methods: Aggregation methods. May be single string or
+            sequence of strings. Possible values are 'mean', 'median',
+            'min', 'max', 'std', 'count'. Defaults to 'mean'. Ignored if
+            geometry is a point.
+        use_groupby: Use group-by operation. May increase or decrease
+            runtime performance and/or memory consumption.
+        cube_asserted: Deprecated and ignored since xcube 0.11.0. No
+            replacement.
     """
     if cube_asserted is not None:
         warnings.warn(

--- a/xcube/core/timeslice.py
+++ b/xcube/core/timeslice.py
@@ -77,12 +77,12 @@ def append_time_slice(
     time_slice: xr.Dataset,
     chunk_sizes: Dict[str, int] = None,
 ):
-    """
-    Append time slice to existing zarr dataset.
+    """Append time slice to existing zarr dataset.
 
-    :param store: A zarr store.
-    :param time_slice: Time slice to insert
-    :param chunk_sizes: desired chunk sizes
+    Args:
+        store: A zarr store.
+        time_slice: Time slice to insert
+        chunk_sizes: desired chunk sizes
     """
     if chunk_sizes:
         time_slice = chunk_dataset(time_slice, chunk_sizes, format_name="zarr")
@@ -110,13 +110,13 @@ def insert_time_slice(
     time_slice: xr.Dataset,
     chunk_sizes: Dict[str, int] = None,
 ):
-    """
-    Insert time slice into existing zarr dataset.
+    """Insert time slice into existing zarr dataset.
 
-    :param store: A zarr store.
-    :param insert_index: Time index
-    :param time_slice: Time slice to insert
-    :param chunk_sizes: desired chunk sizes
+    Args:
+        store: A zarr store.
+        insert_index: Time index
+        time_slice: Time slice to insert
+        chunk_sizes: desired chunk sizes
     """
     update_time_slice(
         store, insert_index, time_slice, "insert", chunk_sizes=chunk_sizes
@@ -129,13 +129,13 @@ def replace_time_slice(
     time_slice: xr.Dataset,
     chunk_sizes: Dict[str, int] = None,
 ):
-    """
-    Replace time slice in existing zarr dataset.
+    """Replace time slice in existing zarr dataset.
 
-    :param store: A zarr store.
-    :param insert_index: Time index
-    :param time_slice: Time slice to insert
-    :param chunk_sizes: desired chunk sizes
+    Args:
+        store: A zarr store.
+        insert_index: Time index
+        time_slice: Time slice to insert
+        chunk_sizes: desired chunk sizes
     """
     update_time_slice(
         store, insert_index, time_slice, "replace", chunk_sizes=chunk_sizes
@@ -149,14 +149,14 @@ def update_time_slice(
     mode: str,
     chunk_sizes: Dict[str, int] = None,
 ):
-    """
-    Update existing zarr dataset by new time slice.
+    """Update existing zarr dataset by new time slice.
 
-    :param store: A zarr store.
-    :param insert_index: Time index
-    :param time_slice: Time slice to insert
-    :param mode: Update mode, 'insert' or 'replace'
-    :param chunk_sizes: desired chunk sizes
+    Args:
+        store: A zarr store.
+        insert_index: Time index
+        time_slice: Time slice to insert
+        mode: Update mode, 'insert' or 'replace'
+        chunk_sizes: desired chunk sizes
     """
 
     if mode not in ("insert", "replace"):

--- a/xcube/core/unchunk.py
+++ b/xcube/core/unchunk.py
@@ -31,12 +31,12 @@ import zarr
 def unchunk_dataset(
     dataset_path: str, var_names: Sequence[str] = None, coords_only: bool = False
 ):
-    """
-    Unchunk dataset variables in-place.
+    """Unchunk dataset variables in-place.
 
-    :param dataset_path: Path to ZARR dataset directory.
-    :param var_names: Optional list of variable names.
-    :param coords_only: Un-chunk coordinate variables only.
+    Args:
+        dataset_path: Path to ZARR dataset directory.
+        var_names: Optional list of variable names.
+        coords_only: Un-chunk coordinate variables only.
     """
 
     is_zarr = os.path.isfile(os.path.join(dataset_path, ".zgroup"))

--- a/xcube/core/update.py
+++ b/xcube/core/update.py
@@ -72,13 +72,18 @@ def update_dataset_attrs(
 def update_dataset_spatial_attrs(
     dataset: xr.Dataset, update_existing: bool = False, in_place: bool = False
 ) -> xr.Dataset:
-    """
-    Update spatial CF/THREDDS attributes of given *dataset*.
+    """Update spatial CF/THREDDS attributes of given *dataset*.
 
-    :param dataset: The dataset.
-    :param update_existing: If ``True``, any existing attributes will be updated.
-    :param in_place: If ``True``, *dataset* will be modified in place and returned.
-    :return: A new dataset, if *in_place* if ``False`` (default), else the passed and modified *dataset*.
+    Args:
+        dataset: The dataset.
+        update_existing: If ``True``, any existing attributes will be
+            updated.
+        in_place: If ``True``, *dataset* will be modified in place and
+            returned.
+
+    Returns:
+        A new dataset, if *in_place* if ``False`` (default), else the
+        passed and modified *dataset*.
     """
     if not in_place:
         dataset = dataset.copy()
@@ -99,13 +104,18 @@ def update_dataset_spatial_attrs(
 def update_dataset_temporal_attrs(
     dataset: xr.Dataset, update_existing: bool = False, in_place: bool = False
 ) -> xr.Dataset:
-    """
-    Update temporal CF/THREDDS attributes of given *dataset*.
+    """Update temporal CF/THREDDS attributes of given *dataset*.
 
-    :param dataset: The dataset.
-    :param update_existing: If ``True``, any existing attributes will be updated.
-    :param in_place: If ``True``, *dataset* will be modified in place and returned.
-    :return: A new dataset, if *in_place* is ``False`` (default), else the passed and modified *dataset*.
+    Args:
+        dataset: The dataset.
+        update_existing: If ``True``, any existing attributes will be
+            updated.
+        in_place: If ``True``, *dataset* will be modified in place and
+            returned.
+
+    Returns:
+        A new dataset, if *in_place* is ``False`` (default), else the
+        passed and modified *dataset*.
     """
     coord_data = [_TIME_ATTRS_DATA]
     if not in_place:
@@ -164,8 +174,7 @@ def update_dataset_temporal_attrs(
 def update_dataset_var_attrs(
     dataset: xr.Dataset, var_attrs_list: NameDictPairList
 ) -> xr.Dataset:
-    """
-    Update the attributes of variables in given *dataset*.
+    """Update the attributes of variables in given *dataset*.
     Optionally rename variables according to a given attribute named "name".
 
     *var_attrs_list* must be a sequence of pairs of the form (<var_name>, <var_attrs>) where <var_name> is a string
@@ -173,9 +182,13 @@ def update_dataset_var_attrs(
     If <var_attrs> contains an attribute "name", the variable named <var_name> will be renamed to that attribute's
     value.
 
-    :param dataset: A dataset.
-    :param var_attrs_list: List of tuples of the form (variable name, properties dictionary).
-    :return: A shallow copy of *dataset* with updated / renamed variables.
+    Args:
+        dataset: A dataset.
+        var_attrs_list: List of tuples of the form (variable name,
+            properties dictionary).
+
+    Returns:
+        A shallow copy of *dataset* with updated / renamed variables.
     """
     if not var_attrs_list:
         return dataset
@@ -222,15 +235,16 @@ def update_dataset_chunk_encoding(
     format_name: str = None,
     in_place: bool = False,
 ) -> xr.Dataset:
-    """
-    Update each variable's encoding in *dataset* with respect to *chunk_sizes*
+    """Update each variable's encoding in *dataset* with respect to *chunk_sizes*
     so *dataset* is written in chunks for given *format_name*.
 
-    :param dataset: input dataset.
-    :param chunk_sizes: the chunk sizes to be used for the encoding.
-        If None, any chunking encoding is removed.
-    :param format_name: format name, e.g. "zarr" or "netcdf4".
-    :param in_place: If ``True``, *dataset* will be modified in place and returned.
+    Args:
+        dataset: input dataset.
+        chunk_sizes: the chunk sizes to be used for the encoding. If
+            None, any chunking encoding is removed.
+        format_name: format name, e.g. "zarr" or "netcdf4".
+        in_place: If ``True``, *dataset* will be modified in place and
+            returned.
     """
     if format_name == FORMAT_NAME_ZARR:
         chunk_sizes_attr_name = "chunks"

--- a/xcube/core/vars2dim.py
+++ b/xcube/core/vars2dim.py
@@ -30,14 +30,20 @@ def vars_to_dim(
     var_name="data",
     cube_asserted: bool = False,
 ):
-    """
-    Convert data variables into a dimension.
+    """Convert data variables into a dimension.
 
-    :param cube: The xcube dataset.
-    :param dim_name: The name of the new dimension and coordinate variable. Defaults to 'var'.
-    :param var_name: The name of the new, single data variable. Defaults to 'data'.
-    :param cube_asserted: If False, *cube* will be verified, otherwise it is expected to be a valid cube.
-    :return: A new xcube dataset with data variables turned into a new dimension.
+    Args:
+        cube: The xcube dataset.
+        dim_name: The name of the new dimension and coordinate variable.
+            Defaults to 'var'.
+        var_name: The name of the new, single data variable. Defaults to
+            'data'.
+        cube_asserted: If False, *cube* will be verified, otherwise it
+            is expected to be a valid cube.
+
+    Returns:
+        A new xcube dataset with data variables turned into a new
+        dimension.
     """
 
     if not cube_asserted:

--- a/xcube/core/verify.py
+++ b/xcube/core/verify.py
@@ -29,11 +29,11 @@ from xcube.core.schema import get_dataset_xy_var_names, get_dataset_time_var_nam
 
 
 def assert_cube(dataset: xr.Dataset, name=None) -> xr.Dataset:
-    """
-    Assert that the given *dataset* is a valid xcube dataset.
+    """Assert that the given *dataset* is a valid xcube dataset.
 
-    :param dataset: The dataset to be validated.
-    :param name: Optional parameter name.
+    Args:
+        dataset: The dataset to be validated.
+        name: Optional parameter name.
     :raise: ValueError, if dataset is not a valid xcube dataset
     """
     report = verify_cube(dataset)
@@ -47,8 +47,7 @@ def assert_cube(dataset: xr.Dataset, name=None) -> xr.Dataset:
 
 
 def verify_cube(dataset: xr.Dataset) -> List[str]:
-    """
-    Verify the given *dataset* for being a valid xcube dataset.
+    """Verify the given *dataset* for being a valid xcube dataset.
 
     The tool verifies that *dataset*
     * defines two spatial x,y coordinate variables, that are 1D, non-empty, using correct units;
@@ -59,8 +58,11 @@ def verify_cube(dataset: xr.Dataset) -> List[str]:
 
     Returns a list of issues, which is empty if *dataset* is a valid xcube dataset.
 
-    :param dataset: A dataset to be verified.
-    :return: List of issues or empty list.
+    Args:
+        dataset: A dataset to be verified.
+
+    Returns:
+        List of issues or empty list.
     """
     report = []
 

--- a/xcube/core/xarray.py
+++ b/xcube/core/xarray.py
@@ -26,8 +26,7 @@ from xcube.core.verify import verify_cube
 
 @xr.register_dataset_accessor("xcube")
 class DatasetAccessor:
-    """
-    The xcube xarray API.
+    """The xcube xarray API.
 
     The API is made available via the ``xcube`` attribute of
     xarray.Dataset instances.
@@ -100,8 +99,7 @@ class DatasetAccessor:
 
     @classmethod
     def new(cls, **kwargs) -> xr.Dataset:
-        """
-        Create a new empty cube. Useful for testing.
+        """Create a new empty cube. Useful for testing.
 
         Refer to :func:`xcube.core.new.new_cube` for details.
         """
@@ -109,25 +107,29 @@ class DatasetAccessor:
 
     @classmethod
     def open(cls, input_path: str, format_name: str = None, **kwargs) -> xr.Dataset:
-        """
-        The ``read`` method as context manager that auto-closes the data cube read.
+        """The ``read`` method as context manager that auto-closes the data cube read.
 
-        :param input_path: input path
-        :param format_name: format, e.g. "zarr" or "netcdf4"
-        :param kwargs: format-specific keyword arguments
-        :return: dataset object
+        Args:
+            input_path: input path
+            format_name: format, e.g. "zarr" or "netcdf4"
+            **kwargs: format-specific keyword arguments
+
+        Returns:
+            dataset object
         """
         return open_cube(input_path, format_name=format_name, **kwargs)
 
     def write(self, output_path: str, format_name: str = None, **kwargs) -> xr.Dataset:
-        """
-        Write this cube to *output_path*.
+        """Write this cube to *output_path*.
         If *format* is not provided it will be guessed from *output_path*.
 
-        :param output_path: output path
-        :param format_name: format, e.g. "zarr" or "netcdf4"
-        :param kwargs: format-specific keyword arguments
-        :return: the input dataset
+        Args:
+            output_path: output path
+            format_name: format, e.g. "zarr" or "netcdf4"
+            **kwargs: format-specific keyword arguments
+
+        Returns:
+            the input dataset
         """
         return write_cube(self._dataset, output_path, format_name=format_name, **kwargs)
 
@@ -140,17 +142,25 @@ class DatasetAccessor:
         method: str = "nearest",
         cube_asserted: bool = False,
     ):
-        """
-        Extract values from cube variables at given coordinates in *points*.
+        """Extract values from cube variables at given coordinates in *points*.
 
-        :param points: Dictionary that maps dimension name to coordinate arrays.
-        :param var_names: An optional list of names of data variables in *cube* whose values shall be extracted.
-        :param index_name_pattern: A naming pattern for the computed indexes columns.
-               Must include "{name}" which will be replaced by the dimension name.
-        :param include_indexes: Whether to include computed indexes in return value.
-        :param method: "nearest" or "linear".
-        :param cube_asserted: If False, *cube* will be verified, otherwise it is expected to be a valid cube.
-        :return: A new data frame whose columns are values from *cube* variables at given *points*.
+        Args:
+            points: Dictionary that maps dimension name to coordinate
+                arrays.
+            var_names: An optional list of names of data variables in
+                *cube* whose values shall be extracted.
+            index_name_pattern: A naming pattern for the computed
+                indexes columns. Must include "{name}" which will be
+                replaced by the dimension name.
+            include_indexes: Whether to include computed indexes in
+                return value.
+            method: "nearest" or "linear".
+            cube_asserted: If False, *cube* will be verified, otherwise
+                it is expected to be a valid cube.
+
+        Returns:
+            A new data frame whose columns are values from *cube*
+            variables at given *points*.
         """
         return get_cube_values_for_points(
             self._dataset,
@@ -170,16 +180,23 @@ class DatasetAccessor:
         method: str = "nearest",
         cube_asserted: bool = False,
     ) -> xr.Dataset:
-        """
-        Get values from this cube at given *indexes*.
+        """Get values from this cube at given *indexes*.
 
-        :param indexes: A mapping from column names to index and fraction arrays for all cube dimensions.
-        :param var_names: An optional list of names of data variables in *cube* whose values shall be extracted.
-        :param index_name_pattern: A naming pattern for the computed indexes columns.
-               Must include "{name}" which will be replaced by the dimension name.
-        :param method: "nearest" or "linear".
-        :param cube_asserted: If False, *cube* will be verified, otherwise it is expected to be a valid cube.
-        :return: A new data frame whose columns are values from *cube* variables at given *indexes*.
+        Args:
+            indexes: A mapping from column names to index and fraction
+                arrays for all cube dimensions.
+            var_names: An optional list of names of data variables in
+                *cube* whose values shall be extracted.
+            index_name_pattern: A naming pattern for the computed
+                indexes columns. Must include "{name}" which will be
+                replaced by the dimension name.
+            method: "nearest" or "linear".
+            cube_asserted: If False, *cube* will be verified, otherwise
+                it is expected to be a valid cube.
+
+        Returns:
+            A new data frame whose columns are values from *cube*
+            variables at given *indexes*.
         """
         return get_cube_values_for_indexes(
             self._dataset,
@@ -198,19 +215,27 @@ class DatasetAccessor:
         index_dtype=np.float64,
         cube_asserted: bool = False,
     ):
-        """
-        Get indexes of given coordinates in *points* into this cube.
+        """Get indexes of given coordinates in *points* into this cube.
 
-        :param points: A mapping from column names to column data arrays, which must all have the same length.
-        :param dim_name_mapping: A mapping from dimension names in *cube* to column names in *points*.
-        :param index_name_pattern: A naming pattern for the computed indexes columns.
-               Must include "{name}" which will be replaced by the dimension name.
-        :param index_dtype: Numpy data type for the indexes. If it is a floating point type (default),
-               then *indexes* will contain fractions, which may be used for interpolation.
-               For out-of-range coordinates in *points*, indexes will be -1 if *index_dtype* is an integer type, and NaN,
-               if *index_dtype* is a floating point types.
-        :param cube_asserted: If False, *cube* will be verified, otherwise it is expected to be a valid cube.
-        :return: A dataset containing the index columns.
+        Args:
+            points: A mapping from column names to column data arrays,
+                which must all have the same length.
+            dim_name_mapping: A mapping from dimension names in *cube*
+                to column names in *points*.
+            index_name_pattern: A naming pattern for the computed
+                indexes columns. Must include "{name}" which will be
+                replaced by the dimension name.
+            index_dtype: Numpy data type for the indexes. If it is a
+                floating point type (default), then *indexes* will
+                contain fractions, which may be used for interpolation.
+                For out-of-range coordinates in *points*, indexes will
+                be -1 if *index_dtype* is an integer type, and NaN, if
+                *index_dtype* is a floating point types.
+            cube_asserted: If False, *cube* will be verified, otherwise
+                it is expected to be a valid cube.
+
+        Returns:
+            A dataset containing the index columns.
         """
         return get_cube_point_indexes(
             self._dataset,
@@ -227,8 +252,7 @@ class DatasetAccessor:
         coord_values: Union[xr.DataArray, np.ndarray],
         index_dtype=np.float64,
     ) -> Union[xr.DataArray, np.ndarray]:
-        """
-        Compute the indexes into a coordinate variable *coord_var_name* of this cube
+        """Compute the indexes into a coordinate variable *coord_var_name* of this cube
         for the given coordinate values *coord_values*.
 
         The coordinate variable's labels must be monotonic increasing or decreasing,
@@ -240,13 +264,19 @@ class DatasetAccessor:
 
         Returns the indexes as an array-like object of type *dtype*.
 
-        :param coord_var_name: Name of a coordinate variable.
-        :param coord_values: Array-like coordinate values.
-        :param index_dtype: Numpy data type for the indexes. If it is a floating point type (default),
-               then *indexes* will contain fractions, which may be used for interpolation.
-               For out-of-range coordinates in *points*, indexes will be -1 if *index_dtype* is an integer type, and NaN,
-               if *index_dtype* is a floating point types.
-        :return: The indexes and their fractions as a tuple of numpy int64 and float64 arrays.
+        Args:
+            coord_var_name: Name of a coordinate variable.
+            coord_values: Array-like coordinate values.
+            index_dtype: Numpy data type for the indexes. If it is a
+                floating point type (default), then *indexes* will
+                contain fractions, which may be used for interpolation.
+                For out-of-range coordinates in *points*, indexes will
+                be -1 if *index_dtype* is an integer type, and NaN, if
+                *index_dtype* is a floating point types.
+
+        Returns:
+            The indexes and their fractions as a tuple of numpy int64
+            and float64 arrays.
         """
         return get_dataset_indexes(
             self._dataset,
@@ -258,54 +288,63 @@ class DatasetAccessor:
     def chunk(
         self, chunk_sizes: Dict[str, int] = None, format_name: str = None
     ) -> xr.Dataset:
-        """
-        Chunk this dataset and update encodings for given format.
+        """Chunk this dataset and update encodings for given format.
 
-        :param chunk_sizes: mapping from dimension name to new chunk size
-        :param format_name: format, e.g. "zarr" or "netcdf4"
-        :return: the re-chunked dataset
+        Args:
+            chunk_sizes: mapping from dimension name to new chunk size
+            format_name: format, e.g. "zarr" or "netcdf4"
+
+        Returns:
+            the re-chunked dataset
         """
         return chunk_dataset(
             self._dataset, chunk_sizes=chunk_sizes, format_name=format_name
         )
 
     def vars_to_dim(self, dim_name: str = "newdim"):
-        """
-        Convert data variables into a dimension
+        """Convert data variables into a dimension
 
-        :param dim_name: The name of the new dimension ['vars']
-        :return: A new xcube dataset with the new dimension.
+        Args:
+            dim_name: The name of the new dimension ['vars']
+
+        Returns:
+            A new xcube dataset with the new dimension.
         """
         return vars_to_dim(self._dataset, dim_name)
 
     def dump(self, var_names=None, show_var_encoding=False) -> str:
-        """
-        Dump this dataset or its variables into a text string.
+        """Dump this dataset or its variables into a text string.
 
-        :param var_names: names of variables to be dumped
-        :param show_var_encoding: also dump variable encodings?
-        :return: the dataset dump
+        Args:
+            var_names: names of variables to be dumped
+            show_var_encoding: also dump variable encodings?
+
+        Returns:
+            the dataset dump
         """
         return dump_dataset(
             self._dataset, var_names=var_names, show_var_encoding=show_var_encoding
         )
 
     def verify(self) -> List[str]:
-        """
-        Verify that this dataset is a valid xcube dataset.
+        """Verify that this dataset is a valid xcube dataset.
 
         Returns a list of issues, which is empty if this dataset is a valid xcube dataset.
 
-        :return: List of issues or empty list.
+        Returns:
+            List of issues or empty list.
         """
         return verify_cube(self._dataset)
 
     def select_variables_subset(self, var_names: Sequence[str] = None):
-        """
-        Select data variable from given *dataset* and create new dataset.
+        """Select data variable from given *dataset* and create new dataset.
 
-        :param var_names: The names of data variables to select.
-        :return: A new dataset. It is empty, if *var_names* is empty. It is *dataset*, if *var_names* is None.
+        Args:
+            var_names: The names of data variables to select.
+
+        Returns:
+            A new dataset. It is empty, if *var_names* is empty. It is
+            *dataset*, if *var_names* is None.
         """
         return select_variables_subset(self._dataset, var_names)
 
@@ -315,21 +354,32 @@ class DatasetAccessor:
         " class xcube.core.mldataset.MultiLevelDataset",
     )
     def levels(self, **kwargs) -> List[xr.Dataset]:
-        """
-        Transform this dataset into the levels of a multi-level pyramid with spatial resolution
+        """Transform this dataset into the levels of a multi-level pyramid with spatial resolution
         decreasing by a factor of two in both spatial dimensions.
 
         It is assumed that the spatial dimensions of each variable are the inner-most, that is, the last two elements
         of a variable's shape provide the spatial dimension sizes.
 
-        :param spatial_dims: If given, only variables are considered whose last to dimension elements match the given *spatial_dims*.
-        :param spatial_shape: If given, only variables are considered whose last to shape elements match the given *spatial_shape*.
-        :param spatial_tile_shape: If given, chunking will match the provided *spatial_tile_shape*.
-        :param var_names: Variables to consider. If None, all variables with at least two dimensions are considered.
-        :param max_num_levels: If given, the maximum number of pyramid levels.
-        :param post_process_level: If given, the function will be called for each level and must return a dataset.
-        :param progress_monitor: If given, the function will be called for each level.
-        :return: A list of dataset instances representing the multi-level pyramid.
+        Args:
+            spatial_dims: If given, only variables are considered whose
+                last to dimension elements match the given
+                *spatial_dims*.
+            spatial_shape: If given, only variables are considered whose
+                last to shape elements match the given *spatial_shape*.
+            spatial_tile_shape: If given, chunking will match the
+                provided *spatial_tile_shape*.
+            var_names: Variables to consider. If None, all variables
+                with at least two dimensions are considered.
+            max_num_levels: If given, the maximum number of pyramid
+                levels.
+            post_process_level: If given, the function will be called
+                for each level and must return a dataset.
+            progress_monitor: If given, the function will be called for
+                each level.
+
+        Returns:
+            A list of dataset instances representing the multi-level
+            pyramid.
         """
         return compute_levels(self._dataset, **kwargs)
 

--- a/xcube/core/zarrstore/cached.py
+++ b/xcube/core/zarrstore/cached.py
@@ -38,10 +38,10 @@ class CachedZarrStore(zarr.storage.Store):
     Note that iterating keys and containment checks are performed
     on *store* only.
 
-    :param store: A Zarr store that is known
-        to be slow in reading values.
-    :param cache: A writable Zarr store that can
-        read values faster than *store*.
+    Args:
+        store: A Zarr store that is known to be slow in reading values.
+        cache: A writable Zarr store that can read values faster than
+            *store*.
     """
 
     _readable = True  # Because the base class is readable

--- a/xcube/core/zarrstore/diagnostic.py
+++ b/xcube/core/zarrstore/diagnostic.py
@@ -29,7 +29,8 @@ class DiagnosticZarrStore(zarr.storage.Store):
     """A diagnostic Zarr store used for testing and investigating
     behaviour of Zarr and xarray's Zarr backend.
 
-    :param store: Wrapped Zarr store.
+    Args:
+        store: Wrapped Zarr store.
     """
 
     def __init__(self, store: collections.abc.MutableMapping):

--- a/xcube/core/zarrstore/generic.py
+++ b/xcube/core/zarrstore/generic.py
@@ -42,8 +42,7 @@ OnClose = Callable[[Dict[str, Any]], None]
 
 
 class GenericArray(Dict[str, any]):
-    """
-    Represent a generic array in the ``GenericZarrStore`` as
+    """Represent a generic array in the ``GenericZarrStore`` as
     dictionary of properties.
 
     Although all properties of this class are optional,
@@ -90,41 +89,42 @@ class GenericArray(Dict[str, any]):
     Note that if the value of a named keyword argument is None,
     it will not be stored.
 
-    :param array: Optional array info dictionary
-    :param name: Optional array name
-    :param data: Optional array data.
-        Mutually exclusive with *get_data*.
-        Must be a bytes object or a numpy array.
-    :param get_data: Optional array data chunk getter.
-        Mutually exclusive with *data*.
-        Called for a requested data chunk of an array.
-        Must return a bytes object or a numpy array.
-    :param get_data_params: Optional keyword-arguments passed
-        to *get_data*.
-    :param dtype: Optional array data type.
-        Either a string using syntax of the Zarr spec or a ``numpy.dtype``.
-        For string encoded data types, see
-        https://zarr.readthedocs.io/en/stable/spec/v2.html#data-type-encoding
-    :param dims: Optional sequence of dimension names.
-    :param shape: Optional sequence of shape sizes for each dimension.
-    :param chunks: Optional sequence of chunk sizes for each dimension.
-    :param fill_value: Optional fill value, see
-        https://zarr.readthedocs.io/en/stable/spec/v2.html#fill-value-encoding
-    :param compressor: Optional compressor.
-        If given, it must be an instance of ``numcodecs.abc.Codec``.
-    :param filters: Optional sequence of filters, see
-        https://zarr.readthedocs.io/en/stable/spec/v2.html#filters.
-    :param order: Optional array endian ordering.
-        If given, must be "C" or "F". Defaults to "C".
-    :param attrs: Optional array attributes.
-        If given, must be JSON-serializable.
-    :param on_close: Optional array close handler.
-        Called if the store is closed.
-    :param chunk_encoding: Optional encoding type of the chunk
-        data returned for the array. Can be "bytes" (the default)
-        or "ndarray" for array chunks that are numpy.ndarray instances.
-    :param kwargs: Other keyword arguments passed directly to the
-        dictionary constructor.
+    Args:
+        array: Optional array info dictionary
+        name: Optional array name
+        data: Optional array data. Mutually exclusive with *get_data*.
+            Must be a bytes object or a numpy array.
+        get_data: Optional array data chunk getter. Mutually exclusive
+            with *data*. Called for a requested data chunk of an array.
+            Must return a bytes object or a numpy array.
+        get_data_params: Optional keyword-arguments passed to
+            *get_data*.
+        dtype: Optional array data type. Either a string using syntax of
+            the Zarr spec or a ``numpy.dtype``. For string encoded data
+            types, see
+            https://zarr.readthedocs.io/en/stable/spec/v2.html#data-
+            type-encoding
+        dims: Optional sequence of dimension names.
+        shape: Optional sequence of shape sizes for each dimension.
+        chunks: Optional sequence of chunk sizes for each dimension.
+        fill_value: Optional fill value, see
+            https://zarr.readthedocs.io/en/stable/spec/v2.html#fill-
+            value-encoding
+        compressor: Optional compressor. If given, it must be an
+            instance of ``numcodecs.abc.Codec``.
+        filters: Optional sequence of filters, see
+            https://zarr.readthedocs.io/en/stable/spec/v2.html#filters.
+        order: Optional array endian ordering. If given, must be "C" or
+            "F". Defaults to "C".
+        attrs: Optional array attributes. If given, must be JSON-
+            serializable.
+        on_close: Optional array close handler. Called if the store is
+            closed.
+        chunk_encoding: Optional encoding type of the chunk data
+            returned for the array. Can be "bytes" (the default) or
+            "ndarray" for array chunks that are numpy.ndarray instances.
+        kwargs: Other keyword arguments passed directly to the
+            dictionary constructor.
     """
 
     def __init__(

--- a/xcube/core/zarrstore/holder.py
+++ b/xcube/core/zarrstore/holder.py
@@ -54,8 +54,9 @@ class ZarrStoreHolder:
     so that the dataset and its Zarr store are no longer in sync.
     This may be an issue and limit the application of the new property.
 
-    :param dataset: The xarray dataset that is
-        associated with a Zarr store.
+    Args:
+        dataset: The xarray dataset that is associated with a Zarr
+            store.
     """
 
     def __init__(self, dataset: xr.Dataset):
@@ -69,7 +70,8 @@ class ZarrStoreHolder:
         ``GenericZarrStore.from_dataset()`` to create and set
         one.
 
-        :return: The Zarr store.
+        Returns:
+            The Zarr store.
         """
         if self._zarr_store is None:
             # Double-checked locking pattern
@@ -88,7 +90,9 @@ class ZarrStoreHolder:
 
     def set(self, zarr_store: collections.abc.MutableMapping) -> None:
         """Set the Zarr store of a dataset.
-        :param zarr_store: The Zarr store.
+
+        Args:
+            zarr_store: The Zarr store.
         """
         assert_instance(zarr_store, collections.abc.MutableMapping, name="zarr_store")
         with self._lock:

--- a/xcube/core/zarrstore/logging.py
+++ b/xcube/core/zarrstore/logging.py
@@ -32,8 +32,7 @@ from xcube.util.perf import measure_time_cm
 
 
 class LoggingZarrStore(zarr.storage.BaseStore):
-    """
-    A Zarr Store that logs all method calls on another store *other*
+    """A Zarr Store that logs all method calls on another store *other*
     including execution time.
     """
 

--- a/xcube/plugin.py
+++ b/xcube/plugin.py
@@ -35,9 +35,7 @@ from xcube.util import extension
 
 
 def init_plugin(ext_registry: extension.ExtensionRegistry):
-    """
-    Register xcube's standard extensions.
-    """
+    """Register xcube's standard extensions."""
     _register_input_processors(ext_registry)
     _register_dataset_ios(ext_registry)
     _register_cli_commands(ext_registry)
@@ -48,9 +46,7 @@ def init_plugin(ext_registry: extension.ExtensionRegistry):
 
 
 def _register_input_processors(ext_registry: extension.ExtensionRegistry):
-    """
-    Register xcube's standard input processors used by "xcube gen" and gen_cube().
-    """
+    """Register xcube's standard input processors used by "xcube gen" and gen_cube()."""
     ext_registry.add_extension(
         loader=extension.import_component("xcube.core.gen.iproc:DefaultInputProcessor"),
         point=EXTENSION_POINT_INPUT_PROCESSORS,
@@ -60,9 +56,7 @@ def _register_input_processors(ext_registry: extension.ExtensionRegistry):
 
 
 def _register_dataset_ios(ext_registry: extension.ExtensionRegistry):
-    """
-    Register xcube's standard dataset I/O components used by various CLI and API functions.
-    """
+    """Register xcube's standard dataset I/O components used by various CLI and API functions."""
     ext_registry.add_extension(
         loader=extension.import_component("xcube.core.dsio:ZarrDatasetIO", call=True),
         point=EXTENSION_POINT_DATASET_IOS,
@@ -132,9 +126,7 @@ _FS_DATA_WRITER_ITEMS = _FS_DATA_ACCESSOR_ITEMS
 
 
 def _register_data_stores(ext_registry: extension.ExtensionRegistry):
-    """
-    Register xcube's standard data stores.
-    """
+    """Register xcube's standard data stores."""
     fs_ds_cls_factory = "xcube.core.store.fs.registry:get_fs_data_store_class"
     for storage_id, storage_description in _FS_STORAGE_ITEMS:
         fs_ds_cls_loader = extension.import_component(
@@ -158,9 +150,7 @@ def _register_data_stores(ext_registry: extension.ExtensionRegistry):
 
 
 def _register_data_accessors(ext_registry: extension.ExtensionRegistry):
-    """
-    Register xcube's standard data accessors.
-    """
+    """Register xcube's standard data accessors."""
     factory = "xcube.core.store.fs.registry:get_fs_data_accessor_class"
 
     # noinspection PyShadowingNames
@@ -190,9 +180,7 @@ def _register_data_accessors(ext_registry: extension.ExtensionRegistry):
 
 
 def _register_cli_commands(ext_registry: extension.ExtensionRegistry):
-    """
-    Register xcube's standard CLI commands.
-    """
+    """Register xcube's standard CLI commands."""
 
     cli_command_names = [
         "chunk",
@@ -229,9 +217,7 @@ def _register_cli_commands(ext_registry: extension.ExtensionRegistry):
 
 
 def _register_server_apis(ext_registry: extension.ExtensionRegistry):
-    """
-    Register xcube's standard server APIs.
-    """
+    """Register xcube's standard server APIs."""
     server_api_names = [
         "meta",
         "auth",

--- a/xcube/server/api.py
+++ b/xcube/server/api.py
@@ -71,8 +71,7 @@ builtin_type = type
 
 
 class Api(Generic[ServerContextT]):
-    """
-    A server API.
+    """A server API.
 
     The most common purpose of this class is to
     add a new API to the server by the means of routes.
@@ -119,27 +118,28 @@ class Api(Generic[ServerContextT]):
             return self.ctx.get_datasets()
     ```
 
-    :param name: The API name. Must be unique within a server.
-    :param version: The API version. Defaults to "0.0.0".
-    :param routes: Optional list of initial routes.
-        A route is a tuple of the form (route-pattern, handler-class) or
-        (route-pattern, handler-class, handler-kwargs). The handler-class
-        must be derived from ApiHandler.
-    :param required_apis: Sequence of names of other required APIs.
-    :param optional_apis: Sequence of names of other optional APIs.
-    :param config_schema: Optional JSON schema for the API's configuration.
-        If not given, or None is passed, the API is assumed to
-        have no configuration.
-    :param create_ctx: Optional API context factory.
-        If given, must be a callable that accepts the server context
-        and returns a ``Context`` instance for the API.
-        Called when a new context is required after configuration changes.
-    :param on_start: Optional start handler.
-        If given, must be a callable that accepts the server context.
-        Called when the server starts.
-    :param on_stop: Optional stop handler.
-        If given, must be a callable that accepts the server context.
-        Called when the server stopped.
+    Args:
+        name: The API name. Must be unique within a server.
+        version: The API version. Defaults to "0.0.0".
+        routes: Optional list of initial routes. A route is a tuple of
+            the form (route-pattern, handler-class) or (route-pattern,
+            handler-class, handler-kwargs). The handler-class must be
+            derived from ApiHandler.
+        required_apis: Sequence of names of other required APIs.
+        optional_apis: Sequence of names of other optional APIs.
+        config_schema: Optional JSON schema for the API's configuration.
+            If not given, or None is passed, the API is assumed to have
+            no configuration.
+        create_ctx: Optional API context factory. If given, must be a
+            callable that accepts the server context and returns a
+            ``Context`` instance for the API. Called when a new context
+            is required after configuration changes.
+        on_start: Optional start handler. If given, must be a callable
+            that accepts the server context. Called when the server
+            starts.
+        on_stop: Optional stop handler. If given, must be a callable
+            that accepts the server context. Called when the server
+            stopped.
     """
 
     def __init__(
@@ -209,17 +209,17 @@ class Api(Generic[ServerContextT]):
     def static_route(
         self, path: str, default_filename: Optional[str] = None, **openapi_metadata
     ):
-        """
-        Decorator that adds static route to this API.
+        """Decorator that adds static route to this API.
 
         The decorator target must be a function that returns the route's
         local root directory path either as a string or a ``pathlib.Path``.
         If it can not determine an existing path, it should return None.
 
-        :param path: The route path.
-        :param default_filename: Optional default filename,
-            e.g., "index.html".
-        :param openapi_metadata: Optional OpenAPI GET operation metadata.
+        Args:
+            path: The route path.
+            default_filename: Optional default filename, e.g.,
+                "index.html".
+            **openapi_metadata: Optional OpenAPI GET operation metadata.
         """
 
         def decorator_func(get_root_path: Callable[[], Optional[str]]):
@@ -238,16 +238,18 @@ class Api(Generic[ServerContextT]):
         return decorator_func
 
     def route(self, path: str, **handler_kwargs):
-        """
-        Decorator that adds a route to this API.
+        """Decorator that adds a route to this API.
 
         The decorator target must be a class derived from ApiHandler.
 
-        :param path: The route path.
-        :param handler_kwargs: Optional keyword arguments passed to
-            ApiHandler constructor.
-        :return: A decorator function that receives a
-            class derived from ApiHandler
+        Args:
+            path: The route path.
+            **handler_kwargs: Optional keyword arguments passed to
+                ApiHandler constructor.
+
+        Returns:
+            A decorator function that receives a class derived from
+            ApiHandler
         """
 
         def decorator_func(handler_cls: Type[ApiHandler]):
@@ -267,25 +269,26 @@ class Api(Generic[ServerContextT]):
         tags: Optional[str] = None,
         **kwargs,
     ):
-        """
-        Decorator that adds OpenAPI 3.0 information to an
+        """Decorator that adds OpenAPI 3.0 information to an
         API handler's operation,
         i.e. one of the get, post, put, delete, or options methods.
 
-        :param operation_id: a string identifier for the operation
-        :param summary: a summary of the operation
-        :param description: A description of the operation. CommonMark syntax
-                            may be used.
-        :param parameters: List of dictionaries, one per parameter, defining
-                           OpenAPI Parameter objects
-        :param request_body: A dictionary defining an OpenAPI Request Body
-                             object
-        :param responses: A dictionary defining an OpenAPI Responses object
-        :param tags: OpenAPI tags
-        :param kwargs: OpenAPI parameters
+        Args:
+            operation_id: a string identifier for the operation
+            summary: a summary of the operation
+            description: A description of the operation. CommonMark
+                syntax may be used.
+            parameters: List of dictionaries, one per parameter,
+                defining OpenAPI Parameter objects
+            request_body: A dictionary defining an OpenAPI Request Body
+                object
+            responses: A dictionary defining an OpenAPI Responses object
+            tags: OpenAPI tags
+            **kwargs: OpenAPI parameters
 
-        :return: A decorator function that receives and returns an
-                 ApiHandler's operation.
+        Returns:
+            A decorator function that receives and returns an
+            ApiHandler's operation.
         """
         openapi = {
             "operationId": operation_id or kwargs.pop("operationId", None),
@@ -341,8 +344,11 @@ class Api(Generic[ServerContextT]):
         Otherwise, a new instance of ``ApiContext`` is returned.
         Should not be called directly.
 
-        :param server_ctx: The server's current context.
-        :return: An instance of ``Context``
+        Args:
+            server_ctx: The server's current context.
+
+        Returns:
+            An instance of ``Context``
         """
         return self._create_ctx(server_ctx)
 
@@ -354,7 +360,8 @@ class Api(Generic[ServerContextT]):
         The default implementation calls the *on_start*
         argument passed to the constructor, if any.
 
-        :param server_ctx: The server's current context
+        Args:
+            server_ctx: The server's current context
         """
         return self._on_start(server_ctx)
 
@@ -366,7 +373,8 @@ class Api(Generic[ServerContextT]):
         The default implementation calls the *on_stop*
         argument passed to the constructor, if any.
 
-        :param server_ctx: The server's current context
+        Args:
+            server_ctx: The server's current context
         """
         return self._on_stop(server_ctx)
 
@@ -376,7 +384,8 @@ class Api(Generic[ServerContextT]):
         Returns a list of dictionaries of the form
         {'path': '/some/path', 'methods': ['get', 'post']}
 
-        :return: a list of dictionaries, each describing an endpoint
+        Returns:
+            a list of dictionaries, each describing an endpoint
         """
         return [route.path_and_methods() for route in self.routes]
 
@@ -408,18 +417,20 @@ class Context(AsyncExecution, ABC):
     def get_api_ctx(
         self, api_name: str, cls: Optional[Type[ApiContextT]] = None
     ) -> Optional[ApiContextT]:
-        """
-        Get the API context for *api_name*.
+        """Get the API context for *api_name*.
         Can be used to access context objects of other APIs.
 
         The keyword argument *cls* can be used to assert a specific
         type if of context.
 
-        :param api_name: The name of a registered API.
-        :param cls: Optional context class.
-            If given, must be a class derived from `ApiContext`.
-        :return: The API context object for *api_name*,
-            or None if no such exists.
+        Args:
+            api_name: The name of a registered API.
+            cls: Optional context class. If given, must be a class
+                derived from `ApiContext`.
+
+        Returns:
+            The API context object for *api_name*, or None if no such
+            exists.
         """
 
     @abstractmethod
@@ -430,9 +441,10 @@ class Context(AsyncExecution, ABC):
         ``self.config`` and the given *prev_context*, if any.
         The method shall not be called directly.
 
-        :param prev_context: The previous context instance.
-            Will be ``None`` if ``on_update()`` is called for the
-            very first time.
+        Args:
+            prev_context: The previous context instance. Will be
+                ``None`` if ``on_update()`` is called for the very first
+                time.
         """
 
     @abstractmethod
@@ -446,8 +458,7 @@ class Context(AsyncExecution, ABC):
 
 
 class ApiContext(Context):
-    """
-    An implementation of the server context to be used by APIs.
+    """An implementation of the server context to be used by APIs.
 
     A typical use case is to cache computationally expensive
     resources served by a particular API.
@@ -466,7 +477,8 @@ class ApiContext(Context):
     * must call the super class constructor with the
       *server_ctx* context, from their own constructor, if any.
 
-    :param server_ctx: The server context.
+    Args:
+        server_ctx: The server context.
     """
 
     def __init__(self, server_ctx: Context):
@@ -533,10 +545,13 @@ class ApiRequest:
         ``reverse_url_prefix`` shall be used for prefixing
         the returned URL.
 
-        :param path: The path component.
-        :param query: Optional query string.
-        :param reverse: Whether the reverse URL shall be returned.
-        :return: Full reverse URL for *path* and *query*.
+        Args:
+            path: The path component.
+            query: Optional query string.
+            reverse: Whether the reverse URL shall be returned.
+
+        Returns:
+            Full reverse URL for *path* and *query*.
         """
 
     @property
@@ -592,11 +607,14 @@ class ApiRequest:
         argument. If *type* is not given, but *default* is, then *type*
         will be inferred from *default*.
 
-        :param name: The name of the argument
-        :param type: The requested data type.
-            Must be a callable type, e.g. bool, int.
-        :param default: Optional default value.
-        :return: The value of the query argument.
+        Args:
+            name: The name of the argument
+            type: The requested data type. Must be a callable type, e.g.
+                bool, int.
+            default: Optional default value.
+
+        Returns:
+            The value of the query argument.
         """
         if type is None and default is not None:
             type = builtin_type(default)
@@ -611,10 +629,14 @@ class ApiRequest:
     ) -> Sequence[ArgT]:
         """Get the values of query argument given by *name*.
         If *type* is given, a sequence of that type will be returned.
-        :param name: The name of the argument
-        :param type: The requested data type.
-            Must be a callable type, e.g. bool, int.
-        :return: The values of the query argument.
+
+        Args:
+            name: The name of the argument
+            type: The requested data type. Must be a callable type, e.g.
+                bool, int.
+
+        Returns:
+            The values of the query argument.
         """
 
 
@@ -639,13 +661,13 @@ class ApiResponse(ABC):
 
 
 class ApiHandler(Generic[ServerContextT], ABC):
-    """
-    Base class for all API handlers.
+    """Base class for all API handlers.
 
-    :param ctx: The API context.
-    :param request: The API handler's request.
-    :param response: The API handler's response.
-    :param kwargs: Client keyword arguments (not used in base class).
+    Args:
+        ctx: The API context.
+        request: The API handler's request.
+        response: The API handler's response.
+        kwargs: Client keyword arguments (not used in base class).
     """
 
     def __init__(
@@ -684,7 +706,8 @@ class ApiHandler(Generic[ServerContextT], ABC):
         Any method with an __openapi__ attribute is assumed to be
         handled.
 
-        :return: a list of the method names handled by this handler
+        Returns:
+            a list of the method names handled by this handler
         """
         return [
             name
@@ -722,15 +745,15 @@ class ApiHandler(Generic[ServerContextT], ABC):
 
 
 class ApiRoute:
-    """
-    An API route.
+    """An API route.
 
-    :param api_name: The name of the API to which this route belongs to.
-    :param path: The route path which may include path variable templates.
-    :param handler_cls: The route handler class.
-        Must be derived from ```ApiHandler```.
-    :param handler_kwargs: Optional keyword arguments passed to
-        the *handler_cls* when it is instantiated.
+    Args:
+        api_name: The name of the API to which this route belongs to.
+        path: The route path which may include path variable templates.
+        handler_cls: The route handler class. Must be derived from
+            ```ApiHandler```.
+        handler_kwargs: Optional keyword arguments passed to the
+            *handler_cls* when it is instantiated.
     """
 
     def __init__(
@@ -791,20 +814,22 @@ class ApiRoute:
         Returns a dictionary of the form
         {'path': '/this/routes/path', 'methods': ['get', 'post']}
 
-        :return: a dictionary describing this route
+        Returns:
+            a dictionary describing this route
         """
         return {"path": self.path, "methods": self.handler_cls.defined_methods()}
 
 
 class ApiStaticRoute:
-    """
-    An API static route.
+    """An API static route.
 
-    :param path: The route path.
-    :param dir_path: A local directory path.
-    :param default_filename: Optional default filename, e.g., "index.html".
-    :param api_name: Optional name of the API to which this route belongs to.
-    :param openapi_metadata: Optional OpenAPI operation metadata.
+    Args:
+        path: The route path.
+        dir_path: A local directory path.
+        default_filename: Optional default filename, e.g., "index.html".
+        api_name: Optional name of the API to which this route belongs
+            to.
+        openapi_metadata: Optional OpenAPI operation metadata.
     """
 
     def __init__(
@@ -831,13 +856,13 @@ class ApiStaticRoute:
 
 
 class ApiError(Exception):
-    """
-    An API error.
+    """An API error.
     This exception should be raised to terminate the current request
     with a defined HTTP status code.
 
-    :param status_code: The HTTP status code
-    :param message: Optional message
+    Args:
+        status_code: The HTTP status code
+        message: Optional message
     """
 
     def __init__(self, status_code: int, message: Optional[str] = None):

--- a/xcube/server/config.py
+++ b/xcube/server/config.py
@@ -177,8 +177,11 @@ def get_url_prefix(config: Mapping[str, Any]) -> str:
     """Get the sanitized URL prefix so, if given, it starts with
     a leading slash and ends without one.
 
-    :param config: Server configuration.
-    :return: Sanitized URL prefix, may be an empty string.
+    Args:
+        config: Server configuration.
+
+    Returns:
+        Sanitized URL prefix, may be an empty string.
     """
     return _sanitize_url_prefix(config.get("url_prefix"))
 
@@ -187,8 +190,11 @@ def get_reverse_url_prefix(config: Mapping[str, Any]) -> str:
     """Get the sanitized reverse URL prefix so, if given, it starts with
     a leading slash and ends without one.
 
-    :param config: Server configuration.
-    :return: Sanitized URL prefix, may be an empty string.
+    Args:
+        config: Server configuration.
+
+    Returns:
+        Sanitized URL prefix, may be an empty string.
     """
     return _sanitize_url_prefix(
         config.get("reverse_url_prefix", config.get("url_prefix"))
@@ -199,8 +205,11 @@ def _sanitize_url_prefix(url_prefix: Optional[str]) -> str:
     """Get a sanitized URL prefix so, if given, it starts with
     a leading slash and ends without one.
 
-    :param url_prefix: URL prefix path.
-    :return: Sanitized URL prefix path, may be an empty string.
+    Args:
+        url_prefix: URL prefix path.
+
+    Returns:
+        Sanitized URL prefix path, may be an empty string.
     """
     if not url_prefix:
         return ""

--- a/xcube/server/framework.py
+++ b/xcube/server/framework.py
@@ -32,59 +32,60 @@ from .asyncexec import AsyncExecution
 
 
 class Framework(AsyncExecution, abc.ABC):
-    """
-    An abstract web server framework.
-    """
+    """An abstract web server framework."""
 
     @property
     @abc.abstractmethod
     def config_schema(self) -> Optional[JsonObjectSchema]:
         """Returns an optional JSON Schema for
         the web server configuration. Returning None
-        indicates that configuration is not possible."""
+        indicates that configuration is not possible.
+        """
 
     @abc.abstractmethod
     def add_static_routes(self, routes: Sequence[ApiStaticRoute], url_prefix: str):
-        """
-        Adds the given static routes to this web server.
+        """Adds the given static routes to this web server.
 
-        :param routes: The static routes to be added.
-        :param url_prefix: URL prefix, may be an empty string.
+        Args:
+            routes: The static routes to be added.
+            url_prefix: URL prefix, may be an empty string.
         """
 
     @abc.abstractmethod
     def add_routes(self, routes: Sequence[ApiRoute], url_prefix: str):
-        """
-        Adds the given routes to this web server.
+        """Adds the given routes to this web server.
 
-        :param routes: The routes to be added.
-        :param url_prefix: URL prefix, may be an empty string.
+        Args:
+            routes: The routes to be added.
+            url_prefix: URL prefix, may be an empty string.
         """
 
     @abc.abstractmethod
     def update(self, ctx: Context):
-        """
-        Called, when the server context has changed.
+        """Called, when the server context has changed.
 
         This is the case immediately after instantiation and before
         start() is called. It may then be called on any context change,
         likely due to a configuration change.
 
-        :param ctx: The current server context.
+        Args:
+            ctx: The current server context.
         """
 
     @abc.abstractmethod
     def start(self, ctx: Context):
-        """
-        Starts the web service.
-        :param ctx: The initial server context.
+        """Starts the web service.
+
+        Args:
+            ctx: The initial server context.
         """
 
     @abc.abstractmethod
     def stop(self, ctx: Context):
-        """
-        Stops the web service.
-        :param ctx: The current server context.
+        """Stops the web service.
+
+        Args:
+            ctx: The current server context.
         """
 
 

--- a/xcube/server/helpers.py
+++ b/xcube/server/helpers.py
@@ -27,11 +27,12 @@ from xcube.util.config import load_configs
 
 
 class ConfigChangeObserver:
-    """
-    An observer for configuration changes.
-    :param server: The server
-    :param config_paths: Configuration file paths.
-    :param check_after: Time in seconds between two observations.
+    """An observer for configuration changes.
+
+    Args:
+        server: The server
+        config_paths: Configuration file paths.
+        check_after: Time in seconds between two observations.
     """
 
     def __init__(self, server: Server, config_paths: Sequence[str], check_after: float):

--- a/xcube/server/server.py
+++ b/xcube/server/server.py
@@ -63,8 +63,7 @@ from ..util.frozen import FrozenDict
 
 
 class Server(AsyncExecution):
-    """
-    A REST server extendable by API extensions.
+    """A REST server extendable by API extensions.
 
     APIs are registered using the extension point
     "xcube.server.api".
@@ -86,10 +85,11 @@ class Server(AsyncExecution):
       * Use any given request JSON schema in openAPI
         to validate requests in HTTP methods
 
-    :param framework: The web server framework to be used
-    :param config: The server configuration.
-    :param extension_registry: Optional extension registry.
-        Defaults to xcube's default extension registry.
+    Args:
+        framework: The web server framework to be used
+        config: The server configuration.
+        extension_registry: Optional extension registry. Defaults to
+            xcube's default extension registry.
     """
 
     def __init__(
@@ -177,13 +177,13 @@ class Server(AsyncExecution):
         self._set_ctx(ctx)
 
     def call_later(self, delay: Union[int, float], callback: Callable, *args, **kwargs):
-        """
-        Executes the given callable *callback* after *delay* seconds.
+        """Executes the given callable *callback* after *delay* seconds.
 
-        :param delay: Delay in seconds.
-        :param callback: Callback to be called.
-        :param args: Positional arguments passed to *callback*.
-        :param kwargs: Keyword arguments passed to *callback*.
+        Args:
+            delay: Delay in seconds.
+            callback: Callback to be called.
+            *args: Positional arguments passed to *callback*.
+            **kwargs: Keyword arguments passed to *callback*.
         """
         return self._framework.call_later(delay, callback, *args, **kwargs)
 
@@ -194,16 +194,18 @@ class Server(AsyncExecution):
         *args: Any,
         **kwargs: Any,
     ) -> Awaitable[ReturnT]:
-        """
-        Concurrently runs a *function* in a ``concurrent.futures.Executor``.
+        """Concurrently runs a *function* in a ``concurrent.futures.Executor``.
         If *executor* is ``None``, the framework's default
         executor will be used.
 
-        :param executor: An optional executor.
-        :param function: The function to be run concurrently.
-        :param args: Positional arguments passed to *function*.
-        :param kwargs: Keyword arguments passed to *function*.
-        :return: The awaitable return value of *function*.
+        Args:
+            executor: An optional executor.
+            function: The function to be run concurrently.
+            *args: Positional arguments passed to *function*.
+            **kwargs: Keyword arguments passed to *function*.
+
+        Returns:
+            The awaitable return value of *function*.
         """
         return self._framework.run_in_executor(executor, function, *args, **kwargs)
 
@@ -447,8 +449,7 @@ class Server(AsyncExecution):
 
 
 class ServerContext(Context):
-    """
-    The server context holds the current server configuration and
+    """The server context holds the current server configuration and
     the API context objects that depend on that specific configuration.
 
     A new server context is created for any new server configuration,
@@ -456,8 +457,9 @@ class ServerContext(Context):
 
     The constructor shall not be called directly.
 
-    :param server: The server.
-    :param config: The current server configuration.
+    Args:
+        server: The server.
+        config: The current server configuration.
     """
 
     def __init__(self, server: Server, config: collections.abc.Mapping):

--- a/xcube/server/testing.py
+++ b/xcube/server/testing.py
@@ -100,11 +100,14 @@ class ServerTestCase(unittest.TestCase, ABC):
     ) -> urllib3.response.HTTPResponse:
         """Fetches the response for given request.
 
-        :param path: Route request path
-        :param method: HTTP request method, default to "GET"
-        :param headers: HTTP request headers
-        :param body: HTTP request body
-        :return: A response object
+        Args:
+            path: Route request path
+            method: HTTP request method, default to "GET"
+            headers: HTTP request headers
+            body: HTTP request body
+
+        Returns:
+            A response object
         """
         if path.startswith("/"):
             path = path[1:]
@@ -122,11 +125,14 @@ class ServerTestCase(unittest.TestCase, ABC):
     ) -> Tuple[Union[type(None), bool, int, float, str, list, dict], int]:
         """Fetches the response's JSON value for given request.
 
-        :param path: Route request path
-        :param method: HTTP request method, default to "GET"
-        :param headers: HTTP request headers
-        :param body: HTTP request body
-        :return: A json object parsed from response data
+        Args:
+            path: Route request path
+            method: HTTP request method, default to "GET"
+            headers: HTTP request headers
+            body: HTTP request body
+
+        Returns:
+            A json object parsed from response data
         """
         response = self.fetch(path, method=method, headers=headers, body=body)
         return json.loads(response.data), response.status
@@ -134,7 +140,8 @@ class ServerTestCase(unittest.TestCase, ABC):
     def assertResponseOK(self, response: urllib3.response.HTTPResponse):
         """Assert that response has status code 200.
 
-        :param response: The response from a ``self.fetch()`` call
+        Args:
+            response: The response from a ``self.fetch()`` call
         """
         self.assertResponse(response, expected_status=200)
 
@@ -145,8 +152,9 @@ class ServerTestCase(unittest.TestCase, ABC):
         has the given status code 404, and
         has the given error message *expected_message*, if given.
 
-        :param response: The response from a ``self.fetch()`` call
-        :param expected_message: The expected error message or part of it.
+        Args:
+            response: The response from a ``self.fetch()`` call
+            expected_message: The expected error message or part of it.
         """
         self.assertResponse(
             response, expected_status=404, expected_message=expected_message
@@ -159,8 +167,9 @@ class ServerTestCase(unittest.TestCase, ABC):
         has the given status code 400, and
         has the given error message *expected_message*, if given.
 
-        :param response: The response from a ``self.fetch()`` call
-        :param expected_message: The expected error message or part of it.
+        Args:
+            response: The response from a ``self.fetch()`` call
+            expected_message: The expected error message or part of it.
         """
         self.assertResponse(
             response, expected_status=400, expected_message=expected_message
@@ -176,9 +185,10 @@ class ServerTestCase(unittest.TestCase, ABC):
         has the given status code *expected_status*, if given, and
         has the given error message *expected_message*, if given.
 
-        :param response: The response from a ``self.fetch()`` call
-        :param expected_status: The expected status code.
-        :param expected_message: The expected error message or part of it.
+        Args:
+            response: The response from a ``self.fetch()`` call
+            expected_status: The expected status code.
+            expected_message: The expected error message or part of it.
         """
         message = self.parse_error_message(response)
         if expected_status is not None:

--- a/xcube/server/webservers/flask.py
+++ b/xcube/server/webservers/flask.py
@@ -31,8 +31,7 @@ from xcube.util.jsonschema import JsonObjectSchema
 
 
 class FlaskFramework(Framework):
-    """
-    The Flask web server framework.
+    """The Flask web server framework.
 
     TODO: implement me!
     """

--- a/xcube/util/assertions.py
+++ b/xcube/util/assertions.py
@@ -43,13 +43,13 @@ def assert_not_none(
 def assert_given(
     value: Any, name: str = None, exception_type: Type[Exception] = ValueError
 ):
-    """
-    Assert *value* is not False when converted into a Boolean value.
+    """Assert *value* is not False when converted into a Boolean value.
     Otherwise, raise *exception_type*.
 
-    :param value: The value to test.
-    :param name: Name of a variable that holds *value*.
-    :param exception_type: The exception type. Default is ```ValueError```.
+    Args:
+        value: The value to test.
+        name: Name of a variable that holds *value*.
+        exception_type: The exception type. Default is ```ValueError```.
     """
     if not value:
         raise exception_type(f"{name or _DEFAULT_NAME} must be given")
@@ -61,14 +61,14 @@ def assert_instance(
     name: str = None,
     exception_type: Type[Exception] = TypeError,
 ):
-    """
-    Assert *value* is an instance of data type *dtype*.
+    """Assert *value* is an instance of data type *dtype*.
     Otherwise, raise *exception_type*.
 
-    :param value: The value to test.
-    :param dtype: A type or tuple of types.
-    :param name: Name of a variable that holds *value*.
-    :param exception_type: The exception type. Default is ```TypeError```.
+    Args:
+        value: The value to test.
+        dtype: A type or tuple of types.
+        name: Name of a variable that holds *value*.
+        exception_type: The exception type. Default is ```TypeError```.
     """
     if not isinstance(value, dtype):
         raise exception_type(
@@ -84,14 +84,14 @@ def assert_subclass(
     name: str = None,
     exception_type: Type[Exception] = TypeError,
 ):
-    """
-    Assert *value* is a subclass of class *cls*.
+    """Assert *value* is a subclass of class *cls*.
     Otherwise, raise *exception_type*.
 
-    :param value: The value to test.
-    :param cls: A class or tuple of classes.
-    :param name: Name of a variable that holds *value*.
-    :param exception_type: The exception type. Default is ```TypeError```.
+    Args:
+        value: The value to test.
+        cls: A class or tuple of classes.
+        name: Name of a variable that holds *value*.
+        exception_type: The exception type. Default is ```TypeError```.
     """
     if not issubclass(value, cls):
         raise exception_type(
@@ -105,27 +105,27 @@ def assert_in(
     name: str = None,
     exception_type: Type[Exception] = ValueError,
 ):
-    """
-    Assert *value* is a member of *container*.
+    """Assert *value* is a member of *container*.
     Otherwise, raise *exception_type*.
 
-    :param value: The value to test for membership.
-    :param container: The container.
-    :param name: Name of a variable that holds *value*.
-    :param exception_type: The exception type. Default is ```ValueError```.
+    Args:
+        value: The value to test for membership.
+        container: The container.
+        name: Name of a variable that holds *value*.
+        exception_type: The exception type. Default is ```ValueError```.
     """
     if value not in container:
         raise exception_type(f"{name or _DEFAULT_NAME} " f"must be one of {container}")
 
 
 def assert_true(value: Any, message: str, exception_type: Type[Exception] = ValueError):
-    """
-    Assert *value* is true after conversion into a Boolean value.
+    """Assert *value* is true after conversion into a Boolean value.
     Otherwise, raise *exception_type*.
 
-    :param value: The value to test.
-    :param message: The error message used if the assertion fails.
-    :param exception_type: The exception type. Default is ```ValueError```.
+    Args:
+        value: The value to test.
+        message: The error message used if the assertion fails.
+        exception_type: The exception type. Default is ```ValueError```.
     """
     if not value:
         raise exception_type(message)
@@ -134,13 +134,13 @@ def assert_true(value: Any, message: str, exception_type: Type[Exception] = Valu
 def assert_false(
     value: Any, message: str, exception_type: Type[Exception] = ValueError
 ):
-    """
-    Assert *value* is false after conversion into a Boolean value.
+    """Assert *value* is false after conversion into a Boolean value.
     Otherwise, raise *exception_type*.
 
-    :param value: The value to test.
-    :param message: The error message used if the assertion fails.
-    :param exception_type: The exception type. Default is ```ValueError```.
+    Args:
+        value: The value to test.
+        message: The error message used if the assertion fails.
+        exception_type: The exception type. Default is ```ValueError```.
     """
     if value:
         raise exception_type(message)

--- a/xcube/util/cache.py
+++ b/xcube/util/cache.py
@@ -90,9 +90,7 @@ class CacheStore(metaclass=ABCMeta):
 
 
 class MemoryCacheStore(CacheStore):
-    """
-    Simple memory store.
-    """
+    """Simple memory store."""
 
     def can_load_from_key(self, key) -> bool:
         # This store type does not maintain key-value pairs on its own
@@ -102,29 +100,36 @@ class MemoryCacheStore(CacheStore):
         raise NotImplementedError()
 
     def store_value(self, key, value):
-        """
-        Return (value, 1).
-        :param key: the key
-        :param value: the original value
-        :return: the tuple (stored value, size) where stored value is the sequence [key, value].
+        """Return (value, 1).
+
+        Args:
+            key: the key
+            value: the original value
+
+        Returns:
+            the tuple (stored value, size) where stored value is the
+            sequence [key, value].
         """
         return [key, value], _compute_object_size(value)
 
     def restore_value(self, key, stored_value):
-        """
-        :param key: the key
-        :param stored_value: the stored representation of the value
-        :return: the original value.
+        """Args:
+            key: the key
+            stored_value: the stored representation of the value
+
+        Returns:
+            the original value.
         """
         if key != stored_value[0]:
             raise ValueError("key does not match stored value")
         return stored_value[1]
 
     def discard_value(self, key, stored_value):
-        """
-        Clears the value in the given stored_value.
-        :param key: the key
-        :param stored_value: the stored representation of the value
+        """Clears the value in the given stored_value.
+
+        Args:
+            key: the key
+            stored_value: the stored representation of the value
         """
         if key != stored_value[0]:
             raise ValueError("key does not match stored value")
@@ -132,9 +137,7 @@ class MemoryCacheStore(CacheStore):
 
 
 class FileCacheStore(CacheStore):
-    """
-    Simple file store for values which can be written and read as bytes, e.g. encoded PNG images.
-    """
+    """Simple file store for values which can be written and read as bytes, e.g. encoded PNG images."""
 
     def __init__(self, cache_dir: str, ext: str):
         self.cache_dir = cache_dir

--- a/xcube/util/cmaps.py
+++ b/xcube/util/cmaps.py
@@ -309,12 +309,15 @@ class ColormapProvider(ABC):
         * have alpha blending (*cm_name* with suffix `"_alpha"`),
         * both (*cm_name* with suffix `"_r_alpha"`).
 
-        :param cm_name: Colormap name.
-        :param num_colors: Optional number of colors, that is,
-            the resolution of the colormap gradient.
-        :return: A tuple comprising the base name
-            of *cm_name* after striping any suffixes, and
-            the colormap as an instance of ``matplotlib.colors.Colormap``.
+        Args:
+            cm_name: Colormap name.
+            num_colors: Optional number of colors, that is, the
+                resolution of the colormap gradient.
+
+        Returns:
+            A tuple comprising the base name of *cm_name* after striping
+            any suffixes, and the colormap as an instance of
+            ``matplotlib.colors.Colormap``.
         """
 
 
@@ -631,13 +634,14 @@ _REGISTRY_JSON = None
     version="0.13.0",
 )
 def get_cmaps() -> List:
-    """
-    Return a JSON-serializable tuple containing records of the form:
+    """Return a JSON-serializable tuple containing records of the form:
      (<cmap-category>, <cmap-category-description>, <cmap-tuples>),
     where <cmap-tuples> is a tuple containing records of the form
     (<cmap-name>, <cbar-png-bytes>), and where
     <cbar-png-bytes> are encoded PNG images of size 256 x 2 pixels,
-    :return: all known matplotlib color maps
+
+    Returns:
+        all known matplotlib color maps
     """
     registry = _get_registry()
     global _REGISTRY_JSON
@@ -655,8 +659,7 @@ def get_cmaps() -> List:
 def get_cmap(
     cmap_name: str, default_cmap_name: str = "viridis", num_colors: Optional[int] = None
 ) -> Tuple[str, matplotlib.colors.Colormap]:
-    """
-    Get color mapping for color bar name *cmap_name*.
+    """Get color mapping for color bar name *cmap_name*.
 
     If *num_colors* is a positive integer,
     a resampled mapping will be returned that contains *num_colors*
@@ -667,10 +670,13 @@ def get_cmap(
 
     Otherwise, a tuple (actual_cmap_name, cmap) is returned.
 
-    :param cmap_name: Color bar name.
-    :param num_colors: Number of colours in returned color mapping.
-    :param default_cmap_name: Default color bar name. (Ignored)
-    :return: A tuple (actual_cmap_name, cmap).
+    Args:
+        cmap_name: Color bar name.
+        num_colors: Number of colours in returned color mapping.
+        default_cmap_name: Default color bar name. (Ignored)
+
+    Returns:
+        A tuple (actual_cmap_name, cmap).
     """
     registry = _get_registry()
     return registry.get_cmap(cmap_name, num_colors=num_colors)
@@ -682,8 +688,7 @@ def get_cmap(
     version="0.13.0",
 )
 def ensure_cmaps_loaded():
-    """
-    Loads all color maps from matplotlib and registers additional ones,
+    """Loads all color maps from matplotlib and registers additional ones,
     if not done before.
     """
     _get_registry()

--- a/xcube/util/dask.py
+++ b/xcube/util/dask.py
@@ -188,17 +188,19 @@ def new_cluster(
     given to ``new_cluster``, it will override the value from the environment
     variable.
 
-    :param provider: identifier of the provider to use. Currently, only
-        'coiled' is supported.
-    :param name: name to use as an identifier for the cluster
-    :param software: identifier for the software environment to be used.
-    :param n_workers: number of workers in the cluster
-    :param resource_tags: tags to apply to the cloud resources forming the
-        cluster
-    :param account: cluster provider account name
-    :param **kwargs: further named arguments will be passed on to the
-        cluster creation function
-    :param region: default region where workers of the cluster will be deployed set to eu-central-1
+    Args:
+        provider: identifier of the provider to use. Currently, only
+            'coiled' is supported.
+        name: name to use as an identifier for the cluster
+        software: identifier for the software environment to be used.
+        n_workers: number of workers in the cluster
+        resource_tags: tags to apply to the cloud resources forming the
+            cluster
+        account: cluster provider account name
+        **kwargs: further named arguments will be passed on to the
+            cluster creation function
+        region: default region where workers of the cluster will be
+            deployed set to eu-central-1
     """
 
     if resource_tags is None:
@@ -296,9 +298,7 @@ def _collate_cluster_resource_tags(extra_tags: Dict[str, str]) -> Dict[str, str]
 
 
 class _NestedList:
-    """
-    Utility class whose instances are used as input to dask.block().
-    """
+    """Utility class whose instances are used as input to dask.block()."""
 
     def __init__(self, shape: Sequence[int], fill_value: Any = None):
         self._shape = tuple(shape)

--- a/xcube/util/expression.py
+++ b/xcube/util/expression.py
@@ -30,8 +30,7 @@ def compute_array_expr(
     errors: str = "raise",
     result_name: str = None,
 ):
-    """
-    Safely evaluate a Python expression and return the result.
+    """Safely evaluate a Python expression and return the result.
 
     The namespace is expected to contain variable references
     which, when evaluated, return numpy-like data arrays.
@@ -42,13 +41,16 @@ def compute_array_expr(
     "np.logical_and(B01 <= 0, np.logical_not(np.fmin(B01) > 2))"
     which is then being evaluated instead.
 
-    :param expr: A valid Python expression.
-    :param namespace: A dictionary that represents the namespace
-        for the evaluation.
-    :param result_name: Name of the result (used for error messages only)
-    :param errors: How to deal with errors raised when
-        evaluating the expression. May be one of "raise" or "warn".
-    :return: The result computed from the evaluating the expression.
+    Args:
+        expr: A valid Python expression.
+        namespace: A dictionary that represents the namespace for the
+            evaluation.
+        result_name: Name of the result (used for error messages only)
+        errors: How to deal with errors raised when evaluating the
+            expression. May be one of "raise" or "warn".
+
+    Returns:
+        The result computed from the evaluating the expression.
     """
     expr = transpile_expr(expr, warn=errors == "warn")
     return compute_expr(
@@ -62,16 +64,18 @@ def compute_expr(
     errors: str = "raise",
     result_name: str = None,
 ):
-    """
-    Safely evaluate a Python expression and return the result.
+    """Safely evaluate a Python expression and return the result.
 
-    :param expr: A valid Python expression.
-    :param namespace: A dictionary that represents the namespace
-        for the evaluation.
-    :param result_name: Name of the result (used for error messages only)
-    :param errors: How to deal with errors raised when
-        evaluating the expression. May be one of "raise" or "warn".
-    :return: The result computed from the evaluating the expression.
+    Args:
+        expr: A valid Python expression.
+        namespace: A dictionary that represents the namespace for the
+            evaluation.
+        result_name: Name of the result (used for error messages only)
+        errors: How to deal with errors raised when evaluating the
+            expression. May be one of "raise" or "warn".
+
+    Returns:
+        The result computed from the evaluating the expression.
     """
     try:
         result = eval(expr, namespace, None)
@@ -89,11 +93,11 @@ def compute_expr(
 
 
 def transpile_expr(expr: str, warn=False) -> str:
-    """
-    Transpile a Python expression into a numpy/xarray array expression.
+    """Transpile a Python expression into a numpy/xarray array expression.
 
-    :param expr: The Python expression
-    :param warn: If warnings shall be emitted
+    Args:
+        expr: The Python expression
+        warn: If warnings shall be emitted
     :return The numpy array expression
     """
     return _ExprTranspiler(expr, warn).transpile()
@@ -101,8 +105,7 @@ def transpile_expr(expr: str, warn=False) -> str:
 
 # noinspection PyMethodMayBeStatic
 class _ExprTranspiler:
-    """
-    Transpile a Python expression into a numpy/xarray array expression.
+    """Transpile a Python expression into a numpy/xarray array expression.
 
     See https://greentreesnakes.readthedocs.io/en/latest/nodes.html#expressions
     """

--- a/xcube/util/extension.py
+++ b/xcube/util/extension.py
@@ -34,19 +34,19 @@ ExtensionPredicate = Callable[["Extension"], bool]
 
 
 class Extension:
-    """
-    An extension that provides a component of any type.
+    """An extension that provides a component of any type.
 
     Extensions are registered in a :class:`ExtensionRegistry`.
 
     Extension objects are not meant to be instantiated directly. Instead,
     :meth:`ExtensionRegistry.add_extension` is used to register extensions.
 
-    :param point: extension point identifier
-    :param name: extension name
-    :param component: extension component
-    :param loader: extension component loader function
-    :param metadata: extension metadata
+    Args:
+        point: extension point identifier
+        name: extension name
+        component: extension component
+        loader: extension component loader function
+        metadata: extension metadata
     """
 
     # noinspection PyShadowingBuiltins
@@ -131,8 +131,7 @@ register_json_formatter(Extension)
 
 # noinspection PyShadowingBuiltins
 class ExtensionRegistry:
-    """
-    A registry of extensions.
+    """A registry of extensions.
     Typically used by plugins to register extensions.
     """
 
@@ -140,35 +139,41 @@ class ExtensionRegistry:
         self._extension_points = {}
 
     def has_extension(self, point: str, name: str) -> bool:
-        """
-        Test if an extension with given *point* and *name* is registered.
+        """Test if an extension with given *point* and *name* is registered.
 
-        :param point: extension point identifier
-        :param name: extension name
-        :return: True, if extension exists
+        Args:
+            point: extension point identifier
+            name: extension name
+
+        Returns:
+            True, if extension exists
         """
         return point in self._extension_points and name in self._extension_points[point]
 
     def get_extension(self, point: str, name: str) -> Optional[Extension]:
-        """
-        Get registered extension for given *point* and *name*.
+        """Get registered extension for given *point* and *name*.
 
-        :param point: extension point identifier
-        :param name: extension name
-        :return: the extension or None, if no such exists
+        Args:
+            point: extension point identifier
+            name: extension name
+
+        Returns:
+            the extension or None, if no such exists
         """
         if point not in self._extension_points:
             return None
         return self._extension_points[point].get(name)
 
     def get_component(self, point: str, name: str) -> Any:
-        """
-        Get extension component for given *point* and *name*.
+        """Get extension component for given *point* and *name*.
         Raises a ValueError if no such extension exists.
 
-        :param point: extension point identifier
-        :param name: extension name
-        :return: extension component
+        Args:
+            point: extension point identifier
+            name: extension name
+
+        Returns:
+            extension component
         """
         extension = self.get_extension(point, name)
         if extension is None:
@@ -180,15 +185,17 @@ class ExtensionRegistry:
     def find_extensions(
         self, point: str, predicate: ExtensionPredicate = None
     ) -> List[Extension]:
-        """
-        Find extensions for *point* and optional filter function *predicate*.
+        """Find extensions for *point* and optional filter function *predicate*.
 
         The filter function is called with an extension and should return
         a truth value to indicate a match or mismatch.
 
-        :param point: extension point identifier
-        :param predicate: optional filter function
-        :return: list of matching extensions
+        Args:
+            point: extension point identifier
+            predicate: optional filter function
+
+        Returns:
+            list of matching extensions
         """
         if point not in self._extension_points:
             return []
@@ -202,15 +209,17 @@ class ExtensionRegistry:
     def find_components(
         self, point: str, predicate: ExtensionPredicate = None
     ) -> List[Component]:
-        """
-        Find extension components for *point* and optional filter function *predicate*.
+        """Find extension components for *point* and optional filter function *predicate*.
 
         The filter function is called with an extension and should return
         a truth value to indicate a match or mismatch.
 
-        :param point: extension point identifier
-        :param predicate: optional filter function
-        :return: list of matching extension components
+        Args:
+            point: extension point identifier
+            predicate: optional filter function
+
+        Returns:
+            list of matching extension components
         """
         return [
             extension.component
@@ -225,8 +234,7 @@ class ExtensionRegistry:
         loader: ComponentLoader = None,
         **metadata,
     ) -> Extension:
-        """
-        Register an extension *component* or an extension component *loader* for
+        """Register an extension *component* or an extension component *loader* for
         the given extension *point*, *name*, and additional *metadata*.
 
         Either *component* or *loader* must be specified, but not both.
@@ -237,12 +245,15 @@ class ExtensionRegistry:
         is requested for the first time. Consider using the function :func:`import_component` to create a
         loader that lazily imports a component from a module and optionally executes it.
 
-        :param point: extension point identifier
-        :param name: extension name
-        :param component: extension component
-        :param loader: extension component loader function
-        :param metadata: extension metadata
-        :return: a registered extension
+        Args:
+            point: extension point identifier
+            name: extension name
+            component: extension component
+            loader: extension component loader function
+            **metadata: extension metadata
+
+        Returns:
+            a registered extension
         """
         extension = Extension(
             point, name, component=component, loader=loader, **metadata
@@ -254,11 +265,11 @@ class ExtensionRegistry:
         return extension
 
     def remove_extension(self, point: str, name: str):
-        """
-        Remove registered extension *name* from given *point*.
+        """Remove registered extension *name* from given *point*.
 
-        :param point: extension point identifier
-        :param name: extension name
+        Args:
+            point: extension point identifier
+            name: extension name
         """
         point_extensions = self._extension_points[point]
         del point_extensions[name]
@@ -288,8 +299,7 @@ def import_component(
     call_args: Sequence[Any] = None,
     call_kwargs: Mapping[str, Any] = None,
 ) -> ComponentLoader:
-    """
-    Return a component loader that imports a module or module component from *spec*.
+    """Return a component loader that imports a module or module component from *spec*.
     To import a module, *spec* should be the fully qualified module name. To import a
     component, *spec* must also append the component name to the fully qualified module name
     separated by a color (":") character.
@@ -306,13 +316,21 @@ def import_component(
 
     Finally, the component is returned.
 
-    :param spec: String of the form "module_path" or "module_path:component_name"
-    :param transform: callable that takes two positional arguments,
-        the imported component and the extension of type :class:`Extension`
-    :param call: Whether to finally call the component with given *call_args* and *call_kwargs*
-    :param call_args: arguments passed to a callable component if *call* flag is set
-    :param call_kwargs: keyword arguments passed to callable component if *call* flag is set
-    :return: a component loader
+    Args:
+        spec: String of the form "module_path" or
+            "module_path:component_name"
+        transform: callable that takes two positional arguments, the
+            imported component and the extension of type
+            :class:`Extension`
+        call: Whether to finally call the component with given
+            *call_args* and *call_kwargs*
+        call_args: arguments passed to a callable component if *call*
+            flag is set
+        call_kwargs: keyword arguments passed to callable component if
+            *call* flag is set
+
+    Returns:
+        a component loader
     """
 
     # noinspection PyUnusedLocal
@@ -329,13 +347,16 @@ def import_component(
 
 
 def _import_component(component_spec: str, force_component: bool = False):
-    """
-    Import a module or module component from *spec*.
+    """Import a module or module component from *spec*.
 
-    :param component_spec: String of the form "module_name" or "module_name:component_name" where
-        module_name must an absolute, fully qualified path to a module.
-    :param force_component: If True, *spec* must specify a component name
-    :return: the imported module or module component
+    Args:
+        component_spec: String of the form "module_name" or
+            "module_name:component_name" where module_name must an
+            absolute, fully qualified path to a module.
+        force_component: If True, *spec* must specify a component name
+
+    Returns:
+        the imported module or module component
     """
     if ":" in component_spec:
         module_name, component_name = component_spec.split(":", maxsplit=1)

--- a/xcube/util/frozen.py
+++ b/xcube/util/frozen.py
@@ -152,7 +152,8 @@ def freeze_value(value: Any) -> Any:
 
 def defrost_value(value: Any) -> Any:
     """Defrost given *value*, that is, return a deeply
-    mutable version of it."""
+    mutable version of it.
+    """
     if isinstance(value, Frozen):
         return value.defrost()
     return value

--- a/xcube/util/fspath.py
+++ b/xcube/util/fspath.py
@@ -27,16 +27,12 @@ from fsspec.implementations.local import LocalFileSystem
 
 
 def is_local_fs(fs: fsspec.AbstractFileSystem) -> bool:
-    """
-    Check whether *fs* is a local filesystem.
-    """
+    """Check whether *fs* is a local filesystem."""
     return "file" in fs.protocol or isinstance(fs, LocalFileSystem)
 
 
 def get_fs_path_class(fs: fsspec.AbstractFileSystem) -> Type[pathlib.PurePath]:
-    """
-    Get the appropriate ``pathlib.PurePath`` class for the filesystem *fs*.
-    """
+    """Get the appropriate ``pathlib.PurePath`` class for the filesystem *fs*."""
     if is_local_fs(fs):
         # Will return PurePosixPath or a PureWindowsPath object
         return pathlib.PurePath
@@ -46,8 +42,7 @@ def get_fs_path_class(fs: fsspec.AbstractFileSystem) -> Type[pathlib.PurePath]:
 
 
 def resolve_path(path: pathlib.PurePath) -> pathlib.PurePath:
-    """
-    Resolve "." and ".." occurrences in *path* without I/O and
+    """Resolve "." and ".." occurrences in *path* without I/O and
     return a new path.
     """
     reversed_parts = reversed(path.parts)

--- a/xcube/util/ipython.py
+++ b/xcube/util/ipython.py
@@ -3,11 +3,14 @@ from typing import Type
 
 
 def register_json_formatter(cls: Type, to_dict_method_name: str = "to_dict"):
-    """
-    TODO
-    :param cls:
-    :param to_dict_method_name:
-    :return:
+    """TODO
+
+    Args:
+        cls
+        to_dict_method_name
+
+    Returns:
+
     """
     if not hasattr(cls, to_dict_method_name) or not callable(
         getattr(cls, to_dict_method_name)
@@ -33,9 +36,7 @@ def register_json_formatter(cls: Type, to_dict_method_name: str = "to_dict"):
 
 
 def enable_asyncio():
-    """
-    Enable asyncio package to be executable in Jupyter Notebooks.
-    """
+    """Enable asyncio package to be executable in Jupyter Notebooks."""
     try:
         import IPython
 

--- a/xcube/util/jsonschema.py
+++ b/xcube/util/jsonschema.py
@@ -267,11 +267,11 @@ class JsonDateAndTimeSchemaBase:
 
 
 class JsonDateSchema(JsonStringSchema, JsonDateAndTimeSchemaBase):
-    """
-    JSON schema for date instances.
+    """JSON schema for date instances.
 
-    :param min_date: optional minimum date.
-    :param max_date: optional maximum date.
+    Args:
+        min_date: optional minimum date.
+        max_date: optional maximum date.
     """
 
     # noinspection PyShadowingBuiltins
@@ -294,12 +294,16 @@ class JsonDateSchema(JsonStringSchema, JsonDateAndTimeSchemaBase):
     def new_range(
         cls, min_date: str = None, max_date: str = None, nullable: bool = False
     ) -> "JsonArraySchema":
-        """
-        Return a schema for a date range.
-        :param min_date: optional minimum date.
-        :param max_date: optional maximum date.
-        :param nullable: whether the whole range as well as individual start and end may be None.
-        :return: a JsonArraySchema with two items.
+        """Return a schema for a date range.
+
+        Args:
+            min_date: optional minimum date.
+            max_date: optional maximum date.
+            nullable: whether the whole range as well as individual
+                start and end may be None.
+
+        Returns:
+            a JsonArraySchema with two items.
         """
         return JsonArraySchema(
             items=[
@@ -311,11 +315,11 @@ class JsonDateSchema(JsonStringSchema, JsonDateAndTimeSchemaBase):
 
 
 class JsonDatetimeSchema(JsonStringSchema, JsonDateAndTimeSchemaBase):
-    """
-    JSON schema for date-time instances.
+    """JSON schema for date-time instances.
 
-    :param min_datetime: optional minimum date-time.
-    :param max_datetime: optional maximum date-time.
+    Args:
+        min_datetime: optional minimum date-time.
+        max_datetime: optional maximum date-time.
     """
 
     # noinspection PyShadowingBuiltins
@@ -338,12 +342,16 @@ class JsonDatetimeSchema(JsonStringSchema, JsonDateAndTimeSchemaBase):
     def new_range(
         cls, min_datetime: str = None, max_datetime: str = None, nullable: bool = False
     ) -> "JsonArraySchema":
-        """
-        Return a schema for a date-time range.
-        :param min_datetime: optional minimum date.
-        :param max_datetime: optional maximum date.
-        :param nullable: whether the whole range as well as individual start and end dates may be None.
-        :return: a JsonArraySchema with two items.
+        """Return a schema for a date-time range.
+
+        Args:
+            min_datetime: optional minimum date.
+            max_datetime: optional maximum date.
+            nullable: whether the whole range as well as individual
+                start and end dates may be None.
+
+        Returns:
+            a JsonArraySchema with two items.
         """
         return JsonArraySchema(
             items=[
@@ -521,8 +529,7 @@ class JsonObjectSchema(JsonSchema):
     def process_kwargs_subset(
         self, kwargs: Dict[str, Any], keywords: Sequence[str]
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """
-        Utility that helps processing keyword-arguments. in *kwargs*:
+        """Utility that helps processing keyword-arguments. in *kwargs*:
 
         Pop every keyword in *keywords* contained in this object schema's properties
         from *kwargs* and put the keyword and value from *kwargs* into a new dictionary.
@@ -665,8 +672,7 @@ class JsonObjectSchema(JsonSchema):
 
 
 class JsonObject(ABC):
-    """
-    The abstract base class for objects
+    """The abstract base class for objects
 
     * whose instances can be created from a JSON-serializable
       dictionary using their :meth:from_dict class method;

--- a/xcube/util/perf.py
+++ b/xcube/util/perf.py
@@ -30,8 +30,7 @@ from xcube.constants import LOG
 
 
 def measure_time_cm(logger=None, disabled=False):
-    """
-    Get a context manager for measuring execution time of code blocks and logging the result.
+    """Get a context manager for measuring execution time of code blocks and logging the result.
 
     Measure duration and log output:::
 
@@ -45,9 +44,13 @@ def measure_time_cm(logger=None, disabled=False):
             do_heavy_computation()
         print("heavy computation took %2.f seconds" % cm.duration)
 
-    :param logger: The logger to be used. May be a string or logger object. Defaults to "xcube".
-    :param disabled: If True, efficiently disables timing and logging.
-    :return: a context manager callable
+    Args:
+        logger: The logger to be used. May be a string or logger object.
+            Defaults to "xcube".
+        disabled: If True, efficiently disables timing and logging.
+
+    Returns:
+        a context manager callable
     """
     if disabled:
         return _do_not_measure_time_cm

--- a/xcube/util/plugin.py
+++ b/xcube/util/plugin.py
@@ -206,9 +206,10 @@ class _ModuleEntryPoint:
         return self._module_name
 
     def load(self) -> Optional[Callable]:
-        """
-        Load function "init_plugin()" either from "<module_name>.plugin" or "<module_name>"
-        :return: plugin init function
+        """Load function "init_plugin()" either from "<module_name>.plugin" or "<module_name>"
+
+        Returns:
+            plugin init function
         """
         try:
             plugin_module = importlib.import_module(
@@ -230,9 +231,7 @@ class _ModuleEntryPoint:
 
 
 class ExtensionComponent(metaclass=abc.ABCMeta):
-    """
-    Utility base class for extension components.
-    """
+    """Utility base class for extension components."""
 
     def __init__(self, extension_point: str, name: str):
         if not extension_point:
@@ -248,22 +247,22 @@ class ExtensionComponent(metaclass=abc.ABCMeta):
 
     @property
     def extension_point(self) -> str:
-        """
-        :return: The extension point for this component.
+        """Returns:
+        The extension point for this component.
         """
         return self._extension_point
 
     @property
     def extension(self) -> Optional[Extension]:
-        """
-        :return: The extension for this component.
-            None, if it has not (yet) been registered as an extension.
+        """Returns:
+        The extension for this component. None, if it has not (yet)
+        been registered as an extension.
         """
         return get_extension_registry().get_extension(self._extension_point, self._name)
 
     def get_metadata_attr(self, key: str, default: Any = None) -> Any:
-        """
-        :return: A metadata attribute for *key* and given *default* value.
+        """Returns:
+        A metadata attribute for *key* and given *default* value.
         """
         extension = self.extension
         return extension.metadata.get(key, default) if extension is not None else ""

--- a/xcube/util/progress.py
+++ b/xcube/util/progress.py
@@ -116,25 +116,18 @@ class ProgressState:
 
 
 class ProgressObserver(ABC):
-    """
-    A progress observer is notified about nested state changes when using the
+    """A progress observer is notified about nested state changes when using the
     :class:observe_progress context manager.
     """
 
     def on_begin(self, state_stack: Sequence[ProgressState]):
-        """
-        Called, if an observed code block begins execution.
-        """
+        """Called, if an observed code block begins execution."""
 
     def on_update(self, state_stack: Sequence[ProgressState]):
-        """
-        Called, if the progress state has changed within an observed code block.
-        """
+        """Called, if the progress state has changed within an observed code block."""
 
     def on_end(self, state_stack: Sequence[ProgressState]):
-        """
-        Called, if an observed block of code ends execution.
-        """
+        """Called, if an observed block of code ends execution."""
 
     def activate(self):
         _ProgressContext.instance().add_observer(self)
@@ -217,11 +210,12 @@ _ProgressContext.set_instance()
 
 
 class new_progress_observers:
-    """
-    Takes zero or more progress observers and activates them in the enclosed context.
+    """Takes zero or more progress observers and activates them in the enclosed context.
     Progress observers from an outer context will no longer be active.
 
-    :param observers: progress observers that will temporarily replace existing ones.
+    Args:
+        observers: progress observers that will temporarily replace
+            existing ones.
     """
 
     def __init__(self, *observers: ProgressObserver):
@@ -238,12 +232,12 @@ class new_progress_observers:
 
 
 class add_progress_observers:
-    """
-    Takes zero or more progress observers and uses them only in the
+    """Takes zero or more progress observers and uses them only in the
     enclosed context. Any progress observers from an outer context
     remain active.
 
-    :param observers: progress observers to be added temporarily.
+    Args:
+        observers: progress observers to be added temporarily.
     """
 
     def __init__(self, *observers: ProgressObserver):
@@ -259,11 +253,11 @@ class add_progress_observers:
 
 
 class observe_progress:
-    """
-    Context manager for observing progress in the enclosed context.
+    """Context manager for observing progress in the enclosed context.
 
-    :param label: A label.
-    :param total_work: The total work.
+    Args:
+        label: A label.
+        total_work: The total work.
     """
 
     def __init__(self, label: str, total_work: float):
@@ -311,14 +305,14 @@ class observe_progress:
 
 
 class observe_dask_progress(dask.callbacks.Callback):
-    """
-    Observe progress made by Dask tasks.
+    """Observe progress made by Dask tasks.
 
-    :param label: A label.
-    :param total_work: The total work.
-    :param interval: Time in seconds to between progress reports.
-    :param initial_interval: Time in seconds to wait before progress
-        is reported.
+    Args:
+        label: A label.
+        total_work: The total work.
+        interval: Time in seconds to between progress reports.
+        initial_interval: Time in seconds to wait before progress is
+            reported.
     """
 
     def __init__(

--- a/xcube/util/temp.py
+++ b/xcube/util/temp.py
@@ -58,25 +58,27 @@ def new_temp_file(
     dir_path: str = None,
     text_mode: bool = False,
 ) -> Tuple[int, str]:
-    """
-    Create new temporary file using ``tempfile.mkstemp()```.
+    """Create new temporary file using ``tempfile.mkstemp()```.
     The file will be removed later when the process ends.
 
-    :param prefix: If not ``None``, the file name will
-        begin with that prefix; otherwise, a default prefix is used.
-    :param suffix: If not ``None``, the file name will
-        end with that suffix, otherwise there will be no suffix.
-    :param dir_path: If not ``None``, the file will be created
-        in that directory; otherwise, a default directory is used.
-        The default directory is chosen from a platform-dependent
-        list, but the user of the application can control the
-        directory location by setting the *TMPDIR*, *TEMP* or *TMP*
-        environment variables.
-    :param text_mode: If specified and true, the file is opened in
-        text mode. Otherwise, (the default) the file is opened in
-        binary mode.
-    :return: A tuple comprising the file descriptor (an int) and the
-        absolute path to the new file.
+    Args:
+        prefix: If not ``None``, the file name will begin with that
+            prefix; otherwise, a default prefix is used.
+        suffix: If not ``None``, the file name will end with that
+            suffix, otherwise there will be no suffix.
+        dir_path: If not ``None``, the file will be created in that
+            directory; otherwise, a default directory is used. The
+            default directory is chosen from a platform-dependent list,
+            but the user of the application can control the directory
+            location by setting the *TMPDIR*, *TEMP* or *TMP*
+            environment variables.
+        text_mode: If specified and true, the file is opened in text
+            mode. Otherwise, (the default) the file is opened in binary
+            mode.
+
+    Returns:
+        A tuple comprising the file descriptor (an int) and the absolute
+        path to the new file.
     """
     prefix = DEFAULT_TEMP_FILE_PREFIX if prefix is None else prefix
     fd, file_path = tempfile.mkstemp(
@@ -86,12 +88,14 @@ def new_temp_file(
 
 
 def remove_dir_later(dir_path: str) -> str:
-    """
-    Remove directory later when the process ends.
+    """Remove directory later when the process ends.
     Removal failures are ignored.
 
-    :param dir_path: Path to directory
-    :return: The absolute path to the directory.
+    Args:
+        dir_path: Path to directory
+
+    Returns:
+        The absolute path to the directory.
     """
     dir_path = os.path.abspath(dir_path)
 
@@ -107,12 +111,14 @@ def remove_dir_later(dir_path: str) -> str:
 
 
 def remove_file_later(file_path: str) -> str:
-    """
-    Remove file later when the process ends.
+    """Remove file later when the process ends.
     Removal failures are ignored.
 
-    :param file_path: path to a file
-    :return: The absolute path to the file.
+    Args:
+        file_path: path to a file
+
+    Returns:
+        The absolute path to the file.
     """
     file_path = os.path.abspath(file_path)
 

--- a/xcube/util/timeindex.py
+++ b/xcube/util/timeindex.py
@@ -220,7 +220,8 @@ def _has_datetime64_time(var: xr.DataArray, time_name) -> bool:
 
     *time_name* specifies the name of the time dimension.
 
-    It is assumed that a *time_name* key is present in var.dims."""
+    It is assumed that a *time_name* key is present in var.dims.
+    """
     return (
         hasattr(var[time_name], "dtype")
         and hasattr(var[time_name].dtype, "type")

--- a/xcube/util/undefined.py
+++ b/xcube/util/undefined.py
@@ -26,9 +26,7 @@ UNDEFINED_STR = "UNDEFINED"
 
 
 class _Undefined:
-    """
-    Represents the UNDEFINED value.
-    """
+    """Represents the UNDEFINED value."""
 
     _hash_code = hash(UNDEFINED_STR) + 1
 

--- a/xcube/util/versions.py
+++ b/xcube/util/versions.py
@@ -62,10 +62,10 @@ _XCUBE_VERSIONS = None
 
 
 def get_xcube_versions() -> Dict[str, str]:
-    """
-    Get a mapping from xcube package names to package versions.
+    """Get a mapping from xcube package names to package versions.
 
-    :return: A mapping of the package names to package versions
+    Returns:
+        A mapping of the package names to package versions
     The result computed from the evaluating the expression.
     """
     from .plugin import get_plugins
@@ -81,16 +81,18 @@ def get_xcube_versions() -> Dict[str, str]:
 def get_versions(
     dependency_names: List[str], plugin_names: List[str]
 ) -> Dict[str, str]:
-    """
-    Get a mapping from package names to package versions.
+    """Get a mapping from package names to package versions.
     The input is divided into names of packages that are external dependencies
     and into names of xcube plugins.
 
-    :param dependency_names: A list of names of packages of which the versions
-        shall be found
-    :param plugin_names: A list of names of xcube plugins of which the versions
-        shall be found
-    :return: A mapping of the package names to package versions
+    Args:
+        dependency_names: A list of names of packages of which the
+            versions shall be found
+        plugin_names: A list of names of xcube plugins of which the
+            versions shall be found
+
+    Returns:
+        A mapping of the package names to package versions
     The result computed from the evaluating the expression.
     """
     # Idea borrowed from xarray.print_versions

--- a/xcube/webapi/auth/context.py
+++ b/xcube/webapi/auth/context.py
@@ -51,9 +51,7 @@ class AuthContext(ApiContext):
 
     @property
     def must_authenticate(self) -> bool:
-        """
-        Test whether the user must authenticate.
-        """
+        """Test whether the user must authenticate."""
         return self.auth_config is not None and self.auth_config.is_required
 
     @cached_property

--- a/xcube/webapi/common/context.py
+++ b/xcube/webapi/common/context.py
@@ -69,8 +69,7 @@ class ResourcesContext(ApiContext):
 
     @property
     def can_authenticate(self) -> bool:
-        """
-        Test whether the user can authenticate.
+        """Test whether the user can authenticate.
         Even if authentication service is configured, user authentication
         may still be optional. In this case the server will publish
         the resources configured to be free for everyone.
@@ -79,9 +78,7 @@ class ResourcesContext(ApiContext):
 
     @property
     def must_authenticate(self) -> bool:
-        """
-        Test whether the user must authenticate.
-        """
+        """Test whether the user must authenticate."""
         return self._auth_ctx.must_authenticate
 
     @property

--- a/xcube/webapi/common/xml.py
+++ b/xcube/webapi/common/xml.py
@@ -30,17 +30,19 @@ class Node(abc.ABC):
 
     @abc.abstractmethod
     def add(self, *elements: "Element") -> "Node":
-        """
-        Adds child elements to this element.
-        :param elements: Child elements
+        """Adds child elements to this element.
+
+        Args:
+            *elements: Child elements
         """
         pass
 
     @abc.abstractmethod
     def to_xml(self, indent: int = 2) -> str:
-        """
-        Converts this node into valid XML text using UTF-8 encoding.
-        :param indent: Indent in spaces. Defaults to 2.
+        """Converts this node into valid XML text using UTF-8 encoding.
+
+        Args:
+            indent: Indent in spaces. Defaults to 2.
         """
         pass
 
@@ -50,13 +52,13 @@ class Node(abc.ABC):
 
 
 class Element(Node):
-    """
-    An XML element node.
+    """An XML element node.
 
-    :param tag: Tag name
-    :param attrs: Attributes
-    :param text: Text
-    :param elements: Child elements
+    Args:
+        tag: Tag name
+        attrs: Attributes
+        text: Text
+        elements: Child elements
     """
 
     def __init__(
@@ -112,9 +114,10 @@ class Element(Node):
 
 
 class Document(Node):
-    """
-    An XML document.
-    :param root: The only root element.
+    """An XML document.
+
+    Args:
+        root: The only root element.
     """
 
     def __init__(self, root: Element):

--- a/xcube/webapi/compute/context.py
+++ b/xcube/webapi/compute/context.py
@@ -269,11 +269,16 @@ def new_job(job_id: int, job_request: JobRequest) -> Job:
 def is_job_status(job: Job, status: str) -> bool:
     """Report whether a specified job has the specified status.
 
-    :param job: a job specification (string-keyed dictionary)
-    :param status: a string representing a recognized status
-    :return: True if the status is recognized and the specified job has the
-             specified status
-    :raises ValueError: if the status is not recognized
+    Args:
+        job: a job specification (string-keyed dictionary)
+        status: a string representing a recognized status
+
+    Returns:
+        True if the status is recognized and the specified job has the
+        specified status
+
+    Raises:
+        ValueError: if the status is not recognized
     """
     _assert_valid_job_status(status)
     return job["state"]["status"] == status
@@ -282,11 +287,14 @@ def is_job_status(job: Job, status: str) -> bool:
 def set_job_status(job: Job, status: str, error: Optional[BaseException] = None):
     """Set the status of a job.
 
-    :param job: a job specification (string-keyed dictionary)
-    :param status: a string representing a recognized status
-    :param error: if supplied, annotate the job specification with information
-                  from this exception
-    :raises ValueError: if the status is not recognized
+    Args:
+        job: a job specification (string-keyed dictionary)
+        status: a string representing a recognized status
+        error: if supplied, annotate the job specification with
+            information from this exception
+
+    Raises:
+        ValueError: if the status is not recognized
     """
     _assert_valid_job_status(status)
     job_id = job["jobId"]
@@ -305,8 +313,9 @@ def set_job_status(job: Job, status: str, error: Optional[BaseException] = None)
 def set_job_result(job: Job, result: Dict[str, Any]):
     """Set the result of a compute job.
 
-    :param job: job specifier (string-keyed dictionary)
-    :param result: results of the job
+    Args:
+        job: job specifier (string-keyed dictionary)
+        result: results of the job
     """
     job["result"] = result
 

--- a/xcube/webapi/compute/op/decorator.py
+++ b/xcube/webapi/compute/op/decorator.py
@@ -15,13 +15,16 @@ def operation(
 ):
     """Decorator that registers a function as an operation.
 
-    :param _op: the function to register as an operation
-    :param params_schema: JSON Schema for the function's parameters
-           (a JSON object schema mapping parameter names to their individual
-           schemas)
-    :param op_registry: the registry in which to register the operation
-    :return: the decorated operation, if an operation was supplied;
-       otherwise, a decorator function
+    Args:
+        _op: the function to register as an operation
+        params_schema: JSON Schema for the function's parameters (a JSON
+            object schema mapping parameter names to their individual
+            schemas)
+        op_registry: the registry in which to register the operation
+
+    Returns:
+        the decorated operation, if an operation was supplied;
+        otherwise, a decorator function
     """
 
     def decorator(op: Callable):
@@ -53,16 +56,20 @@ def op_param(
 
     See also
     https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-basic-meta
-    :param name: name of the parameter to apply schema information to
-    :param json_type: JSON Schema type of the parameter
-    :param py_type: Python type of the parameter
-    :param title: title of the parameter
-    :param description: description of the parameter
-    :param default: default value for the parameter
-    :param required: whether the parameter is required
-    :param schema: JSON Schema describing the parameter
-    :param op_registry: registry in which to register the operation
-    :return: parameterized decorator for a compute operation function
+
+    Args:
+        name: name of the parameter to apply schema information to
+        json_type: JSON Schema type of the parameter
+        py_type: Python type of the parameter
+        title: title of the parameter
+        description: description of the parameter
+        default: default value for the parameter
+        required: whether the parameter is required
+        schema: JSON Schema describing the parameter
+        op_registry: registry in which to register the operation
+
+    Returns:
+        parameterized decorator for a compute operation function
     """
 
     def decorator(op: Callable):

--- a/xcube/webapi/compute/op/info.py
+++ b/xcube/webapi/compute/op/info.py
@@ -33,9 +33,10 @@ class OpInfo:
     ):
         """Create information about a compute operation
 
-        :param params_schema: map of parameter names to their JSON Schema
-                              definitions
-        :param param_py_types: map of parameter names to their Python types
+        Args:
+            params_schema: map of parameter names to their JSON Schema
+                definitions
+            param_py_types: map of parameter names to their Python types
         """
         self.params_schema = params_schema
         self.param_py_types = param_py_types
@@ -46,8 +47,11 @@ class OpInfo:
         The supplied function is modified in-place (with the addition of an
         attribute referencing this information instance) and returned.
 
-        :param function: the function to associate with this information
-        :return: the same function (with an attribute added)
+        Args:
+            function: the function to associate with this information
+
+        Returns:
+            the same function (with an attribute added)
         """
         setattr(function, _ATTR_NAME_OP_INFO, self)
         return function
@@ -56,10 +60,15 @@ class OpInfo:
     def get_op_info(cls, op: Callable) -> "OpInfo":
         """Get the information object for a specified function
 
-        :param op: the function for which information is requested
-        :return: the function’s associated information object, if present
-        :raises ValueError: if there is no associated information object
-                            (i.e. the function is not an operation)
+        Args:
+            op: the function for which information is requested
+
+        Returns:
+            the function’s associated information object, if present
+
+        Raises:
+            ValueError: if there is no associated information object
+                (i.e. the function is not an operation)
         """
         op_info = getattr(op, _ATTR_NAME_OP_INFO, None)
         if not isinstance(op_info, OpInfo):
@@ -75,8 +84,11 @@ class OpInfo:
         The returned information object contains a parameter type dictionary
         and JSON schema created by analysis of the supplied function.
 
-        :param op: a function
-        :return: operation information for the supplied function
+        Args:
+            op: a function
+
+        Returns:
+            operation information for the supplied function
         """
         members = dict(inspect.getmembers(op))
         annotations = members.get("__annotations__")
@@ -157,8 +169,9 @@ class OpInfo:
         as the value in the returned type dictionary. Otherwise `None` will
         be used.
 
-        :return: a dictionary mapping operation parameter names to their
-                 effective Python types
+        Returns:
+            a dictionary mapping operation parameter names to their
+            effective Python types
         """
         py_types = self.param_py_types.copy()
         for param_name, param_schema in self.param_schemas.items():
@@ -176,15 +189,16 @@ class OpInfo:
 
     @property
     def param_schemas(self) -> Dict[str, Any]:
-        """
-        :return: a mapping of parameter names to their JSON schemas
+        """Returns:
+        a mapping of parameter names to their JSON schemas
         """
         return self.params_schema.get("properties", {})
 
     def set_param_schemas(self, schemas: Dict[str, Any]):
         """Set JSON schemas for operation parameters
 
-        :param schemas: a mapping of parameter names to their JSON schemas
+        Args:
+            schemas: a mapping of parameter names to their JSON schemas
         """
         self.params_schema["properties"] = schemas
 
@@ -196,17 +210,19 @@ class OpInfo:
         with any schemas for the individual parameters in a sub-dictionary
         under the `properties` key.
 
-        :param schema: the schema with which to update the parameters
-                       dictionary schema
+        Args:
+            schema: the schema with which to update the parameters
+                dictionary schema
         """
         self.params_schema.update(schema)
 
     def update_param_schema(self, param_name: str, schema: Dict[str, Any]):
         """Update the JSON Schema for a single parameter
 
-        :param param_name: name of the parameter
-        :param schema: schema with which to update the parameter’s current
-                       schema
+        Args:
+            param_name: name of the parameter
+            schema: schema with which to update the parameter’s
+                current schema
         """
         param_schemas = self.param_schemas
         param_schema = param_schemas.get(param_name, {})
@@ -218,15 +234,19 @@ class OpInfo:
     def get_param_py_type(self, param_name: str) -> PyType:
         """Get the Python type for a parameter
 
-        :param param_name: name of parameter
-        :return: Python type of specified parameter
+        Args:
+            param_name: name of parameter
+
+        Returns:
+            Python type of specified parameter
         """
         return self.param_py_types[param_name]
 
     def set_param_py_type(self, param_name: str, py_type: PyType):
         """Set the Python type for a parameter
 
-        :param param_name: name of parameter
-        :param py_type: Python type of specified parameter
+        Args:
+            param_name: name of parameter
+            py_type: Python type of specified parameter
         """
         self.param_py_types[param_name] = py_type

--- a/xcube/webapi/datasets/authutil.py
+++ b/xcube/webapi/datasets/authutil.py
@@ -33,16 +33,16 @@ def assert_scopes(
     granted_scopes: Optional[Set[str]],
     is_substitute: bool = False,
 ):
-    """
-    Assert scopes.
+    """Assert scopes.
     Raise ServiceAuthError if one of *required_scopes* is
     not in *granted_scopes*.
 
-    :param required_scopes: The list of required scopes
-    :param granted_scopes: The set of granted scopes.
-        If user is not authenticated, its value is None.
-    :param is_substitute: True, if the resource to be checked
-        is a substitute.
+    Args:
+        required_scopes: The list of required scopes
+        granted_scopes: The set of granted scopes. If user is not
+            authenticated, its value is None.
+        is_substitute: True, if the resource to be checked is a
+            substitute.
     """
     missing_scope = _get_missing_scope(
         required_scopes, granted_scopes, is_substitute=is_substitute
@@ -56,8 +56,7 @@ def check_scopes(
     granted_scopes: Optional[Set[str]],
     is_substitute: bool = False,
 ) -> bool:
-    """
-    Check scopes.
+    """Check scopes.
 
     This function is used to filter out a resource's sub-resources for
     which a given client has no permission.
@@ -66,12 +65,15 @@ def check_scopes(
     If *granted_scopes* exists and *is_substitute*, fail too.
     Else succeed.
 
-    :param required_scopes: The list of required scopes
-    :param granted_scopes: The set of granted scopes.
-        If user is not authenticated, its value is None.
-    :param is_substitute: True, if the resource to be checked
-        is a substitute.
-    :return: True, if scopes are ok.
+    Args:
+        required_scopes: The list of required scopes
+        granted_scopes: The set of granted scopes. If user is not
+            authenticated, its value is None.
+        is_substitute: True, if the resource to be checked is a
+            substitute.
+
+    Returns:
+        True, if scopes are ok.
     """
     return (
         _get_missing_scope(required_scopes, granted_scopes, is_substitute=is_substitute)
@@ -84,16 +86,18 @@ def _get_missing_scope(
     granted_scopes: Optional[Set[str]],
     is_substitute: bool = False,
 ) -> Optional[str]:
-    """
-    Return the first required scope that is
+    """Return the first required scope that is
     fulfilled by any granted scope
 
-    :param required_scopes: The list of required scopes
-    :param granted_scopes: The set of granted scopes.
-        If user is not authenticated, its value is None.
-    :param is_substitute: True, if the resource to be checked
-        is a substitute.
-    :return: The missing scope.
+    Args:
+        required_scopes: The list of required scopes
+        granted_scopes: The set of granted scopes. If user is not
+            authenticated, its value is None.
+        is_substitute: True, if the resource to be checked is a
+            substitute.
+
+    Returns:
+        The missing scope.
     """
     is_authenticated = granted_scopes is not None
     if is_authenticated:

--- a/xcube/webapi/datasets/controllers.py
+++ b/xcube/webapi/datasets/controllers.py
@@ -376,16 +376,18 @@ def get_bbox_geometry(
 def get_time_chunk_size(
     ts_ds: Optional[xr.Dataset], var_name: str, ds_id: str
 ) -> Optional[int]:
-    """
-    Get the time chunk size for variable *var_name*
+    """Get the time chunk size for variable *var_name*
     in time-chunked dataset *ts_ds*.
 
     Internal function.
 
-    :param ts_ds: time-chunked dataset
-    :param var_name: variable name
-    :param ds_id: original dataset identifier
-    :return: the time chunk size (integer) or None
+    Args:
+        ts_ds: time-chunked dataset
+        var_name: variable name
+        ds_id: original dataset identifier
+
+    Returns:
+        the time chunk size (integer) or None
     """
     if ts_ds is not None:
         ts_var: Optional[xr.DataArray] = ts_ds.get(var_name)

--- a/xcube/webapi/ows/coverages/controllers.py
+++ b/xcube/webapi/ows/coverages/controllers.py
@@ -39,14 +39,16 @@ from xcube.webapi.ows.coverages.util import get_h_dim, get_v_dim
 
 
 def get_coverage_as_json(ctx: DatasetsContext, collection_id: str):
-    """
-    Return a JSON representation of the specified coverage
+    """Return a JSON representation of the specified coverage
 
     Currently, the range set component is omitted.
 
-    :param ctx: a dataset context
-    :param collection_id: the ID of the collection providing the coverage
-    :return: a JSON representation of the coverage
+    Args:
+        ctx: a dataset context
+        collection_id: the ID of the collection providing the coverage
+
+    Returns:
+        a JSON representation of the coverage
     """
     return {
         "id": collection_id,
@@ -71,22 +73,24 @@ def get_coverage_data(
     query: Mapping[str, Sequence[str]],
     content_type: str,
 ) -> tuple[Optional[bytes], list[float], pyproj.CRS]:
-    """
-    Return coverage data from a dataset
+    """Return coverage data from a dataset
 
     This method currently returns coverage data from a dataset as either
     TIFF or NetCDF. The bbox, datetime, and properties parameters are
     currently handled.
 
-    :param ctx: a datasets context
-    :param collection_id: the dataset from which to return the coverage
-    :param query: the HTTP query parameters
-    :param content_type: the MIME type of the desired output format
-    :return: A tuple consisting of: (1) the coverage as bytes in the requested
-             output format, or None if the requested output format is not
-             supported; (2) the bounding box of the returned data, respecting
-             the axis ordering of the CRS (e.g. latitude first for EPSG:4326);
-             (3) the CRS of the returned dataset and bounding box
+    Args:
+        ctx: a datasets context
+        collection_id: the dataset from which to return the coverage
+        query: the HTTP query parameters
+        content_type: the MIME type of the desired output format
+
+    Returns:
+        A tuple consisting of: (1) the coverage as bytes in the
+        requested output format, or None if the requested output format
+        is not supported; (2) the bounding box of the returned data,
+        respecting the axis ordering of the CRS (e.g. latitude first for
+        EPSG:4326); (3) the CRS of the returned dataset and bounding box
     """
 
     ds = get_dataset(ctx, collection_id)
@@ -418,13 +422,15 @@ def dataset_to_image(
     image_format: Literal["png", "tiff"] = "png",
     crs: pyproj.CRS = None,
 ) -> bytes:
-    """
-    Return an in-memory bitmap (TIFF or PNG) representing a dataset
+    """Return an in-memory bitmap (TIFF or PNG) representing a dataset
 
-    :param ds: a dataset
-    :param image_format: image format to generate ("png" or "tiff")
-    :param crs: CRS of the dataset
-    :return: TIFF-formatted bytes representing the dataset
+    Args:
+        ds: a dataset
+        image_format: image format to generate ("png" or "tiff")
+        crs: CRS of the dataset
+
+    Returns:
+        TIFF-formatted bytes representing the dataset
     """
 
     if image_format == "png":
@@ -453,11 +459,13 @@ def dataset_to_image(
 
 
 def dataset_to_netcdf(ds: xr.Dataset) -> bytes:
-    """
-    Return an in-memory NetCDF representing a dataset
+    """Return an in-memory NetCDF representing a dataset
 
-    :param ds: a dataset
-    :return: NetCDF-formatted bytes representing the dataset
+    Args:
+        ds: a dataset
+
+    Returns:
+        NetCDF-formatted bytes representing the dataset
     """
     with tempfile.TemporaryDirectory() as tempdir:
         path = os.path.join(tempdir, "out.nc")
@@ -468,15 +476,17 @@ def dataset_to_netcdf(ds: xr.Dataset) -> bytes:
 
 
 def get_coverage_domainset(ctx: DatasetsContext, collection_id: str):
-    """
-    Return the domain set of a dataset-backed coverage
+    """Return the domain set of a dataset-backed coverage
 
     The domain set is the set of input parameters (e.g. geographical extent,
     time span) for which a coverage is defined.
 
-    :param ctx: a datasets context
-    :param collection_id: the dataset for which to return the domain set
-    :return: a dictionary representing an OGC API - Coverages domain set
+    Args:
+        ctx: a datasets context
+        collection_id: the dataset for which to return the domain set
+
+    Returns:
+        a dictionary representing an OGC API - Coverages domain set
     """
     ds = get_dataset(ctx, collection_id)
     grid_limits = dict(
@@ -496,26 +506,30 @@ def get_coverage_domainset(ctx: DatasetsContext, collection_id: str):
 
 
 def get_collection_metadata(ctx: DatasetsContext, collection_id: str):
-    """
-    Return a metadata dictionary for a dataset
+    """Return a metadata dictionary for a dataset
 
     The metadata is taken directly from the dataset attributes.
 
-    :param ctx: a datasets context
-    :param collection_id: the dataset for which to return the metadata
-    :return: a dictionary of metadata keys and values
+    Args:
+        ctx: a datasets context
+        collection_id: the dataset for which to return the metadata
+
+    Returns:
+        a dictionary of metadata keys and values
     """
     ds = get_dataset(ctx, collection_id)
     return ds.attrs
 
 
 def get_dataset(ctx: DatasetsContext, collection_id: str):
-    """
-    Get a dataset from a datasets context
+    """Get a dataset from a datasets context
 
-    :param ctx: a datasets context
-    :param collection_id: the ID of a dataset in the context
-    :return: the dataset
+    Args:
+        ctx: a datasets context
+        collection_id: the ID of a dataset in the context
+
+    Returns:
+        the dataset
     """
     ml_dataset = ctx.get_ml_dataset(collection_id)
     ds = ml_dataset.get_dataset(0)
@@ -560,14 +574,16 @@ def get_units(ds: xr.Dataset, dim: str) -> str:
 
 
 def get_crs_from_dataset(ds: xr.Dataset) -> pyproj.CRS:
-    """
-    Return the CRS of a dataset as a string. The CRS is taken from the
+    """Return the CRS of a dataset as a string. The CRS is taken from the
     metadata of the crs or spatial_ref variables, if available.
     "EPSG:4326" is used as a fallback.
 
-    :param ds: a dataset
-    :return: a string representation of the dataset's CRS, or "EPSG:4326"
-             if the CRS cannot be determined
+    Args:
+        ds: a dataset
+
+    Returns:
+        a string representation of the dataset's CRS, or "EPSG:4326" if
+        the CRS cannot be determined
     """
     for var_name in "crs", "spatial_ref":
         if var_name in ds.variables:
@@ -585,9 +601,12 @@ def get_coverage_rangetype(ctx: DatasetsContext, collection_id: str) -> dict[str
     The range type describes the data types of the dataset's variables
     using a format defined in https://docs.ogc.org/is/09-146r6/09-146r6.html
 
-    :param ctx: datasets context
-    :param collection_id: ID of the dataset in the supplied context
-    :return: a dictionary representing the specified dataset's range type
+    Args:
+        ctx: datasets context
+        collection_id: ID of the dataset in the supplied context
+
+    Returns:
+        a dictionary representing the specified dataset's range type
     """
     return get_coverage_rangetype_for_dataset(get_dataset(ctx, collection_id))
 
@@ -598,8 +617,11 @@ def get_coverage_rangetype_for_dataset(ds) -> dict[str, list]:
     The range type describes the data types of the dataset's variables
     using a format defined in https://docs.ogc.org/is/09-146r6/09-146r6.html
 
-    :param ds: a dataset
-    :return: a dictionary representing the supplied dataset's range type
+    Args:
+        ds: a dataset
+
+    Returns:
+        a dictionary representing the supplied dataset's range type
     """
     result = dict(type="DataRecord", field=[])
     for var_name, variable in ds.data_vars.items():
@@ -620,12 +642,14 @@ def get_coverage_rangetype_for_dataset(ds) -> dict[str, list]:
 
 
 def dtype_to_opengis_datatype(dt: np.dtype) -> str:
-    """
-    Convert a NumPy dtype to an equivalent OpenGIS type identifier string.
+    """Convert a NumPy dtype to an equivalent OpenGIS type identifier string.
 
-    :param dt: a NumPy dtype
-    :return: an equivalent OpenGIS type identifier string, or an empty string
-             if the dtype is not recognized
+    Args:
+        dt: a NumPy dtype
+
+    Returns:
+        an equivalent OpenGIS type identifier string, or an empty string
+        if the dtype is not recognized
     """
     nbits = 8 * np.dtype(dt).itemsize
     int_size_map = {8: "Byte", 16: "Short", 32: "Int", 64: "Long"}
@@ -644,12 +668,14 @@ def dtype_to_opengis_datatype(dt: np.dtype) -> str:
 
 
 def get_dataarray_description(da: xr.DataArray) -> str:
-    """
-    Return a string describing a DataArray, either from an attribute or,
+    """Return a string describing a DataArray, either from an attribute or,
     as a fallback, from its name attribute.
 
-    :param da: a DataArray
-    :return: a string describing the DataArray
+    Args:
+        da: a DataArray
+
+    Returns:
+        a string describing the DataArray
     """
     if hasattr(da, "attrs"):
         for attr in ["description", "long_name", "standard_name", "name"]:
@@ -659,14 +685,16 @@ def get_dataarray_description(da: xr.DataArray) -> str:
 
 
 def get_collection_envelope(ds_ctx, collection_id):
-    """
-    Return the OGC API - Coverages envelope of a dataset.
+    """Return the OGC API - Coverages envelope of a dataset.
 
     The envelope comprises the extents of all the dataset's dimensions.
 
-    :param ds_ctx: a datasets context
-    :param collection_id: a dataset ID within the given context
-    :return: the envelope of the specified dataset
+    Args:
+        ds_ctx: a datasets context
+        collection_id: a dataset ID within the given context
+
+    Returns:
+        the envelope of the specified dataset
     """
     ds = get_dataset(ds_ctx, collection_id)
     return {

--- a/xcube/webapi/ows/coverages/routes.py
+++ b/xcube/webapi/ows/coverages/routes.py
@@ -104,8 +104,7 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
 @api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/domainset")
 @api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/domainset/")
 class CoveragesDomainsetHandler(ApiHandler[CoveragesContext]):
-    """
-    Describe the domain set of a coverage
+    """Describe the domain set of a coverage
 
     The domain set is the set of input parameters (e.g. geographical extent,
     time span) for which the coverage is defined.
@@ -125,8 +124,7 @@ class CoveragesDomainsetHandler(ApiHandler[CoveragesContext]):
 @api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/rangetype")
 @api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/rangetype/")
 class CoveragesRangetypeHandler(ApiHandler[CoveragesContext]):
-    """
-    Describe the range type of a coverage
+    """Describe the range type of a coverage
 
     The range type describes the types of the data contained in the range
     of this coverage. For a data cube, these would typically correspond to
@@ -146,8 +144,7 @@ class CoveragesRangetypeHandler(ApiHandler[CoveragesContext]):
 @api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/metadata")
 @api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/metadata/")
 class CoveragesMetadataHandler(ApiHandler[CoveragesContext]):
-    """
-    Return coverage metadata
+    """Return coverage metadata
 
     The metadata is taken from the source dataset's attributes
     """
@@ -166,8 +163,7 @@ class CoveragesMetadataHandler(ApiHandler[CoveragesContext]):
 @api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/rangeset")
 @api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/rangeset/")
 class CoveragesRangesetHandler(ApiHandler[CoveragesContext]):
-    """
-    Handle rangeset endpoint with a "not allowed" response
+    """Handle rangeset endpoint with a "not allowed" response
 
     This endpoint has been deprecated
     (see https://github.com/m-mohr/geodatacube-api/pull/1 ),
@@ -191,17 +187,19 @@ class CoveragesRangesetHandler(ApiHandler[CoveragesContext]):
 def negotiate_content_type(
     request: ApiRequest, available: Collection[str]
 ) -> Optional[str]:
-    """
-    Determine a MIME content type based on client and server capabilities
+    """Determine a MIME content type based on client and server capabilities
 
     Client preferences are determined both from the standard HTTP Accept
     header provided by the client, and by an optional `f` parameter which
     can override the Accept header.
 
-    :param request: HTTP request with Accept header and/or f parameter
-    :param available: List of MIME types that the server can produce
-    :return: the MIME type that is most acceptable to both client and server,
-             or None if there is no MIME type acceptable to both
+    Args:
+        request: HTTP request with Accept header and/or f parameter
+        available: List of MIME types that the server can produce
+
+    Returns:
+        the MIME type that is most acceptable to both client and server,
+        or None if there is no MIME type acceptable to both
     """
     if "f" in request.query:  # overrides headers
         content_type = request.query["f"][0]

--- a/xcube/webapi/ows/coverages/scaling.py
+++ b/xcube/webapi/ows/coverages/scaling.py
@@ -47,12 +47,14 @@ class CoverageScaling:
     def __init__(self, request: CoverageRequest, crs: pyproj.CRS, ds: xr.Dataset):
         """Create a new scaling from a coverages request object
 
-        :param request: a request optionally including scaling parameters.
-          If any scaling parameters are present, the returned instance will
-          correspond to them. If no scaling parameters are present, a
-          default scaling will be used (currently 1:1)
-        :param crs: the CRS of the dataset to be scaled
-        :param ds: the dataset to be scaled
+        Args:
+            request: a request optionally including scaling parameters.
+                If any scaling parameters are present, the returned
+                instance will correspond to them. If no scaling
+                parameters are present, a default scaling will be used
+                (currently 1:1)
+            crs: the CRS of the dataset to be scaled
+            ds: the dataset to be scaled
         """
         h_dim = get_h_dim(ds)
         v_dim = get_v_dim(ds)
@@ -109,7 +111,8 @@ class CoverageScaling:
         dimensions; the effective factor may be different when the scaling
         is applied to a GridMapping.
 
-        :return: a 2-tuple of the x and y scale factors, in that order
+        Returns:
+            a 2-tuple of the x and y scale factors, in that order
         """
         if self._scale is not None:
             return self._scale
@@ -122,8 +125,9 @@ class CoverageScaling:
     def size(self) -> tuple[float, float]:
         """Return the final coverage size produced by this scaling
 
-        :return: a 2-tuple of the scaled x and y sizes, in that order,
-          in pixels
+        Returns:
+            a 2-tuple of the scaled x and y sizes, in that order, in
+            pixels
         """
         if self._final_size is not None:
             return self._final_size
@@ -149,10 +153,13 @@ class CoverageScaling:
         the CRS which has either a name or abbreviation matching any string
         in the supplied set.
 
-        :param valid_identifiers: a set of axis identifiers
-        :return: the abbreviation of the first axis in this scaling's CRS
-          whose name or abbreviation is in the supplied set, or `None` if
-          no such axis exists
+        Args:
+            valid_identifiers: a set of axis identifiers
+
+        Returns:
+            the abbreviation of the first axis in this scaling's CRS
+            whose name or abbreviation is in the supplied set, or `None`
+            if no such axis exists
         """
         for axis in self._crs.axis_info:
             if not hasattr(axis, "abbrev"):
@@ -172,10 +179,13 @@ class CoverageScaling:
 
         The supplied grid mapping is regularized before being scaled.
 
-        :param gm: a grid mapping to be scaled
-        :return: the supplied grid mapping, scaled according to this scaling.
-          If this scaling is 1:1, the returned grid mapping may be the
-          original object.
+        Args:
+            gm: a grid mapping to be scaled
+
+        Returns:
+            the supplied grid mapping, scaled according to this scaling.
+            If this scaling is 1:1, the returned grid mapping may be the
+            original object.
         """
         if self.factor == (1, 1):
             return gm

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -93,9 +93,12 @@ _CONFORMANCE = (
 def get_root(ctx: DatasetsContext, base_url: str):
     """Return content for the STAC/OGC root endpoint (a STAC catalogue)
 
-    :param ctx: the datasets context
-    :param base_url: the base URL of the server
-    :return: content for the root endpoint
+    Args:
+        ctx: the datasets context
+        base_url: the base URL of the server
+
+    Returns:
+        content for the root endpoint
     """
     c_id, c_title, c_description = _get_catalog_metadata(ctx.config)
 
@@ -180,7 +183,8 @@ def _root_link(base_url):
 def get_conformance() -> dict[str, list[str]]:
     """Return conformance data for this API implementation
 
-    :return: a dictionary containing a list of conformance specifiers
+    Returns:
+        a dictionary containing a list of conformance specifiers
     """
     return {"conformsTo": _CONFORMANCE}
 
@@ -191,9 +195,12 @@ def get_collections(ctx: StacContext, base_url: str) -> dict[str, Any]:
     These include a union collection representing all the datasets,
     as well as an individual named collection per dataset.
 
-    :param ctx: a datasets context
-    :param base_url: the base URL of the current server
-    :return: a STAC dictionary listing the available collections
+    Args:
+        ctx: a datasets context
+        base_url: the base URL of the current server
+
+    Returns:
+        a STAC dictionary listing the available collections
     """
     return {
         "collections": [_get_datasets_collection(ctx, base_url)]
@@ -216,11 +223,13 @@ def get_collections(ctx: StacContext, base_url: str) -> dict[str, Any]:
 def get_collection(ctx: StacContext, base_url: str, collection_id: str) -> dict:
     """Return a STAC representation of a collection
 
-    :param ctx: a datasets context
-    :param base_url: the base URL of the current server
-    :param collection_id: the ID of the collection to describe
-    :return: a STAC object representing the collection, if found
-    :raises: ApiError.NotFound if no collection with the given ID exists
+    Args:
+        ctx: a datasets context
+        base_url: the base URL of the current server
+        collection_id: the ID of the collection to describe
+
+    Returns:
+        a STAC object representing the collection, if found
     """
     ds_ctx = ctx.datasets_ctx
     all_datasets_collection_id, _, _ = _get_collection_metadata(ctx.config)
@@ -238,11 +247,14 @@ def get_single_collection_items(
 ) -> dict:
     """Get the singleton item list for a single-dataset collection
 
-    :param ctx: a datasets context
-    :param base_url: the base URL of the current server
-    :param collection_id: the ID of a single-dataset collection
-    :return: a FeatureCollection dictionary with a singleton feature
-        list containing a feature for the requested dataset
+    Args:
+        ctx: a datasets context
+        base_url: the base URL of the current server
+        collection_id: the ID of a single-dataset collection
+
+    Returns:
+        a FeatureCollection dictionary with a singleton feature list
+        containing a feature for the requested dataset
     """
     feature = _get_dataset_feature(
         ctx,
@@ -273,13 +285,16 @@ def get_datasets_collection_items(
 ) -> dict:
     """Get the items in the unified datasets collection
 
-    :param ctx: a datasets context
-    :param base_url: base URL of the current server
-    :param collection_id: the ID of the unified datasets collection
-    :param limit: the maximum number of items to return
-    :param cursor: the index of the first item to return
-    :return: A STAC dictionary of the items in the unified datasets collection,
-        limited by the specified limit and cursor values
+    Args:
+        ctx: a datasets context
+        base_url: base URL of the current server
+        collection_id: the ID of the unified datasets collection
+        limit: the maximum number of items to return
+        cursor: the index of the first item to return
+
+    Returns:
+        A STAC dictionary of the items in the unified datasets
+        collection, limited by the specified limit and cursor values
     """
     _assert_valid_collection(ctx, collection_id)
     all_configs = ctx.get_dataset_configs()
@@ -334,14 +349,17 @@ def get_collection_item(
     or that the collection ID will be the dataset ID and the feature ID
     will be the default feature ID for a single-collection dataset.
 
-    :param ctx: a datasets context
-    :param base_url: the base URL of the current server
-    :param collection_id: the ID of the unified datasets collection or of
-        a single-dataset collection
-    :param feature_id: the ID of a single dataset within the unified
-       collection or of the default feature within a single-dataset collection
-    :return: a STAC object representing the specified item, if found
-    :raises: ApiError.NotFound, if the specified item is not found
+    Args:
+        ctx: a datasets context
+        base_url: the base URL of the current server
+        collection_id: the ID of the unified datasets collection or of a
+            single-dataset collection
+        feature_id: the ID of a single dataset within the unified
+            collection or of the default feature within a single-dataset
+            collection
+
+    Returns:
+        a STAC object representing the specified item, if found
     """
     dataset_ids = {c["Identifier"] for c in ctx.get_dataset_configs()}
 
@@ -374,10 +392,13 @@ def get_collection_item(
 def get_collection_queryables(ctx: DatasetsContext, collection_id: str) -> dict:
     """Get a JSON schema of queryable parameters for the specified collection
 
-    :param ctx: a datasets context
-    :param collection_id: the ID of a collection
-    :return: a JSON schema of queryable parameters, if the collection was found
-    :raises: ApiError.NotFound, if the collection was not found
+    Args:
+        ctx: a datasets context
+        collection_id: the ID of a collection
+
+    Returns:
+        a JSON schema of queryable parameters, if the collection was
+        found
     """
     _assert_valid_collection(ctx, collection_id)
     schema = JsonObjectSchema(
@@ -395,10 +416,14 @@ def get_collection_schema(
     https://docs.ogc.org/DRAFTS/19-087.html#_collection_schema_response_collectionscollectionidschema
     for links to a metaschema defining the schema.
 
-    :param ctx: a datasets context
-    :param base_url: the base URL at which this API is being served
-    :param collection_id: the ID of a dataset in the provided context
-    :return: a JSON schema representing the specified dataset's data variables
+    Args:
+        ctx: a datasets context
+        base_url: the base URL at which this API is being served
+        collection_id: the ID of a dataset in the provided context
+
+    Returns:
+        a JSON schema representing the specified dataset's data
+        variables
     """
     if collection_id == DEFAULT_COLLECTION_ID:
         # The default collection contains multiple datasets, so a range
@@ -663,9 +688,12 @@ def get_time_grid(ds: xr.Dataset) -> dict[str, Any]:
     The dictionary format is defined by the schema at
     https://github.com/opengeospatial/ogcapi-coverages/blob/master/standard/openapi/schemas/common-geodata/extent.yaml
 
-    :param ds: a dataset
-    :return: a dictionary representation of the grid of the dataset's
-             time variable
+    Args:
+        ds: a dataset
+
+    Returns:
+        a dictionary representation of the grid of the dataset's time
+        variable
     """
     if "time" not in ds:
         return {}
@@ -881,9 +909,12 @@ def get_datacube_dimensions(
     """Create the value of the "datacube:dimensions" property
     for the given *dataset*.
 
-    :param dataset: the dataset to describe
-    :param grid_mapping: the dataset's grid mapping
-    :return: a dictionary of the datacube properties of the dataset
+    Args:
+        dataset: the dataset to describe
+        grid_mapping: the dataset's grid mapping
+
+    Returns:
+        a dictionary of the datacube properties of the dataset
     """
     x_dim_name, y_dim_name = grid_mapping.xy_dim_names
     x_var_name, y_var_name = grid_mapping.xy_var_names

--- a/xcube/webapi/s3/dsmapping.py
+++ b/xcube/webapi/s3/dsmapping.py
@@ -46,9 +46,10 @@ class DatasetsMapping(collections.abc.Mapping):
     more user-friendly. If *is_multi_level* is True, the new names
     will always have ".levels" suffix, otherwise the ".zarr" suffix.
 
-    :param datasets_ctx: The datasets' context
-    :param is_multi_level: Whether this is a multi-level datasets'
-        object storage
+    Args:
+        datasets_ctx: The datasets' context
+        is_multi_level: Whether this is a multi-level datasets' object
+            storage
     """
 
     def __init__(self, datasets_ctx: DatasetsContext, is_multi_level: bool = False):
@@ -93,7 +94,8 @@ class DatasetsMapping(collections.abc.Mapping):
         Overridden to avoid a call to __getitem__(),
         which will open the dataset (or raise ApiError!),
         but we want this to happen for direct __getitem__()
-        calls only."""
+        calls only.
+        """
         return s3_name in self._s3_names
 
     def __getitem__(self, s3_name: str) -> Union[xr.Dataset, MultiLevelDataset]:

--- a/xcube/webapi/s3/listbucket.py
+++ b/xcube/webapi/s3/listbucket.py
@@ -46,51 +46,52 @@ def list_s3_bucket_v2(
     (https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html)
     for the local filesystem.
 
-    :param object_storage: mapping from path-like keys to byte-objects.
-    :param name: The bucket name.
-    :param delimiter: A delimiter is a character you use to group keys.
-        If you specify a prefix, all of the keys that contain the same string
-        between the prefix and the first occurrence of the delimiter after
-        the prefix are grouped under a single result element called
-        CommonPrefixes.
-        If you don't specify the prefix parameter, the substring starts
-        at the beginning of the key.
-        The keys that are grouped under the CommonPrefixes result element
-        are not returned elsewhere in the response.
-        Refer to AWS docs for details. No default.
-    :param prefix: Limits the response to keys that begin with the
-        specified prefix.
-        You can use prefixes to separate a bucket into different
-        groupings of keys. (You can think of using prefix to make groups
-        in the same way you'd use a folder in a file system.)
-        Refer to AWS docs for details. No default.
-    :param max_keys: Sets the maximum number of keys returned
-        in the response body.
-        If you want to retrieve fewer than the default 1000 keys,
-        you can add this to your request.
-        The response might contain fewer keys, but it never contains more.
-        If there are additional keys that satisfy the search criteria,
-        but these keys were not returned because max-keys was exceeded,
-        the response contains <IsTruncated>true</IsTruncated>.
-        To return the additional keys, see NextContinuationToken.
-        Refer to AWS docs for details. Defaults to 1000.
-    :param start_after: If you want the API to return key names after
-        a specific object key in your key space, you can add this parameter.
-        Amazon S3 lists objects in UTF-8 character encoding
-        in lexicographical order. Refer to AWS docs for details.
-        No default.
-    :param continuation_token: When the response to this API call is
-        truncated (that is, the IsTruncated response element value is true),
-        the response also includes the NextContinuationToken element.
-        To list the next set of objects,
-        you can use the NextContinuationToken element in the next request
-        as the continuation-token.
-        Refer to AWS docs for details. No default.
-    :param storage_class: Refer to AWS docs for details.
-        Defaults to "STANDARD".
-    :param last_modified: For testing only: always use this value
-        for the "LastModified" entry of results
-    :return: A dictionary that represents the contents of a
+    Args:
+        object_storage: mapping from path-like keys to byte-objects.
+        name: The bucket name.
+        delimiter: A delimiter is a character you use to group keys. If
+            you specify a prefix, all of the keys that contain the same
+            string between the prefix and the first occurrence of the
+            delimiter after the prefix are grouped under a single result
+            element called CommonPrefixes. If you don't specify the
+            prefix parameter, the substring starts at the beginning of
+            the key. The keys that are grouped under the CommonPrefixes
+            result element are not returned elsewhere in the response.
+            Refer to AWS docs for details. No default.
+        prefix: Limits the response to keys that begin with the
+            specified prefix. You can use prefixes to separate a bucket
+            into different groupings of keys. (You can think of using
+            prefix to make groups in the same way you'd use a folder in
+            a file system.) Refer to AWS docs for details. No default.
+        max_keys: Sets the maximum number of keys returned in the
+            response body. If you want to retrieve fewer than the
+            default 1000 keys, you can add this to your request. The
+            response might contain fewer keys, but it never contains
+            more. If there are additional keys that satisfy the search
+            criteria, but these keys were not returned because max-keys
+            was exceeded, the response contains
+            <IsTruncated>true</IsTruncated>. To return the additional
+            keys, see NextContinuationToken. Refer to AWS docs for
+            details. Defaults to 1000.
+        start_after: If you want the API to return key names after a
+            specific object key in your key space, you can add this
+            parameter. Amazon S3 lists objects in UTF-8 character
+            encoding in lexicographical order. Refer to AWS docs for
+            details. No default.
+        continuation_token: When the response to this API call is
+            truncated (that is, the IsTruncated response element value
+            is true), the response also includes the
+            NextContinuationToken element. To list the next set of
+            objects, you can use the NextContinuationToken element in
+            the next request as the continuation-token. Refer to AWS
+            docs for details. No default.
+        storage_class: Refer to AWS docs for details. Defaults to
+            "STANDARD".
+        last_modified: For testing only: always use this value for the
+            "LastModified" entry of results
+
+    Returns:
+        A dictionary that represents the contents of a
         "ListBucketResult". Refer to AWS docs for details.
     """
     assert_instance(object_storage, collections.abc.Mapping, name="object_storage")
@@ -182,42 +183,43 @@ def list_s3_bucket_v1(
     (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html)
     for the local filesystem.
 
-    :param object_storage: mapping from path-like keys to byte-objects.
-    :param name: The bucket name, defaults to "s3bucket"
-    :param delimiter: A delimiter is a character you use to group keys.
-        If you specify a prefix, all of the keys that contain the same string
-        between the prefix and the first occurrence of the delimiter after
-        the prefix are grouped under a single result element called
-        CommonPrefixes.
-        If you don't specify the prefix parameter, the substring starts
-        at the beginning of the key.
-        The keys that are grouped under the CommonPrefixes result
-        element are not returned elsewhere in the response.
-        Refer to AWS docs for details. No default.
-    :param prefix: Limits the response to keys that begin with the
-        specified prefix.
-        You can use prefixes to separate a bucket into different
-        groupings of keys. (You can think of using prefix to make groups
-        in the same way you'd use a folder in a file system.)
-        Refer to AWS docs for details. No default.
-    :param max_keys: Sets the maximum number of keys returned in the
-        response body. If you want to retrieve fewer than the default
-        1000 keys, you can add this to your request.
-        The response might contain fewer keys, but it never contains more.
-        If there are additional keys that satisfy the search criteria,
-        but these keys were not returned because max-keys was exceeded,
-        the response contains <IsTruncated>true</IsTruncated>.
-        To return the additional keys, see NextMarker.
-        Refer to AWS docs for details.
-    :param marker: Indicates the object key to start with when listing
-        objects in a bucket. All objects are listed in the dictionary order.
-        Refer to AWS docs for details. No default.
-    :param storage_class: Refer to AWS docs for details.
-        Defaults to "STANDARD".
-    :param last_modified: For testing only: always use this value
-        for the "LastModified" entry of results
-    :return: A dictionary that represents the contents of
-        a "ListBucketResult". Refer to AWS docs for details.
+    Args:
+        object_storage: mapping from path-like keys to byte-objects.
+        name: The bucket name, defaults to "s3bucket"
+        delimiter: A delimiter is a character you use to group keys. If
+            you specify a prefix, all of the keys that contain the same
+            string between the prefix and the first occurrence of the
+            delimiter after the prefix are grouped under a single result
+            element called CommonPrefixes. If you don't specify the
+            prefix parameter, the substring starts at the beginning of
+            the key. The keys that are grouped under the CommonPrefixes
+            result element are not returned elsewhere in the response.
+            Refer to AWS docs for details. No default.
+        prefix: Limits the response to keys that begin with the
+            specified prefix. You can use prefixes to separate a bucket
+            into different groupings of keys. (You can think of using
+            prefix to make groups in the same way you'd use a folder in
+            a file system.) Refer to AWS docs for details. No default.
+        max_keys: Sets the maximum number of keys returned in the
+            response body. If you want to retrieve fewer than the
+            default 1000 keys, you can add this to your request. The
+            response might contain fewer keys, but it never contains
+            more. If there are additional keys that satisfy the search
+            criteria, but these keys were not returned because max-keys
+            was exceeded, the response contains
+            <IsTruncated>true</IsTruncated>. To return the additional
+            keys, see NextMarker. Refer to AWS docs for details.
+        marker: Indicates the object key to start with when listing
+            objects in a bucket. All objects are listed in the
+            dictionary order. Refer to AWS docs for details. No default.
+        storage_class: Refer to AWS docs for details. Defaults to
+            "STANDARD".
+        last_modified: For testing only: always use this value for the
+            "LastModified" entry of results
+
+    Returns:
+        A dictionary that represents the contents of a
+        "ListBucketResult". Refer to AWS docs for details.
     """
     assert_instance(object_storage, collections.abc.Mapping, name="object_storage")
     assert_instance(name, str, name="name")

--- a/xcube/webapi/s3/objectstorage.py
+++ b/xcube/webapi/s3/objectstorage.py
@@ -37,8 +37,9 @@ class ObjectStorage(collections.abc.Mapping):
     * "{dataset_id}/{level}.zarr/{*path}" for multi-level datasets and
     * "{dataset_id}/{*path}" for other datasets.
 
-    :param datasets: Mapping from dataset Identifier
-        to (multi-level) datasets.
+    Args:
+        datasets: Mapping from dataset Identifier to (multi-level)
+            datasets.
     """
 
     def __init__(self, datasets: Mapping[str, Union[xr.Dataset, MultiLevelDataset]]):
@@ -64,7 +65,8 @@ class ObjectStorage(collections.abc.Mapping):
     def __contains__(self, key: str) -> bool:
         """Overridden to avoid a call to __getitem__(),
         which will load data, but we want this to happen
-        for direct __getitem__() calls only."""
+        for direct __getitem__() calls only.
+        """
         try:
             zarr_store, item_key = self._parse_key(key)
         except (KeyError, ApiError.NotFound):

--- a/xcube/webapi/timeseries/controllers.py
+++ b/xcube/webapi/timeseries/controllers.py
@@ -75,27 +75,27 @@ def get_time_series(
     For non-point geometries that cover spatial areas, there
     will be values for all keys given by *agg_methods*.
 
-    :param ctx: Service context object
-    :param ds_name: The dataset identifier.
-    :param var_name: The variable name.
-    :param geo_json: The GeoJSON object that is a or has
-        a geometry or collection of geometries.
-    :param agg_methods: Spatial aggregation methods
-        for geometries that cover a spatial area.
-    :param start_date: An optional start date.
-    :param end_date: An optional end date.
-    :param tolerance: Time tolerance in seconds that expands
-        the given time range. Defaults to one second.
-    :param max_valids: Optional number of valid points.
-        If it is None (default),
-        also missing values are returned as NaN;
-        if it is -1,
-        only valid values are returned;
-        if it is a positive integer,
-        the most recent valid values are returned.
-    :param incl_ancillary_vars: For point geometries,
-        include values of ancillary variables, if any.
-    :return: Time-series data structure.
+    Args:
+        ctx: Service context object
+        ds_name: The dataset identifier.
+        var_name: The variable name.
+        geo_json: The GeoJSON object that is a or has a geometry or
+            collection of geometries.
+        agg_methods: Spatial aggregation methods for geometries that
+            cover a spatial area.
+        start_date: An optional start date.
+        end_date: An optional end date.
+        tolerance: Time tolerance in seconds that expands the given time
+            range. Defaults to one second.
+        max_valids: Optional number of valid points. If it is None
+            (default), also missing values are returned as NaN; if it is
+            -1, only valid values are returned; if it is a positive
+            integer, the most recent valid values are returned.
+        incl_ancillary_vars: For point geometries, include values of
+            ancillary variables, if any.
+
+    Returns:
+        Time-series data structure.
     """
     if tolerance:
         timedelta = pd.Timedelta(tolerance, unit="seconds")

--- a/xcube/webapi/viewer/viewer.py
+++ b/xcube/webapi/viewer/viewer.py
@@ -47,12 +47,12 @@ _LAB_INFO_FILE = "~/.xcube/jupyterlab/lab-info.json"
 
 
 class Viewer:
-    """
-    Experimental class that represents the xcube Viewer
+    """Experimental class that represents the xcube Viewer
     in Jupyter Notebooks.
 
-    :param server_config: Server configuration.
-        See "xcube serve --show configschema".
+    Args:
+        server_config: Server configuration. See "xcube serve --show
+            configschema".
     """
 
     def __init__(self, server_config: Optional[Mapping[str, Any]] = None):
@@ -136,22 +136,25 @@ class Viewer:
         style: Optional[str] = None,
         color_mappings: Dict[str, Dict[str, Any]] = None,
     ):
-        """
-        Add a dataset to this viewer.
+        """Add a dataset to this viewer.
 
-        :param dataset: The dataset to me added. Must be an instance of
-            ``xarray.Dataset`` or ``xcube.core.mldataset.MultiLevelDataset``.
-        :param ds_id: Optional dataset identifier.
-            If not given, an identifier will be generated and returned.
-        :param title: Optional dataset title.
-            Overrides a title given by dataset metadata.
-        :param style: Optional name of a style that must exist
-            in the server configuration.
-        :param color_mappings: Maps a variable name to a specific
-            color mapping that is a dictionary comprising a "ValueRange"
-            (a pair of numbers) and a "ColorBar"
-            (a matplotlib color bar name).
-        :return: The dataset identifier.
+        Args:
+            dataset: The dataset to me added. Must be an instance of
+                ``xarray.Dataset`` or
+                ``xcube.core.mldataset.MultiLevelDataset``.
+            ds_id: Optional dataset identifier. If not given, an
+                identifier will be generated and returned.
+            title: Optional dataset title. Overrides a title given by
+                dataset metadata.
+            style: Optional name of a style that must exist in the
+                server configuration.
+            color_mappings: Maps a variable name to a specific color
+                mapping that is a dictionary comprising a "ValueRange"
+                (a pair of numbers) and a "ColorBar" (a matplotlib color
+                bar name).
+
+        Returns:
+            The dataset identifier.
         """
         if not self._check_server_running():
             return
@@ -164,24 +167,24 @@ class Viewer:
         )
 
     def remove_dataset(self, ds_id: str):
-        """
-        Remove a dataset from this viewer.
+        """Remove a dataset from this viewer.
 
-        :param ds_id: The identifier of the dataset to be removed.
+        Args:
+            ds_id: The identifier of the dataset to be removed.
         """
         if not self._check_server_running():
             return
         self.datasets_ctx.remove_dataset(ds_id)
 
     def show(self, width: Union[int, str] = "100%", height: Union[str, int] = 800):
-        """
-        Show this viewer as an iframe.
+        """Show this viewer as an iframe.
         Intended to be used in a Jupyter notebook.
         If used outside a Jupyter notebook the viewer will be shown
         as a new browser tab.
 
-        :param width: The width of the viewer's iframe.
-        :param height: The height of the viewer's iframe.
+        Args:
+            width: The width of the viewer's iframe.
+            height: The height of the viewer's iframe.
         """
         try:
             from IPython.core.display import HTML


### PR DESCRIPTION
- Converted docstrings from reST to Google style 
- Changed devguide accordingly using [docconvert](https://github.com/cbillingham/docconvert)
- Adjusted Sphinx configuration, which is now using [sphinx.ext.napoleon](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#module-sphinx.ext.napoleon) for API doc generation

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [x] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
