### PR TITLE
refactored xcube workflow to build docker image only on release event

### DIFF
--- a/.github/workflows/xcube_workflow.yaml
+++ b/.github/workflows/xcube_workflow.yaml
@@ -51,6 +51,7 @@ jobs:
     name: build-docker-image
     # Only run if unittests succeed
     needs: unittest
+    if: ${{ github.event_name == 'release' }}
     steps:
       - name: git-checkout
         uses: actions/checkout@v4
@@ -64,98 +65,13 @@ jobs:
         run: |
           echo "TAG: ${{ steps.release.outputs.tag }}"
           echo "EVENT: ${{ github.event_name }}"
-      # commented out the below step to avoid building docker image for each
-      # commit to master, rather build and push the xcube docker image only on
-      # event type release
-      # Build and push docker image 'latest' to quay.io when the event is a 'push' and branch 'master'
-#      - uses: mr-smithers-excellent/docker-build-push@v5
-#        name: build-push-docker-image-latest
-#        if: ${{ github.event_name == 'push' && steps.release.outputs.tag == 'master'  }}
-#        with:
-#          image: ${{ env.ORG_NAME }}/${{ env.APP_NAME }}
-#          tags: master, latest
-#          registry: ${{ env.IMG_REG_NAME }}
-#          username: ${{ secrets.IMG_REG_USERNAME }}
-#          password: ${{ secrets.IMG_REG_PASSWORD }}
       # Build and push docker release to quay.io when the event is a 'release'
       - uses: mr-smithers-excellent/docker-build-push@v6
         name: build-push-docker-image-release
-        if: ${{ github.event_name == 'release' }}
         with:
           image: ${{ env.ORG_NAME }}/${{ env.APP_NAME }}
           tags: ${{ steps.release.outputs.tag }}
           registry: ${{ env.IMG_REG_NAME }}
           username: ${{ secrets.IMG_REG_USERNAME }}
           password: ${{ secrets.IMG_REG_PASSWORD }}
-  update-version:
-    runs-on: ubuntu-latest
-    needs: build-docker-image
-    name: update-xcube-tag
-    steps:
-      - name: Get installation token
-        id: get_installation_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.TOKEN_PROVIDER_APP_ID }}
-          private_key: ${{ secrets.TOKEN_PROVIDER_KEY }}
-          repository: bc-org/k8s-configs
-          # the installationId of the GitHub app we are using
-          installationId: 36950178
-      - name: git-checkout
-        uses: actions/checkout@v4
-      - name: checkout-k8s
-        run: |
-          git clone https://x-access-token:${{ steps.get_installation_token.outputs.token }}@github.com/bc-org/k8s-configs.git
-          mv k8s-configs k8s
-      - name: get-release-tag
-        id: release
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - name: deployment-phase
-        id: deployment-phase
-        uses: bc-org/gha-determine-phase@v0.1
-        with:
-          event_name: ${{ github.event_name }}
-          tag: ${{ steps.release.outputs.tag }}
-      - name: get-hash
-        id: get-hash
-        run: |
-          HASH=$(skopeo inspect docker://${{ env.IMG_REG_NAME }}/${{ env.ORG_NAME }}/${{ env.APP_NAME }}:${{ steps.release.outputs.tag }} | jq '.Digest')
-          if [[ "$HASH" == *"sha256"* ]]; then
-            echo ::set-output name=hash::$HASH
-          else
-            echo "No hash present. Using none as hash. This will use the version tag instead for deployment."
-            echo ::set-output name=hash::none
-          fi
-      - name: info
-        run: |
-          echo "Event: ${{ github.event_name }}"
-          echo "Deployment Stage: ${{ steps.deployment-phase.outputs.phase }}"
 
-          echo "Release Tag: ${{ steps.release.outputs.tag }}"
-          echo "Deployment Release Tag: ${{ steps.deployment-phase.outputs.tag }}"
-          echo "Deployment Digest: ${{ steps.get-hash.outputs.hash }}"
-      - name: set-version-tag-xcube-gen
-        uses: bc-org/update-application-version-tags@main
-        with:
-          app: ${{ env.APP_NAME }}
-          phase: ${{ steps.deployment-phase.outputs.phase }}
-          delimiter: ' '
-          tag: ${{ steps.deployment-phase.outputs.tag }}
-          hash: ${{ steps.get-hash.outputs.hash }}
-          working-directory: ./k8s/xcube-gen/helm
-      - name: cat-result
-        working-directory: ./k8s/xcube-gen/helm
-        run: |
-          head values-dev.yaml
-          head values-stage.yaml
-          head values-prod.yaml
-      - name: Pushes to another repository
-        # Don't run if run locally and should be ignored
-        if: ${{ steps.deployment-phase.outputs.phase != 'ignore' && !env.ACT }}
-        run: |
-          cd ./k8s
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git commit -am "${{ github.event.release }}. Set version to ${{ steps.release.outputs.tag }}."
-          git remote set-url origin https://x-access-token:${{ steps.get_installation_token.outputs.token }}@github.com/bc-org/k8s-configs.git
-          git push origin main

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 ## Changes in 1.6.0 (in development)
 
-* Refactored xcube workflow to build docker images only on release and deleted the 
-  update xcube tag job
+### Other changes
+
+*  Refactored xcube workflow to build docker images only on release and deleted the 
+  update xcube tag job.
 
 ### Enhancements
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changes in 1.6.0 (in development)
 
+* Refactored xcube workflow to build docker images only on release and deleted the 
+  update xcube tag job
+
 ### Enhancements
 
 * xcube server's tile API can now handle user-defined colormaps from xcube 


### PR DESCRIPTION
Refactored xcube workflow to build docker image only on release event and deleted update xcube tag job as it no longer required. Argocd image updater will be responsible for fetching the latest tag automatically.

Checklist:

* [ ] ~~Add unit tests and/or doctests in docstrings~~
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in `docs/source/*`~~
* [x] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] ~~Test coverage remains or increases (target 100%)~~
