### PR TITLE
Allow for user-defined color bars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changes in 1.5.2 (in development)
 
+* xcube server can now read SNAP color palette definition files (`*.cpd`) with
+  alpha values. (#932)
+
 
 ## Changes in 1.5.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## Changes in 1.5.2 (in development)
+
+
 ## Changes in 1.5.1
 
 * Embedded [xcube-viewer 1.1.1](https://github.com/xcube-dev/xcube-viewer/releases/tag/v1.1.1).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * xcube server can now read SNAP color palette definition files (`*.cpd`) with
   alpha values. (#932)
 
+* xcube server's tile API can now handle user-defined colormaps from xcube viewer.
 
 ## Changes in 1.5.1
 

--- a/test/util/test_cmaps.py
+++ b/test/util/test_cmaps.py
@@ -176,6 +176,20 @@ class ColormapRegistryTest(TestCase):
             matplotlib.colors.Normalize,
         )
 
+    def test_load_snap_cpd_colormap_with_alpha(self):
+        cmap_name = os.path.join(os.path.dirname(__file__), "transparent_red.cpd")
+        colormap = load_snap_cpd_colormap(cmap_name)
+        self.assertIsInstance(colormap, Colormap)
+        self.assertEqual("transparent_red", colormap.cm_name)
+        self.assertIsInstance(
+            colormap.cmap,
+            matplotlib.colors.LinearSegmentedColormap,
+        )
+        self.assertIsInstance(
+            colormap.norm,
+            matplotlib.colors.Normalize,
+        )
+
     def test_load_snap_cpd_colormap_invalid(self):
         cmap_name = os.path.join(
             os.path.dirname(__file__), "chl_DeM2_200_invalid_for_testing.cpd"

--- a/test/util/transparent_red.cpd
+++ b/test/util/transparent_red.cpd
@@ -1,0 +1,6 @@
+numPoints=2
+color0=255,0,0,0
+color1=255,0,0
+sample0=0.0
+sample1=0.5
+sample2=1.0

--- a/xcube/util/cmaps.py
+++ b/xcube/util/cmaps.py
@@ -2,9 +2,9 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-import ast
 import base64
 import io
+import json
 import os
 from abc import ABC, abstractmethod
 from functools import cached_property
@@ -443,7 +443,7 @@ def parse_cm_code(cm_code: str) -> Union[Tuple[str, Colormap], Tuple[None, None]
     # Note, if we get performance issues here, we should
     # cache cm_code -> colormap
     try:
-        user_color_map: Dict[str, Any] = ast.literal_eval(cm_code)
+        user_color_map: Dict[str, Any] = json.loads(cm_code)
         cm_name = user_color_map["name"]
         colors = user_color_map["colors"]
         return cm_name, Colormap(

--- a/xcube/version.py
+++ b/xcube/version.py
@@ -2,4 +2,4 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-version = "1.5.1"
+version = "1.5.2.dev0"

--- a/xcube/version.py
+++ b/xcube/version.py
@@ -2,4 +2,4 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-version = "1.5.2.dev0"
+version = "1.6.0.dev0"


### PR DESCRIPTION
Allow for user-defined color bars in xcube viewer.
Merge #971 first.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
