### PR TITLE
Allow for interpolation in `rectify_dataset()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,14 @@
 ## Changes in 1.4.2 (in development)
 
-* Enhanced spatial resampling in module `xcube.core.resampling`: (#955)
-    - Added optional keyword argument `interpolation` to `rectify_dataset()` 
-      with values `"nearest"`, `"linear"`, or `"bilinear"`. 
-      `"linear"` interpolates between 3 and `"bilinear"` between 4 adjacent 
-      source pixels. 
-    - Added optional keyword argument `rectify_kwargs` to `resample_in_space()`.
+* Enhanced spatial resampling in module `xcube.core.resampling` (#955): 
+    - Added optional keyword argument `interpolation` to function
+      `rectify_dataset()` with values `"nearest"`, `"linear"`, 
+      and `"bilinear"` where `"linear"` interpolates between 3 
+      and `"bilinear"` between 4 adjacent source pixels. 
+    - Function `rectify_dataset()` is now ~2 times faster by early 
+      detection of already transformed target pixels.      
+    - Added optional keyword argument `rectify_kwargs` to 
+    - `resample_in_space()`.
       If given, it is spread into keyword arguments passed to the internal 
       `rectify_dataset()` delegation, if any.
     - Deprecated unused keyword argument `xy_var_names` of 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 ## Changes in 1.4.2 (in development)
 
+* Enhanced spatial resampling in module `xcube.core.resampling`: (#955)
+    - Added optional keyword argument `interpolation` to `rectify_dataset()` 
+      with values `"nearest"` or `"linear"`.  The latter performs a linear 
+      interpolation between adjacent source pixels. 
+    - Added optional keyword argument `rectify_kwargs` to `resample_in_space()`.
+      If given, it is spread into keyword arguments passed to the internal 
+      `rectify_dataset()` delegation, if any.
+    - Deprecated unused keyword argument `xy_var_names` of 
+      function `rectify_dataset()`.
+
 * Update dependencies to better match imports; remove the defaults channel;
   turn adlfs into a soft dependency. (#945)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,8 @@
     - Function `rectify_dataset()` is now ~2 times faster by early 
       detection of already transformed target pixels.      
     - Added optional keyword argument `rectify_kwargs` to 
-    - `resample_in_space()`.
-      If given, it is spread into keyword arguments passed to the internal 
-      `rectify_dataset()` delegation, if any.
+      `resample_in_space()`. If given, it is spread into keyword arguments 
+      passed to the internal `rectify_dataset()` delegation, if any.
     - Deprecated unused keyword argument `xy_var_names` of 
       function `rectify_dataset()`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 * Enhanced spatial resampling in module `xcube.core.resampling`: (#955)
     - Added optional keyword argument `interpolation` to `rectify_dataset()` 
-      with values `"nearest"` or `"linear"`.  The latter performs a linear 
-      interpolation between adjacent source pixels. 
+      with values `"nearest"`, `"linear"`, or `"bilinear"`. 
+      `"linear"` interpolates between 3 and `"bilinear"` between 4 adjacent 
+      source pixels. 
     - Added optional keyword argument `rectify_kwargs` to `resample_in_space()`.
       If given, it is spread into keyword arguments passed to the internal 
       `rectify_dataset()` delegation, if any.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 * Enhanced spatial resampling in module `xcube.core.resampling` (#955): 
     - Added optional keyword argument `interpolation` to function
-      `rectify_dataset()` with values `"nearest"`, `"linear"`, 
-      and `"bilinear"` where `"linear"` interpolates between 3 
+      `rectify_dataset()` with values `"nearest"`, `"triangular"`, 
+      and `"bilinear"` where `"triangular"` interpolates between 3 
       and `"bilinear"` between 4 adjacent source pixels. 
     - Function `rectify_dataset()` is now ~2 times faster by early 
       detection of already transformed target pixels.      

--- a/test/core/resampling/test_rectify.py
+++ b/test/core/resampling/test_rectify.py
@@ -109,8 +109,8 @@ class RectifyDatasetTest(SourceDatasetMixin, unittest.TestCase):
                     [_nan_, 1.478, 1.391, _nan_, _nan_, _nan_, _nan_],
                     [_nan_, 1.957, 1.870, 1.784, 1.697, _nan_, _nan_],
                     [_nan_, 2.435, 2.348, 2.261, 2.174, 2.087, 2.000],
-                    [3.000, 2.929, 2.857, 2.786, 2.714, _nan_, _nan_],
-                    [_nan_, 4.000, 3.429, 3.357, _nan_, _nan_, _nan_],
+                    [3.000, 3.000, 3.000, 3.000, 3.000, _nan_, _nan_],
+                    [_nan_, 4.000, 4.000, 4.000, _nan_, _nan_, _nan_],
                     [_nan_, _nan_, 5.000, _nan_, _nan_, _nan_, _nan_],
                 ],
                 dtype=rad.dtype,
@@ -923,7 +923,6 @@ class RectifySentinel2DatasetTest(SourceDatasetMixin, unittest.TestCase):
 
         target_ds = rectify_dataset(source_ds, source_gm=source_gm, tile_size=None)
         self.assertEqual(None, target_ds.rrs_665.chunks)
-        print(repr(target_ds.rrs_665.values))
         np.testing.assert_almost_equal(
             target_ds.rrs_665.values, expected_data, decimal=3
         )

--- a/test/core/resampling/test_rectify.py
+++ b/test/core/resampling/test_rectify.py
@@ -78,7 +78,7 @@ class RectifyDatasetTest(SourceDatasetMixin, unittest.TestCase):
             ),
         )
 
-    def test_rectify_2x2_to_7x7_linear_interpol(self):
+    def test_rectify_2x2_to_7x7_triangular_interpol(self):
         source_ds = self.new_2x2_dataset_with_irregular_coords()
         # Add offset to "rad" so it's values do not lie on a plane
         source_ds["rad"] = source_ds.rad + xr.DataArray(
@@ -90,7 +90,7 @@ class RectifyDatasetTest(SourceDatasetMixin, unittest.TestCase):
         )
 
         target_ds = rectify_dataset(
-            source_ds, target_gm=target_gm, interpolation="linear"
+            source_ds, target_gm=target_gm, interpolation="triangular"
         )
 
         lon, lat, rad = self._assert_shape_and_dim(target_ds, (7, 7))

--- a/test/core/resampling/test_rectify.py
+++ b/test/core/resampling/test_rectify.py
@@ -157,9 +157,7 @@ class RectifyDatasetTest(SourceDatasetMixin, unittest.TestCase):
         )
 
         # Just to cover emitting deprecation warning
-        rectify_dataset(
-            source_ds, target_gm=target_gm, xy_var_names=("X", "Y")
-        )
+        rectify_dataset(source_ds, target_gm=target_gm, xy_var_names=("X", "Y"))
 
     def test_rectify_2x2_to_13x13(self):
         source_ds = self.new_2x2_dataset_with_irregular_coords()

--- a/test/core/resampling/test_rectify.py
+++ b/test/core/resampling/test_rectify.py
@@ -2,6 +2,7 @@ import unittest
 from typing import Tuple
 
 import numpy as np
+import pytest
 
 # noinspection PyUnresolvedReferences
 import xarray as xr
@@ -13,6 +14,7 @@ from xcube.core.gridmapping import GridMapping
 from xcube.core.resampling import rectify_dataset
 
 nan = np.nan
+_nan_ = np.nan
 
 
 # noinspection PyMethodMayBeStatic
@@ -24,16 +26,8 @@ class RectifyDatasetTest(SourceDatasetMixin, unittest.TestCase):
             size=(4, 4), xy_min=(-1, 49), xy_res=2, crs=CRS_WGS84
         )
         target_ds = rectify_dataset(source_ds, target_gm=target_gm)
-        # target_ds = rectify_dataset(source_ds)
 
         rad = target_ds.rad
-        # lon, lat, rad = self._assert_shape_and_dim(target_ds, (4, 4))
-        # np.testing.assert_almost_equal(lon.values,
-        #                                np.array([0., 2., 4., 6.],
-        #                                         dtype=lon.dtype))
-        # np.testing.assert_almost_equal(lat.values,
-        #                                np.array([56., 54., 52., 50.],
-        #                                         dtype=lat.dtype))
         np.testing.assert_almost_equal(
             rad.values,
             np.array(
@@ -49,6 +43,10 @@ class RectifyDatasetTest(SourceDatasetMixin, unittest.TestCase):
 
     def test_rectify_2x2_to_7x7(self):
         source_ds = self.new_2x2_dataset_with_irregular_coords()
+        # Add offset to "rad" so it's values do not lie on a plane
+        source_ds["rad"] = source_ds.rad + xr.DataArray(
+            np.array([[0.0, 0.0], [0.0, 1.0]]), dims=("y", "x")
+        )
 
         target_gm = GridMapping.regular(
             size=(7, 7), xy_min=(-0.5, 49.5), xy_res=1.0, crs=CRS_WGS84
@@ -72,16 +70,20 @@ class RectifyDatasetTest(SourceDatasetMixin, unittest.TestCase):
                     [nan, 1.0, 1.0, nan, nan, nan, nan],
                     [nan, 1.0, 1.0, 1.0, 2.0, nan, nan],
                     [nan, 3.0, 3.0, 1.0, 2.0, 2.0, 2.0],
-                    [3.0, 3.0, 3.0, 4.0, 2.0, nan, nan],
-                    [nan, 3.0, 4.0, 4.0, nan, nan, nan],
-                    [nan, nan, 4.0, nan, nan, nan, nan],
+                    [3.0, 3.0, 3.0, 5.0, 2.0, nan, nan],
+                    [nan, 3.0, 5.0, 5.0, nan, nan, nan],
+                    [nan, nan, 5.0, nan, nan, nan, nan],
                 ],
                 dtype=rad.dtype,
             ),
         )
 
-    def test_rectify_2x2_to_7x7_lin_interpol(self):
+    def test_rectify_2x2_to_7x7_linear_interpol(self):
         source_ds = self.new_2x2_dataset_with_irregular_coords()
+        # Add offset to "rad" so it's values do not lie on a plane
+        source_ds["rad"] = source_ds.rad + xr.DataArray(
+            np.array([[0.0, 0.0], [0.0, 1.0]]), dims=("y", "x")
+        )
 
         target_gm = GridMapping.regular(
             size=(7, 7), xy_min=(-0.5, 49.5), xy_res=1.0, crs=CRS_WGS84
@@ -99,23 +101,72 @@ class RectifyDatasetTest(SourceDatasetMixin, unittest.TestCase):
             lat.values,
             np.array([56.0, 55.0, 54.0, 53.0, 52.0, 51.0, 50.0], dtype=lat.dtype),
         )
-        _nan_ = nan
         np.testing.assert_almost_equal(
             rad.values,
             np.array(
                 [
                     [_nan_, 1.000, _nan_, _nan_, _nan_, _nan_, _nan_],
                     [_nan_, 1.478, 1.391, _nan_, _nan_, _nan_, _nan_],
-                    [_nan_, 1.957, 1.870, 1.783, 1.696, _nan_, _nan_],
+                    [_nan_, 1.957, 1.870, 1.784, 1.697, _nan_, _nan_],
                     [_nan_, 2.435, 2.348, 2.261, 2.174, 2.087, 2.000],
                     [3.000, 2.929, 2.857, 2.786, 2.714, _nan_, _nan_],
-                    [_nan_, 3.500, 3.429, 3.357, _nan_, _nan_, _nan_],
-                    [_nan_, _nan_, 4.000, _nan_, _nan_, _nan_, _nan_],
+                    [_nan_, 4.000, 3.429, 3.357, _nan_, _nan_, _nan_],
+                    [_nan_, _nan_, 5.000, _nan_, _nan_, _nan_, _nan_],
                 ],
                 dtype=rad.dtype,
             ),
             decimal=3,
         )
+
+    def test_rectify_2x2_to_7x7_bilinear_interpol(self):
+        source_ds = self.new_2x2_dataset_with_irregular_coords()
+        # Add offset to "rad" so it's values do not lie on a plane
+        source_ds["rad"] = source_ds.rad + xr.DataArray(
+            np.array([[0.0, 0.0], [0.0, 1.0]]), dims=("y", "x")
+        )
+
+        target_gm = GridMapping.regular(
+            size=(7, 7), xy_min=(-0.5, 49.5), xy_res=1.0, crs=CRS_WGS84
+        )
+
+        target_ds = rectify_dataset(
+            source_ds, target_gm=target_gm, interpolation="bilinear"
+        )
+
+        lon, lat, rad = self._assert_shape_and_dim(target_ds, (7, 7))
+        np.testing.assert_almost_equal(
+            lon.values, np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=lon.dtype)
+        )
+        np.testing.assert_almost_equal(
+            lat.values,
+            np.array([56.0, 55.0, 54.0, 53.0, 52.0, 51.0, 50.0], dtype=lat.dtype),
+        )
+        np.testing.assert_almost_equal(
+            rad.values,
+            np.array(
+                [
+                    [_nan_, 1.000, _nan_, _nan_, _nan_, _nan_, _nan_],
+                    [_nan_, 1.488, 1.410, _nan_, _nan_, _nan_, _nan_],
+                    [_nan_, 1.994, 1.949, 1.858, 1.722, _nan_, _nan_],
+                    [_nan_, 2.520, 2.506, 2.448, 2.344, 2.195, 2.000],
+                    [3.000, 3.112, 3.163, 3.153, 3.082, _nan_, _nan_],
+                    [_nan_, 4.000, 4.041, 4.020, _nan_, _nan_, _nan_],
+                    [_nan_, _nan_, 5.000, _nan_, _nan_, _nan_, _nan_],
+                ],
+                dtype=rad.dtype,
+            ),
+            decimal=3,
+        )
+
+    def test_rectify_2x2_to_7x7_invalid_interpol(self):
+        source_ds = self.new_2x2_dataset_with_irregular_coords()
+
+        target_gm = GridMapping.regular(
+            size=(7, 7), xy_min=(-0.5, 49.5), xy_res=1.0, crs=CRS_WGS84
+        )
+
+        with pytest.raises(ValueError, match="invalid interpolation: 'bicubic'"):
+            rectify_dataset(source_ds, target_gm=target_gm, interpolation="bicubic")
 
     def test_rectify_2x2_to_7x7_subset(self):
         source_ds = self.new_2x2_dataset_with_irregular_coords()
@@ -761,7 +812,7 @@ class RectifyDatasetTest(SourceDatasetMixin, unittest.TestCase):
 
         target_rad = np.full((13, 13), np.nan, dtype=np.float64)
 
-        compute_var_image(source_ds.rad.values, dst_src_ij, target_rad)
+        compute_var_image(source_ds.rad.values, dst_src_ij, target_rad, 0)
 
         if not is_j_axis_up:
             np.testing.assert_almost_equal(

--- a/xcube/core/resampling/rectify.py
+++ b/xcube/core/resampling/rectify.py
@@ -33,7 +33,7 @@ from xcube.util.dask import compute_array_from_func
 from .cf import maybe_encode_grid_mapping
 
 
-_INTERPOLATIONS = {"nearest": 0, "linear": 1, "bilinear": 2}
+_INTERPOLATIONS = {"nearest": 0, "triangular": 1, "bilinear": 2}
 
 
 def rectify_dataset(
@@ -103,8 +103,8 @@ def rectify_dataset(
             defined by the input x,y coordinates. The higher this value,
             the more inaccurate the rectification will be.
         interpolation: Interpolation method for computing output pixels.
-            If given, must be "nearest", "linear", or "bilinear".
-            The default is "nearest". The "linear" interpolation is
+            If given, must be "nearest", "triangular", or "bilinear".
+            The default is "nearest". The "triangular" interpolation is
             performed between 3 and "bilinear" between 4 adjacent source
             pixels. Both are applied only to variables of
             floating point type. If you need to interpolate between
@@ -732,14 +732,14 @@ def _compute_var_image_for_dest_line(
         u = src_i_f - src_i0
         v = src_j_f - src_j0
         if interpolation == 0:
-            # nearest
+            # interpolation == "nearest"
             if u > 0.5:
                 src_i0 = _iclamp(src_i0 + 1, src_i_min, src_i_max)
             if v > 0.5:
                 src_j0 = _iclamp(src_j0 + 1, src_j_min, src_j_max)
             dst_var_value = src_var_image[..., src_j0, src_i0]
         elif interpolation == 1:
-            # linear
+            # interpolation == "triangular"
             src_i1 = _iclamp(src_i0 + 1, src_i_min, src_i_max)
             src_j1 = _iclamp(src_j0 + 1, src_j_min, src_j_max)
             value_01 = src_var_image[..., src_j0, src_i1]
@@ -759,7 +759,7 @@ def _compute_var_image_for_dest_line(
                     + (1.0 - v) * (value_01 - value_11)
                 )
         else:
-            # bilinear
+            # interpolation == "bilinear"
             src_i1 = _iclamp(src_i0 + 1, src_i_min, src_i_max)
             src_j1 = _iclamp(src_j0 + 1, src_j_min, src_j_max)
             value_00 = src_var_image[..., src_j0, src_i0]

--- a/xcube/core/resampling/spatial.py
+++ b/xcube/core/resampling/spatial.py
@@ -47,6 +47,7 @@ def resample_in_space(
     var_configs: Mapping[Hashable, Mapping[str, Any]] = None,
     encode_cf: bool = True,
     gm_name: Optional[str] = None,
+    rectify_kwargs: Optional[dict] = None,
 ):
     """
     Resample a dataset in the spatial dimensions.
@@ -149,7 +150,7 @@ def resample_in_space(
         # If the source is not regular, we need to rectify it,
         # so the target is regular. Our rectification implementation
         # works only correctly if source pixel size >= target pixel
-        # size. Therefore check if we must downscale source first.
+        # size. Therefore, check if we must downscale source first.
         x_scale = source_gm.x_res / target_gm.x_res
         y_scale = source_gm.y_res / target_gm.y_res
         if x_scale > _SCALE_LIMIT and y_scale > _SCALE_LIMIT:
@@ -161,6 +162,7 @@ def resample_in_space(
                 target_gm=target_gm,
                 encode_cf=encode_cf,
                 gm_name=gm_name,
+                **(rectify_kwargs or {})
             )
 
         # Source has higher resolution than target.
@@ -199,6 +201,7 @@ def resample_in_space(
             target_gm=target_gm,
             encode_cf=encode_cf,
             gm_name=gm_name,
+            **(rectify_kwargs or {})
         )
 
     # If CRSes are not both geographic and their CRSes are different


### PR DESCRIPTION
Enhanced spatial resampling in module `xcube.core.resampling`:

- Added optional keyword argument `interpolation` to `rectify_dataset()` with values `"nearest"`, `"linear"`, or `"bilinear"`. `"linear"` interpolates between 3 and `"bilinear"` between 4 adjacent source pixels. 
- Added optional keyword argument `rectify_kwargs` to `resample_in_space()`. If given, it is spread into keyword arguments passed to the internal `rectify_dataset()` delegation, if any.
- Deprecated unused keyword argument `xy_var_names` of function `rectify_dataset()`.

Closes #955

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~ (dedicated PR #957)
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
