### PR TITLE
Fixed xcube plugin auto-recognition in case a plugin project uses `pyproject.toml` file.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Changes in 1.5.2 (in development)
+
+* Update of xcube plugins auto-recognition when plugin uses `pyproject.toml'file (#963)
+
 ## Changes in 1.5.0
 
 * Enhanced spatial resampling in module `xcube.core.resampling` (#955): 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Changes in 1.5.2 (in development)
 
-* Update of xcube plugins auto-recognition when plugin uses `pyproject.toml'file (#963)
+* Fixed xcube plugin auto-recognition in case a plugin project
+  uses `pyproject.toml` file. (#963)
 
 ## Changes in 1.5.0
 

--- a/xcube/util/plugin.py
+++ b/xcube/util/plugin.py
@@ -83,9 +83,12 @@ def discover_plugin_modules(module_prefixes=None):
             # print(f'xcube plugin module found: {module_name}')
             entry_points.append(_ModuleEntryPoint(module_name))
 
-    # discover plugins if they are only installed in a editable mode
+    # discover plugins if they are installed in a editable mode (see PR #963)
     for module_prefix in module_prefixes:
-        for path_hook in fnmatch.filter(sys.path, f'__editable__.{module_prefix}*.finder.__path_hook__'):
+        for path_hook in fnmatch.filter(
+            sys.path,
+            f'__editable__.{module_prefix}*.finder.__path_hook__'
+        ):
             module_name = path_hook.split("-")[0].split(".")[1]
             entry_points.append(_ModuleEntryPoint(module_name))
 

--- a/xcube/util/plugin.py
+++ b/xcube/util/plugin.py
@@ -66,7 +66,8 @@ def discover_plugin_modules(module_prefixes=None):
             # print(f'xcube plugin module found: {module_name}')
             entry_points.append(_ModuleEntryPoint(module_name))
 
-    # discover plugins if they are installed in a editable mode (see PR #963)
+    # Discover plugins if they are installed in a editable mode.
+    # See https://github.com/xcube-dev/xcube/issues/963
     for module_prefix in module_prefixes:
         for path_hook in fnmatch.filter(
             sys.path,

--- a/xcube/util/plugin.py
+++ b/xcube/util/plugin.py
@@ -20,6 +20,7 @@
 # SOFTWARE.
 
 import abc
+import fnmatch
 import importlib
 import pkgutil
 import sys
@@ -81,6 +82,13 @@ def discover_plugin_modules(module_prefixes=None):
             #  but logging is not yet configured at this point.
             # print(f'xcube plugin module found: {module_name}')
             entry_points.append(_ModuleEntryPoint(module_name))
+
+    # discover plugins if they are only installed in a editable mode
+    for module_prefix in module_prefixes:
+        for path_hook in fnmatch.filter(sys.path, f'__editable__.{module_prefix}*.finder.__path_hook__'):
+            module_name = path_hook.split("-")[0].split(".")[1]
+            entry_points.append(_ModuleEntryPoint(module_name))
+
     return entry_points
 
 


### PR DESCRIPTION
Closes #963

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%) 
