### PR TITLE
Mark ListS3BucketTest as not a test

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Changes in 1.5.2 (in development)
 
+* Make tests compatible with PyTest 8.2.0. (#973)
 
 ## Changes in 1.5.1
 

--- a/test/webapi/s3/test_listbucket.py
+++ b/test/webapi/s3/test_listbucket.py
@@ -31,6 +31,9 @@ class S3BucketTest(unittest.TestCase, metaclass=ABCMeta):
 
 
 class ListS3BucketTest(S3BucketTest, metaclass=ABCMeta):
+
+    __test__ = False
+
     @abstractmethod
     def list_bucket(self, bucket_dict, **kwargs):
         pass


### PR DESCRIPTION
PyTest 8.2.0 tries to instantiate all candidate test classes when collecting tests, which fails for the abstract ListS3BucketTest class. This commit adds a __test__ = False attribute to the ListS3BucketTest, which instructs PyTest to ignore it during test collection (see
https://docs.pytest.org/en/8.2.x/example/pythoncollection.html#customizing-test-collection ).

Closes #973.

Note for reviewers: GitHub unit tests are passing (and you can click through to the logs to confirm this). However, the GH actions check as a whole is hanging due to some time-out errors which are evidently unrelated to this PR. It's unclear to me at the moment whether this is a temporary Codecov problem or something we need to fix/update on our side, but in any case it will be easier to diagnose after this PR is merged (since at least then the test suite will be runnable without Codecov!).

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~ n/a
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~ n/a
* ~[ ] New/modified features documented in `docs/source/*`~ n/a
* [x] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
