### PR TITLE
Updates for xarray 2024.3.0 compatibility

### DIFF
--- a/.github/workflows/xcube_workflow.yaml
+++ b/.github/workflows/xcube_workflow.yaml
@@ -24,7 +24,9 @@ jobs:
           environment-file: environment.yml
           init-shell: >-
             bash
-          cache-environment: true
+          # Don't cache the environment, since this would prevent us from
+          # catching test failures caused by updated versions of dependencies.
+          cache-environment: false
           post-cleanup: 'all'
       # Setup xcube
       - name: setup-xcube

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
   Existing docstrings have been converted using the awesome [docconvert](https://github.com/cbillingham/docconvert) 
   tool.
 
+* Add a `data_vars_only` parameter to `chunk_dataset` and
+  `update_dataset_chunk_encoding` (#958).
+
+* Update some unit tests to make them compatible with xarray 2024.3.0 (#958).
 
 ## Changes in 1.4.1
 

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -80,7 +80,7 @@ class NewCubeDataTestMixin(unittest.TestCase):
         """open data un-packed (the default)"""
         data_1 = xr.open_zarr(self.path, mask_and_scale=True)
         self.assertEqual(np.float64, data_1.var_a.dtype)
-        self.assertEqual(np.float32, data_1.var_b.dtype)
+        self.assertEqual(np.float64, data_1.var_b.dtype)
         self.assertEqual(np.uint8, data_1.var_c.dtype)
         self.assertTrue(np.isnan(data_1.var_a[0, 0, 0]))
         self.assertEqual(8.5, data_1.var_a[1, 0, 0].values)
@@ -263,7 +263,7 @@ class FsDataStoresTestMixin(ABC):
             )
             # assert dtype is as expected
             self.assertEqual(np.float64, dataset.var_a.dtype)
-            self.assertEqual(np.float32, dataset.var_b.dtype)
+            self.assertEqual(np.float64, dataset.var_b.dtype)
             self.assertEqual(np.uint8, dataset.var_c.dtype)
             # assert dtype encoding is as expected
             self.assertEqual(np.float64, dataset.var_a.encoding.get("dtype"))

--- a/test/core/test_chunk.py
+++ b/test/core/test_chunk.py
@@ -7,6 +7,7 @@ from test.sampledata import new_test_dataset
 from xcube.core.chunk import chunk_dataset
 from xcube.core.chunk import compute_chunk_slices
 from xcube.core.chunk import get_empty_dataset_chunks
+from xcube.core.new import new_cube
 
 
 class ChunkDatasetTest(unittest.TestCase):
@@ -61,6 +62,45 @@ class ChunkDatasetTest(unittest.TestCase):
             {"chunks": (1, 10, 20)}, chunked_dataset.precipitation.encoding
         )
         self.assertEqual({"chunks": (1, 10, 20)}, chunked_dataset.temperature.encoding)
+
+    def test_chunk_dataset_data_vars_only(self):
+        cube = chunk_dataset(
+            new_cube(
+                time_periods=5,
+                time_freq="1D",
+                time_start="2019-01-01",
+                variables=dict(
+                    precipitation=0.1,
+                    temperature=270.5,
+                    soil_moisture=0.2),
+            ),
+            dict(time=1, lat=90, lon=90),
+            format_name="zarr",
+            data_vars_only=True
+        )
+        self.assertEqual((1, 90, 90), cube.precipitation.data.chunksize)
+        self.assertEqual(
+            {"chunks": (1, 90, 90)}, cube.precipitation.encoding
+        )
+        self.assertEqual((1, 90, 90), cube.precipitation.data.chunksize)
+        self.assertEqual(
+            {"chunks": (1, 90, 90)}, cube.temperature.encoding
+        )
+        self.assertEqual((1, 90, 90), cube.precipitation.data.chunksize)
+        self.assertEqual(
+            {"chunks": (1, 90, 90)}, cube.soil_moisture.encoding
+        )
+        self.assertIsNone(cube.lat.chunks)
+        self.assertEqual({}, cube.lat.encoding)
+        self.assertIsNone(cube.lon.chunks)
+        self.assertEqual({}, cube.lon.encoding)
+        self.assertIsNone(cube.lat_bnds.chunks)
+        self.assertEqual({}, cube.lat_bnds.encoding)
+        self.assertIsNone(cube.lon_bnds.chunks)
+        self.assertEqual({}, cube.lon_bnds.encoding)
+        self.assertIsNone(cube.time.chunks)
+        self.assertNotIn("chunks", cube.time.encoding)
+
 
     def test_unchunk_dataset(self):
         dataset = new_test_dataset(

--- a/test/core/test_timeslice.py
+++ b/test/core/test_timeslice.py
@@ -38,7 +38,8 @@ class TimeSliceTest(unittest.TestCase):
         cube = self.make_cube(start_date, num_days)
         cube.to_zarr(self.CUBE_PATH)
 
-    def make_cube(self, start_date, num_days: int) -> xr.Dataset:
+    @staticmethod
+    def make_cube(start_date, num_days: int) -> xr.Dataset:
         cube = new_cube(
             time_periods=num_days,
             time_freq="1D",
@@ -46,7 +47,9 @@ class TimeSliceTest(unittest.TestCase):
             variables=dict(precipitation=0.1, temperature=270.5, soil_moisture=0.2),
         )
         chunk_sizes = dict(time=1, lat=90, lon=90)
-        cube = chunk_dataset(cube, chunk_sizes, format_name="zarr")
+        cube = chunk_dataset(
+            cube, chunk_sizes, format_name="zarr", data_vars_only=True
+        )
         return cube
 
     def test_find_time_slice(self):

--- a/xcube/core/chunk.py
+++ b/xcube/core/chunk.py
@@ -8,7 +8,10 @@ from xcube.core.update import update_dataset_chunk_encoding
 
 
 def chunk_dataset(
-    dataset: xr.Dataset, chunk_sizes: Dict[str, int] = None, format_name: str = None
+    dataset: xr.Dataset,
+    chunk_sizes: Dict[str, int] = None,
+    format_name: str = None,
+    data_vars_only: bool = False,
 ) -> xr.Dataset:
     """Chunk *dataset* using *chunk_sizes* and optionally
     update encodings for given *format_name*.
@@ -17,14 +20,23 @@ def chunk_dataset(
         dataset: input dataset
         chunk_sizes: mapping from dimension name to new chunk size
         format_name: optional format, e.g. "zarr" or "netcdf4"
+        data_vars_only: only chunk data variables, not coordinates
 
     Returns:
         the (re)chunked dataset
     """
-    dataset = dataset.chunk(chunks=chunk_sizes)
+
+    if data_vars_only:
+        for variable in dataset.data_vars:
+            dataset[variable] = dataset[variable].chunk(chunk_sizes)
+    else:
+        dataset = dataset.chunk(chunks=chunk_sizes)
     if format_name:
         dataset = update_dataset_chunk_encoding(
-            dataset, chunk_sizes=chunk_sizes, format_name=format_name
+            dataset,
+            chunk_sizes=chunk_sizes,
+            format_name=format_name,
+            data_vars_only=data_vars_only,
         )
     return dataset
 

--- a/xcube/core/update.py
+++ b/xcube/core/update.py
@@ -234,6 +234,7 @@ def update_dataset_chunk_encoding(
     chunk_sizes: Dict[str, int] = None,
     format_name: str = None,
     in_place: bool = False,
+    data_vars_only: bool = False
 ) -> xr.Dataset:
     """Update each variable's encoding in *dataset* with respect to *chunk_sizes*
     so *dataset* is written in chunks for given *format_name*.
@@ -245,6 +246,7 @@ def update_dataset_chunk_encoding(
         format_name: format name, e.g. "zarr" or "netcdf4".
         in_place: If ``True``, *dataset* will be modified in place and
             returned.
+        data_vars_only: only chunk data variables, not coordinates
     """
     if format_name == FORMAT_NAME_ZARR:
         chunk_sizes_attr_name = "chunks"
@@ -254,7 +256,7 @@ def update_dataset_chunk_encoding(
         return dataset
     if not in_place:
         dataset = dataset.copy()
-    for var_name in dataset.variables:
+    for var_name in dataset.data_vars if data_vars_only else dataset.variables:
         var = dataset[var_name]
         if chunk_sizes is not None:
 


### PR DESCRIPTION
Closes #958.

- We now expect float64, not float32, when decoding and scaling variables from a Zarr. 
- Add `data_vars_only` parameter to `chunk_dataset` and `update_dataset_chunk_encoding`.
- Update `test_append_time_slice` to use `data_vars_only` parameter to ensure compatibility with xarray 2024.3.0.
- Disable mamba environment caching in GitHub workflow, since it prevents us from catching problems caused by dependency updates.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* ~[ ] New/modified features documented in `docs/source/*`~ n/a
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
