### PR TITLE
Links added, which will be shown on the left side panel on the PyPI xcube-core webpage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,9 @@
   release. To install xcube via the `pip` tool use `pip install xcube-core`,  
   since the name "xcube" is already taken on PyPI by another software. (#982)
 
+* Add project urls and classifiers to `setup.py` which will be shown in the
+  left sidebar onthe [PyPI xcube-core](https://pypi.org/project/xcube-core/) webpage.
+
 ## Changes in 1.5.1
 
 * Embedded [xcube-viewer 1.1.1](https://github.com/xcube-dev/xcube-viewer/releases/tag/v1.1.1).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,8 +62,8 @@
   release. To install xcube via the `pip` tool use `pip install xcube-core`,  
   since the name "xcube" is already taken on PyPI by another software. (#982)
 
-* Add project urls and classifiers to `setup.py` which will be shown in the
-  left sidebar onthe [PyPI xcube-core](https://pypi.org/project/xcube-core/) webpage.
+* Add project urls and classifiers to `setup.py`, which will be shown in the
+  left sidebar on the [PyPI xcube-core](https://pypi.org/project/xcube-core/) webpage.
 
 ## Changes in 1.5.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,7 +62,7 @@
   release. To install xcube via the `pip` tool use `pip install xcube-core`,  
   since the name "xcube" is already taken on PyPI by another software. (#982)
 
-* Add project urls and classifiers to `setup.py`, which will be shown in the
+* Added project URLs and classifiers to `setup.py`, which will be shown in the
   left sidebar on the [PyPI xcube-core](https://pypi.org/project/xcube-core/) webpage.
 
 ## Changes in 1.5.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   # Python
   - python >=3.9
   # Required
+  - affine >=2.2
   - botocore >=1.34.51
   - cftime >=1.6.3
   - click >=8.0
@@ -20,7 +21,7 @@ dependencies:
   - jdcal >=1.4
   - jsonschema >=3.2
   - mashumaro
-  - matplotlib >=3.8.3
+  - matplotlib-base >=3.8.3
   - netcdf4 >=1.5
   - numba >=0.52
   - numcodecs >=0.12.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: xcube_test
+name: xcube
 channels:
   - conda-forge
 dependencies:

--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,10 @@
-name: xcube
+name: xcube_test
 channels:
   - conda-forge
 dependencies:
   # Python
   - python >=3.9
   # Required
-  - affine >=2.2
   - botocore >=1.34.51
   - cftime >=1.6.3
   - click >=8.0
@@ -21,12 +20,11 @@ dependencies:
   - jdcal >=1.4
   - jsonschema >=3.2
   - mashumaro
-  - matplotlib-base >=3.8.3
+  - matplotlib >=3.8.3
   - netcdf4 >=1.5
-  - numcodecs >=0.12.1
   - numba >=0.52
+  - numcodecs >=0.12.1
   - numpy >=1.16
-  - openssl
   - pandas >=1.3
   - pillow >=6.0
   - pyjwt >=1.7

--- a/setup.py
+++ b/setup.py
@@ -96,4 +96,32 @@ setup(
         ],
     },
     install_requires=requirements,
+    # these links will be shown in the left panel on PyPI
+    project_urls={
+        "documentation": "https://xcube.readthedocs.io/en/latest/",
+        "source": "https://github.com/xcube-dev/xcube",
+        "download": "https://pypi.org/project/xcube-core/#files",
+        "tracker": "https://github.com/xcube-dev/xcube/issues",
+        "release notes": "https://github.com/xcube-dev/xcube/releases"
+    },
+    # these classifiers will be shown in the left panel on PyPI
+    # they to not interfer with pip install and are meta data for the user
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Science/Research',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Topic :: Software Development',
+        'Topic :: Scientific/Engineering',
+        'Typing :: Typed',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX',
+        'Operating System :: Unix',
+        'Operating System :: MacOS',
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -27,36 +27,42 @@ from setuptools import setup, find_packages
 
 
 requirements = [
-    #
-    # xcube requirements are given in file ./environment.yml.
-    #
-    # All packages here have been commented out,
-    # because otherwise setuptools will install
-    # additional pip packages although conda packages
-    # with same name are already available
-    # in the conda environment defined by file ./environment.yml.
-    #
-    # 'affine',
-    # 'click',
-    # 'cmocean',
-    # 'dask',
-    # 'fiona',
-    # 'gdal',
-    # 'matplotlib',
-    # 'netcdf4',
-    # 'numba',
-    # 'numpy',
-    # 'pandas',
-    # 'pillow',
-    # 'proj4',
-    # 'pyyaml',
-    # 'rasterio',
-    # 's3fs',
-    # 'setuptools',
-    # 'shapely',
-    # 'tornado',
-    # 'xarray',
-    # 'zarr',
+    "botocore>=1.34.51",
+    "cftime>=1.6.3",
+    "click>=8.0",
+    "cmocean>=2.0",
+    "dask>=2021.6",
+    "dask-image>=0.6",
+    "deprecated>=1.2",
+    "distributed>=2021.6",
+    "fiona>=1.8",
+    "fsspec>=2021.6",
+    "gdal>=3.0",
+    "geopandas>=0.8",
+    "jdcal>=1.4",
+    "jsonschema>=3.2",
+    "mashumaro",
+    "matplotlib>=3.8.3",
+    "netcdf4>=1.5",
+    "numba>=0.52",
+    "numcodecs>=0.12.1",
+    "numpy>=1.16",
+    "pandas>=1.3",
+    "pillow>=6.0",
+    "pyjwt>=1.7",
+    "pyproj>=3.0",
+    "pyyaml>=5.4",
+    "rasterio>=1.2",
+    "requests>=2.25",
+    "rfc3339-validator>=0.1",
+    "rioxarray>=0.11",
+    "s3fs>=2021.6",
+    "setuptools>=41.0",
+    "shapely>=1.6",
+    "tornado>=6.0",
+    "urllib3>=1.26",
+    "xarray>=2022.6",
+    "zarr>=2.11"
 ]
 
 packages = find_packages(exclude=["test", "test.*"])
@@ -98,11 +104,12 @@ setup(
     install_requires=requirements,
     # these links will be shown in the left panel on PyPI
     project_urls={
-        "documentation": "https://xcube.readthedocs.io/en/latest/",
-        "source": "https://github.com/xcube-dev/xcube",
-        "download": "https://pypi.org/project/xcube-core/#files",
-        "tracker": "https://github.com/xcube-dev/xcube/issues",
-        "release notes": "https://github.com/xcube-dev/xcube/releases"
+        "Documentation": "https://xcube.readthedocs.io/en/latest/",
+        "Source": "https://github.com/xcube-dev/xcube",
+        "Download": "https://pypi.org/project/xcube-core/#files",
+        "Tracker": "https://github.com/xcube-dev/xcube/issues",
+        "Release notes": "https://github.com/xcube-dev/xcube/releases",
+        "Changelog": "https://github.com/xcube-dev/xcube/blob/main/CHANGES.md"
     },
     # these classifiers will be shown in the left panel on PyPI
     # they to not interfer with pip install and are meta data for the user


### PR DESCRIPTION
Links added to the left sidebar on [PyPI xcube-core](https://pypi.org/project/xcube-core/). Note that this will be available after the next release. As a example view [TestPyPI xcube-core](https://test.pypi.org/project/xcube/1.6.0.dev12/) 

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
