### PR TITLE
Replace use of deprecated method in testing module. (#961)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Changes in 1.4.2 (in development)
 
+* Replace use of deprecated method in testing module. (#961)
+
 * Update dependencies to better match imports; remove the defaults channel;
   turn adlfs into a soft dependency. (#945)
 

--- a/xcube/server/testing.py
+++ b/xcube/server/testing.py
@@ -30,7 +30,6 @@ from contextlib import closing
 from typing import Dict, Optional, Any, Union, Tuple
 
 import urllib3
-from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 from urllib3.exceptions import MaxRetryError
 
 from xcube.server.server import Server
@@ -53,7 +52,7 @@ class ServerTestCase(unittest.TestCase, ABC):
         config = self.get_config()
         config.update({"port": self.port, "address": "localhost"})
         self.add_config(config)
-        asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
+        asyncio.set_event_loop(asyncio.new_event_loop())
         er = self.get_extension_registry()
         self.add_extension(er)
         self.server = Server(


### PR DESCRIPTION
This PR fixes #961 .

Checklist:

* [ ] Add unit tests and/or doctests in docstrings - dna
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions - dna
* [ ] New/modified features documented in `docs/source/*` - dna
* [x] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
