### PR TITLE
Used pyupgrade to automatically upgrade syntax for newer versions of the language

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,7 +91,7 @@
   left sidebar on the [PyPI xcube-core](https://pypi.org/project/xcube-core/) webpage.
 
 * Used [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade
-  syntax for newer versions of the language.  
+  language syntax for Python versions >= 3.9.  
 
 ## Changes in 1.5.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,9 @@
 * Added project URLs and classifiers to `setup.py`, which will be shown in the
   left sidebar on the [PyPI xcube-core](https://pypi.org/project/xcube-core/) webpage.
 
+* Used [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade
+  syntax for newer versions of the language.  
+
 ## Changes in 1.5.1
 
 * Embedded [xcube-viewer 1.1.1](https://github.com/xcube-dev/xcube-viewer/releases/tag/v1.1.1).

--- a/test/cli/helpers.py
+++ b/test/cli/helpers.py
@@ -18,20 +18,20 @@ TEST_ZARR_DIR = "test.zarr"
 
 
 class CliTest(unittest.TestCase, metaclass=ABCMeta):
-    def invoke_cli(self, args: List[str]):
+    def invoke_cli(self, args: list[str]):
         self.runner = click.testing.CliRunner(mix_stderr=False)
         # noinspection PyTypeChecker
         return self.runner.invoke(cli, args, catch_exceptions=False)
 
 
 class CliDataTest(CliTest, metaclass=ABCMeta):
-    def outputs(self) -> List[str]:
+    def outputs(self) -> list[str]:
         return []
 
     def time_periods(self) -> int:
         return 5
 
-    def chunks(self) -> Optional[Dict[str, int]]:
+    def chunks(self) -> Optional[dict[str, int]]:
         return None
 
     def setUp(self):

--- a/test/cli/test_compute.py
+++ b/test/cli/test_compute.py
@@ -13,7 +13,7 @@ OUTPUT_PATH = "out.zarr"
 
 
 class ComputeCliTest(CliDataTest):
-    def outputs(self) -> List[str]:
+    def outputs(self) -> list[str]:
         return [OUTPUT_PATH]
 
     def test_help_option(self):

--- a/test/cli/test_genpts.py
+++ b/test/cli/test_genpts.py
@@ -16,7 +16,7 @@ TEST_GEOJSON = os.path.join(os.path.dirname(__file__), "out.geojson")
 
 
 class GenptsCliTest(CliDataTest):
-    def outputs(self) -> List[str]:
+    def outputs(self) -> list[str]:
         return [TEST_CSV, TEST_GEOJSON]
 
     def test_help_option(self):

--- a/test/cli/test_grid.py
+++ b/test/cli/test_grid.py
@@ -96,7 +96,7 @@ class GridToolsTest(unittest.TestCase):
 
 class GridCliTest(unittest.TestCase):
     @classmethod
-    def invoke_cli(cls, args: List[str]):
+    def invoke_cli(cls, args: list[str]):
         runner = click.testing.CliRunner()
         return runner.invoke(cli, args)
 

--- a/test/cli/test_level.py
+++ b/test/cli/test_level.py
@@ -21,10 +21,10 @@ class LevelTest(CliTest):
 class LevelDataTest(CliDataTest):
     TEST_OUTPUT = "test.levels"
 
-    def outputs(self) -> List[str]:
+    def outputs(self) -> list[str]:
         return [LevelDataTest.TEST_OUTPUT, "my.levels"]
 
-    def chunks(self) -> Optional[Dict[str, int]]:
+    def chunks(self) -> Optional[dict[str, int]]:
         return dict(time=1, lat=90, lon=180)
 
     def test_all_defaults(self):
@@ -64,7 +64,7 @@ class LevelDataTest(CliDataTest):
         )
 
     def _assert_result_ok(
-        self, result, level_chunks: List[Tuple], output_path: str, message_regex: str
+        self, result, level_chunks: list[tuple], output_path: str, message_regex: str
     ):
         self.assertEqual(0, result.exit_code)
         self.assertRegex(result.stderr, message_regex)

--- a/test/cli/test_rectify.py
+++ b/test/cli/test_rectify.py
@@ -10,7 +10,7 @@ from xcube.core.verify import assert_cube
 
 
 class RectifyTest(CliDataTest):
-    def outputs(self) -> List[str]:
+    def outputs(self) -> list[str]:
         return ["out.zarr"]
 
     def test_rectify_without_vars(self):

--- a/test/cli/test_resample.py
+++ b/test/cli/test_resample.py
@@ -18,7 +18,7 @@ class ResampleTest(CliTest):
 
 
 class ResampleDataTest(CliDataTest):
-    def outputs(self) -> List[str]:
+    def outputs(self) -> list[str]:
         return ["out.zarr", "resampled.zarr"]
 
     def test_all_defaults(self):

--- a/test/core/byoa/test_data/user_code/impl/algorithm.py
+++ b/test/core/byoa/test_data/user_code/impl/algorithm.py
@@ -9,7 +9,7 @@ import xarray as xr
 
 
 def compute_chunk(
-    input_var_1: np.ndarray, input_var_2: np.ndarray, input_params: Dict[str, Any]
+    input_var_1: np.ndarray, input_var_2: np.ndarray, input_params: dict[str, Any]
 ) -> xr.Dataset:
     factor_1: float = input_params["factor_1"]
     factor_2: float = input_params["factor_2"]

--- a/test/core/diagnosticstore.py
+++ b/test/core/diagnosticstore.py
@@ -5,7 +5,8 @@
 import time
 from collections.abc import MutableMapping
 from types import MethodType
-from typing import TypeVar, Iterator, List, Callable, Any, Tuple
+from typing import TypeVar, List, Callable, Any, Tuple
+from collections.abc import Iterator
 
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
@@ -17,7 +18,7 @@ class DiagnosticStore(MutableMapping):
     def __init__(
         self,
         delegate: MutableMapping,
-        observer: Callable[[int, float, str, List[Tuple[str, Any]]], None] = None,
+        observer: Callable[[int, float, str, list[tuple[str, Any]]], None] = None,
     ):
         self._delegate = delegate
         self._observer = observer or logging_observer()
@@ -26,10 +27,10 @@ class DiagnosticStore(MutableMapping):
         self._add_optional_method("rmdir", ["path"])
         self._add_optional_method("rename", ["from_path", "to_path"])
 
-    def _add_optional_method(self, method_name: str, arg_names: List[str]):
+    def _add_optional_method(self, method_name: str, arg_names: list[str]):
         if hasattr(self._delegate, method_name):
 
-            def method(_self, *args) -> List[str]:
+            def method(_self, *args) -> list[str]:
                 return _self.call_and_notify(
                     method_name, *[(arg_names[i], args[i]) for i in range(len(args))]
                 )

--- a/test/core/gen/test_gen.py
+++ b/test/core/gen/test_gen.py
@@ -4,7 +4,8 @@
 
 import os
 import unittest
-from typing import Any, Dict, Optional, Sequence, Tuple
+from typing import Any, Dict, Optional, Tuple
+from collections.abc import Sequence
 
 import numpy as np
 import xarray as xr
@@ -731,7 +732,7 @@ class DefaultProcessTest(unittest.TestCase):
         self,
         cube: xr.Dataset,
         expected_time_dim: int,
-        expected_extra_attrs: Dict[str, Any],
+        expected_extra_attrs: dict[str, Any],
         expected_output_vars: Sequence[str] = ("analysed_sst",),
     ):
         self.assertEqual(
@@ -813,7 +814,7 @@ def gen_cube_wrapper(
     input_processor_name=None,
     processed_variables=None,
     output_variables=(("analysed_sst", None),),
-) -> Tuple[bool, Optional[str]]:
+) -> tuple[bool, Optional[str]]:
     output = None
 
     def output_monitor(msg):

--- a/test/core/gen2/local/test_generator.py
+++ b/test/core/gen2/local/test_generator.py
@@ -26,7 +26,7 @@ CALLBACK_MOCK_URL = "https://xcube-gen.test/api/v1/jobs/tomtom/iamajob/callback"
 
 
 class LocalCubeGeneratorTest(unittest.TestCase):
-    REQUEST: Dict[str, Any] = dict(
+    REQUEST: dict[str, Any] = dict(
         input_config=dict(store_id="memory", data_id="S2L2A.zarr"),
         cube_config=dict(
             variable_names=["B01", "B02", "B03"],

--- a/test/core/gen2/remote/server.py
+++ b/test/core/gen2/remote/server.py
@@ -30,15 +30,15 @@ from xcube.core.gen2.request import CubeGeneratorRequest
 from xcube.util.temp import new_temp_dir
 from xcube.util.temp import new_temp_file
 
-Job = Tuple[
+Job = tuple[
     subprocess.Popen,  # process
     str,  # result_path
     str,  # start_time
-    Dict[str, Any],  # updated state object
+    dict[str, Any],  # updated state object
 ]
 
 STORES_CONFIG_PATH: str = ""
-JOBS: Dict[str, Job] = {}
+JOBS: dict[str, Job] = {}
 
 app = flask.Flask("test.core.gen2.remote.server")
 
@@ -147,7 +147,7 @@ def _get_generate_cube_result(
     process: Optional[subprocess.Popen],
     result_path: Optional[str],
     job_id: Optional[str],
-) -> Tuple[Dict[str, Any], int]:
+) -> tuple[dict[str, Any], int]:
     global JOBS
 
     if process is not None:
@@ -203,7 +203,7 @@ def _get_generate_cube_result(
 
 
 def _get_set_status_code(
-    result_json: Dict[str, Any], success_code: int = 200, failure_code: int = 400
+    result_json: dict[str, Any], success_code: int = 200, failure_code: int = 400
 ) -> int:
     status_code = result_json.get("status_code")
     if status_code is None:

--- a/test/core/gen2/remote/test_generator.py
+++ b/test/core/gen2/remote/test_generator.py
@@ -22,8 +22,8 @@ def make_result(
     worked,
     total_work,
     failed=False,
-    output: List[str] = None,
-    job_result: Dict[str, Any] = None,
+    output: list[str] = None,
+    job_result: dict[str, Any] = None,
 ):
     json = {
         "job_id": "93",

--- a/test/core/gridmapping/test_cfconv.py
+++ b/test/core/gridmapping/test_cfconv.py
@@ -231,7 +231,7 @@ class XarrayDecodeCfTest(unittest.TestCase):
         self.assertVarNames({"noise", "crs", "lon", "lat"}, set(), decode_cf=False)
 
     def assertVarNames(
-        self, exp_data_vars: Set[str], exp_coords: Set[str], decode_cf: bool
+        self, exp_data_vars: set[str], exp_coords: set[str], decode_cf: bool
     ):
         ds1 = xr.open_zarr("noise.zarr", decode_cf=decode_cf)
         self.assertEqual(exp_coords, set(ds1.coords))

--- a/test/core/mldataset/test_fs.py
+++ b/test/core/mldataset/test_fs.py
@@ -5,7 +5,8 @@
 
 import math
 import unittest
-from typing import Optional, List, Mapping
+from typing import Optional, List
+from collections.abc import Mapping
 
 import fsspec
 import fsspec.core
@@ -85,10 +86,10 @@ class FsMultiLevelDatasetTest(unittest.TestCase):
         tile_size: Optional[int],
         use_saved_levels: bool,
         base_dataset_path: Optional[str],
-        expected_files: List[str],
+        expected_files: list[str],
         expected_num_levels: int,
         expected_agg_methods: Optional[Mapping[str, AggMethod]],
-        expected_tile_size: List[int],
+        expected_tile_size: list[int],
     ):
         fs = self.fs
         FsMultiLevelDataset.write_dataset(
@@ -105,7 +106,7 @@ class FsMultiLevelDatasetTest(unittest.TestCase):
         )
         self.assertTrue(fs.isdir(path))
         self.assertEqual(
-            set([f"/{path}/{f}" for f in expected_files]),
+            {f"/{path}/{f}" for f in expected_files},
             set(fs.listdir(path, detail=False)),
         )
 

--- a/test/core/resampling/test_rectify.py
+++ b/test/core/resampling/test_rectify.py
@@ -733,7 +733,7 @@ class RectifyDatasetTest(SourceDatasetMixin, unittest.TestCase):
 
     def _assert_shape_and_dim(
         self, target_ds, size, chunks=None, var_names=("rad",)
-    ) -> Tuple[xr.DataArray, ...]:
+    ) -> tuple[xr.DataArray, ...]:
         w, h = size
 
         self.assertIn("lon", target_ds)

--- a/test/core/store/fs/test_plugin.py
+++ b/test/core/store/fs/test_plugin.py
@@ -46,9 +46,9 @@ class FsDataStoreAndAccessorsPluginTest(unittest.TestCase):
     def test_find_data_store_extensions(self):
         extensions = find_data_store_extensions()
         self.assertTrue(len(extensions) >= len(expected_fs_store_ids))
-        self.assertEqual({"xcube.core.store"}, set(ext.point for ext in extensions))
+        self.assertEqual({"xcube.core.store"}, {ext.point for ext in extensions})
         self.assertTrue(
-            expected_fs_store_ids.issubset(set(ext.name for ext in extensions))
+            expected_fs_store_ids.issubset({ext.name for ext in extensions})
         )
         for ext in extensions:
             if ext.name not in expected_fs_store_ids:
@@ -70,10 +70,10 @@ class FsDataStoreAndAccessorsPluginTest(unittest.TestCase):
         extensions = find_data_opener_extensions()
         self.assertTrue(len(extensions) >= len(expected_fs_data_accessor_ids))
         self.assertEqual(
-            {"xcube.core.store.opener"}, set(ext.point for ext in extensions)
+            {"xcube.core.store.opener"}, {ext.point for ext in extensions}
         )
         self.assertTrue(
-            expected_fs_data_accessor_ids.issubset(set(ext.name for ext in extensions))
+            expected_fs_data_accessor_ids.issubset({ext.name for ext in extensions})
         )
         for ext in extensions:
             if ext.name not in expected_fs_data_accessor_ids:
@@ -89,10 +89,10 @@ class FsDataStoreAndAccessorsPluginTest(unittest.TestCase):
         extensions = find_data_writer_extensions()
         self.assertTrue(len(extensions) >= len(expected_fs_data_accessor_ids))
         self.assertEqual(
-            {"xcube.core.store.writer"}, set(ext.point for ext in extensions)
+            {"xcube.core.store.writer"}, {ext.point for ext in extensions}
         )
         self.assertTrue(
-            expected_fs_data_accessor_ids.issubset(set(ext.name for ext in extensions))
+            expected_fs_data_accessor_ids.issubset({ext.name for ext in extensions})
         )
         for ext in extensions:
             if ext.name not in expected_fs_data_accessor_ids:

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -325,13 +325,13 @@ class FsDataStoresTestMixin(ABC):
         data_store: FsDataStore,
         filename_ext: str,
         requested_dtype_alias: Optional[str],
-        expected_dtype_aliases: Set[str],
-        expected_return_type: Union[Type[xr.Dataset], Type[MultiLevelDataset]],
+        expected_dtype_aliases: set[str],
+        expected_return_type: Union[type[xr.Dataset], type[MultiLevelDataset]],
         expected_descriptor_type: Optional[
-            Union[Type[DatasetDescriptor], Type[MultiLevelDatasetDescriptor]]
+            Union[type[DatasetDescriptor], type[MultiLevelDatasetDescriptor]]
         ] = None,
-        write_params: Optional[Dict[str, Any]] = None,
-        open_params: Optional[Dict[str, Any]] = None,
+        write_params: Optional[dict[str, Any]] = None,
+        open_params: Optional[dict[str, Any]] = None,
         assert_data_ok: Optional[Callable[[Any], Any]] = None,
     ):
         """Call all DataStore operations to ensure data of type

--- a/test/core/store/fs/test_subset.py
+++ b/test/core/store/fs/test_subset.py
@@ -25,7 +25,7 @@ class FsStoreSubset:
 
         @classmethod
         @abstractmethod
-        def get_fs_root(cls) -> Tuple[fsspec.AbstractFileSystem, str]:
+        def get_fs_root(cls) -> tuple[fsspec.AbstractFileSystem, str]:
             pass
 
         @classmethod
@@ -151,7 +151,7 @@ class FsStoreSubset:
 
 class MemoryFsStoreSubsetTest(FsStoreSubset.CommonTest):
     @classmethod
-    def get_fs_root(cls) -> Tuple[fsspec.AbstractFileSystem, str]:
+    def get_fs_root(cls) -> tuple[fsspec.AbstractFileSystem, str]:
         fs = fsspec.get_filesystem_class("memory")()
         root = "xcube"
         fs.mkdirs(root, exist_ok=True)
@@ -166,7 +166,7 @@ class MemoryFsStoreSubsetTest(FsStoreSubset.CommonTest):
 
 class FileFsStoreSubsetTest(FsStoreSubset.CommonTest):
     @classmethod
-    def get_fs_root(cls) -> Tuple[fsspec.AbstractFileSystem, str]:
+    def get_fs_root(cls) -> tuple[fsspec.AbstractFileSystem, str]:
         return fsspec.get_filesystem_class("file")(), new_temp_dir()
 
     @classmethod
@@ -180,7 +180,7 @@ class FileFsStoreSubsetTest(FsStoreSubset.CommonTest):
 @unittest.skip("OSError: [Errno 5] Internal Server Error")
 class S3FsStoreSubsetTest(FsStoreSubset.CommonTest, S3Test):
     @classmethod
-    def get_fs_root(cls) -> Tuple[fsspec.AbstractFileSystem, str]:
+    def get_fs_root(cls) -> tuple[fsspec.AbstractFileSystem, str]:
         fs = fsspec.get_filesystem_class("s3")(**cls.get_storage_options())
         root = "xcube"
         fs.mkdirs(root, exist_ok=True)

--- a/test/core/store/ref/test_store.py
+++ b/test/core/store/ref/test_store.py
@@ -56,7 +56,7 @@ def create_ref_paths():
     return [cube_ref_path] + reference_file_paths
 
 
-def delete_ref_paths(ref_paths: List[str]):
+def delete_ref_paths(ref_paths: list[str]):
     fs = fsspec.filesystem("file")
     for ref_path in ref_paths:
         fs.delete(ref_path)
@@ -64,7 +64,7 @@ def delete_ref_paths(ref_paths: List[str]):
 
 # noinspection PyPep8Naming,PyUnresolvedReferences
 class KerchunkMixin:
-    ref_paths: List[str] = []
+    ref_paths: list[str] = []
 
     @classmethod
     def setUpClass(cls):

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -58,7 +58,7 @@ class NewDataDescriptorTest(unittest.TestCase):
     def assertExpectedDescriptor(
         self,
         descriptor: DataDescriptor,
-        expected_type: Type[DataDescriptor],
+        expected_type: type[DataDescriptor],
         expected_data_type_alias: str,
     ):
         self.assertIsInstance(descriptor, DatasetDescriptor)

--- a/test/core/test_chunkstore.py
+++ b/test/core/test_chunkstore.py
@@ -80,7 +80,7 @@ class ChunkStoreTest(unittest.TestCase):
 
 def gen_index_var(dims, shape, chunks, trace_store_calls: bool = False):
     # noinspection PyUnusedLocal
-    def get_chunk(cube_store: ChunkStore, name: str, index: Tuple[int, ...]) -> bytes:
+    def get_chunk(cube_store: ChunkStore, name: str, index: tuple[int, ...]) -> bytes:
         data = np.zeros(cube_store.chunks, dtype=np.uint64)
         data_view = data.ravel()
         if data_view.base is not data:
@@ -115,7 +115,7 @@ class LoggingStoreTest(unittest.TestCase):
         self.assertWriteOk(MutableLoggingStore(self.original_store))
 
     def setUp(self) -> None:
-        self.zattrs_value = bytes()
+        self.zattrs_value = b''
         self.original_store = MemoryStore()
         self.original_store.update({"chl/.zattrs": self.zattrs_value})
 
@@ -133,7 +133,7 @@ class LoggingStoreTest(unittest.TestCase):
         self.assertEqual({"chl/.zattrs"}, set(self.original_store.keys()))
 
     def assertWriteOk(self, logging_store: MutableLoggingStore):
-        zarray_value = bytes()
+        zarray_value = b''
         logging_store["chl/.zarray"] = zarray_value
         self.assertEqual(
             {"chl/.zattrs", "chl/.zarray"}, set(self.original_store.keys())

--- a/test/core/test_compute.py
+++ b/test/core/test_compute.py
@@ -32,9 +32,9 @@ class ComputeCubeTest(unittest.TestCase):
         calls = []
 
         def my_cube_func(
-            input_params: Dict[str, Any] = None,
-            dim_coords: Dict[str, np.ndarray] = None,
-            dim_ranges: Dict[str, Tuple[int, int]] = None,
+            input_params: dict[str, Any] = None,
+            dim_coords: dict[str, np.ndarray] = None,
+            dim_ranges: dict[str, tuple[int, int]] = None,
         ) -> CubeFuncOutput:
             nonlocal calls
             calls.append((input_params, dim_coords, dim_ranges))
@@ -72,9 +72,9 @@ class ComputeCubeTest(unittest.TestCase):
         def my_cube_func(
             analysed_sst: np.ndarray,
             analysis_error: np.ndarray,
-            input_params: Dict[str, Any] = None,
-            dim_coords: Dict[str, np.ndarray] = None,
-            dim_ranges: Dict[str, Tuple[int, int]] = None,
+            input_params: dict[str, Any] = None,
+            dim_coords: dict[str, np.ndarray] = None,
+            dim_ranges: dict[str, tuple[int, int]] = None,
         ) -> CubeFuncOutput:
             nonlocal calls
             calls.append(

--- a/test/core/test_dsio.py
+++ b/test/core/test_dsio.py
@@ -99,7 +99,7 @@ class MyDatasetIO(DatasetIO):
         return "test"
 
     @property
-    def modes(self) -> Set[str]:
+    def modes(self) -> set[str]:
         return set()
 
     def fitness(self, input_path: str, path_type: str = None) -> float:

--- a/test/core/test_maskset.py
+++ b/test/core/test_maskset.py
@@ -118,7 +118,7 @@ class MaskSetTest(unittest.TestCase):
         self,
         mask_set: MaskSet,
         mask_name: str,
-        expected_chunks: Tuple[Tuple[int, ...], ...] = None,
+        expected_chunks: tuple[tuple[int, ...], ...] = None,
     ):
         mask = getattr(mask_set, mask_name)
 

--- a/test/core/test_optimize.py
+++ b/test/core/test_optimize.py
@@ -5,7 +5,8 @@
 import os
 import os.path
 import unittest
-from typing import Set, Union, Sequence
+from typing import Set, Union
+from collections.abc import Sequence
 
 from xcube.constants import FORMAT_NAME_ZARR
 from xcube.core.chunk import chunk_dataset
@@ -230,7 +231,7 @@ class OptimizeDatasetTest(unittest.TestCase):
         self.assertEqual("Output path already exists.", f"{cm.exception}")
 
 
-def list_file_set(dir_path: str) -> Set[str]:
+def list_file_set(dir_path: str) -> set[str]:
     """Get set of all files in a directory and all of its sub-directories."""
     actual_files = set()
     for root, dirs, files in os.walk(dir_path):

--- a/test/core/test_select.py
+++ b/test/core/test_select.py
@@ -7,7 +7,8 @@ import json
 import math
 import unittest
 from collections.abc import MutableMapping
-from typing import Dict, KeysView, Iterator, Sequence, Any
+from typing import Dict, Any
+from collections.abc import KeysView, Iterator, Sequence
 
 import cftime
 import numpy as np
@@ -456,11 +457,11 @@ def new_virtual_dataset(
 
 
 class VirtualChunkStore(MutableMapping):
-    def __init__(self, entries: Dict[str, bytes] = None):
+    def __init__(self, entries: dict[str, bytes] = None):
         if entries:
-            self._entries: Dict[str, bytes] = dict(entries)
+            self._entries: dict[str, bytes] = dict(entries)
         else:
-            self._entries: Dict[str, bytes] = {
+            self._entries: dict[str, bytes] = {
                 ".zgroup": bytes(
                     json.dumps({"zarr_format": 2}, indent=2), encoding="utf-8"
                 ),
@@ -472,7 +473,7 @@ class VirtualChunkStore(MutableMapping):
         name: str,
         dims: Sequence[str],
         values: np.ndarray,
-        attrs: Dict[str, Any] = None,
+        attrs: dict[str, Any] = None,
     ):
         self._entries.update(
             self.get_array_entries_unchunked(name, dims, values, attrs=attrs)
@@ -517,8 +518,8 @@ class VirtualChunkStore(MutableMapping):
         name: str,
         dims: Sequence[str],
         values: np.ndarray,
-        attrs: Dict[str, Any] = None,
-    ) -> Dict[str, bytes]:
+        attrs: dict[str, Any] = None,
+    ) -> dict[str, bytes]:
         zarray = {
             "zarr_format": 2,
             "chunks": list(values.shape),
@@ -551,7 +552,7 @@ class VirtualChunkStore(MutableMapping):
         shape: Sequence[int],
         chunks: Sequence[int],
         value: float = None,
-    ) -> Dict[str, bytes]:
+    ) -> dict[str, bytes]:
         dtype = np.dtype("float64")
 
         zarray = {

--- a/test/core/test_tile2.py
+++ b/test/core/test_tile2.py
@@ -116,7 +116,7 @@ class ComputeTilesTest(Tile2Test, unittest.TestCase):
         )
 
         # Test data variables
-        tiles: List[np.ndarray] = []
+        tiles: list[np.ndarray] = []
         for var_name in ("var_a", "var_b", "var_c"):
             self.assertIn(var_name, dataset.data_vars)
             var = dataset[var_name]
@@ -134,7 +134,7 @@ class ComputeTilesTest(Tile2Test, unittest.TestCase):
             self.assertEqual(expected_size, len(var))
 
     def assert_tiles_ok(
-        self, expected_tile_w: int, expected_tile_h: int, actual_tiles: List[np.ndarray]
+        self, expected_tile_w: int, expected_tile_h: int, actual_tiles: list[np.ndarray]
     ):
         self.assertEqual(3, len(actual_tiles))
         for i in range(3):

--- a/test/core/test_timeseries.py
+++ b/test/core/test_timeseries.py
@@ -146,7 +146,7 @@ class GetTimeSeriesTest(unittest.TestCase):
         self,
         ts_ds: xr.Dataset,
         expected_max_number_of_observations: int = 0,
-        expected_var_names: Set = None,
+        expected_var_names: set = None,
     ):
         expected_var_names = expected_var_names or set()
         self.assertIsNotNone(ts_ds)
@@ -163,7 +163,7 @@ class GetTimeSeriesTest(unittest.TestCase):
         self.assert_variable_ok(ts_ds, "B_count", expected_var_names, self.ts_b_count)
         self.assert_variable_ok(ts_ds, "B_std", expected_var_names, self.ts_b_std)
 
-    def assert_variable_ok(self, ts_ds, name, expected_var_names: Set, expected_values):
+    def assert_variable_ok(self, ts_ds, name, expected_var_names: set, expected_values):
         if name in expected_var_names:
             self.assertIn(name, ts_ds)
             self.assertEqual(("time",), ts_ds[name].dims)

--- a/test/core/zarrstore/test_generic.py
+++ b/test/core/zarrstore/test_generic.py
@@ -924,7 +924,7 @@ class CommonZarrStoreTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.dtype = np.dtype(np.int16)
-        self.store: Dict[str, Any] = {
+        self.store: dict[str, Any] = {
             ".zgroup": dict_to_bytes(
                 {
                     "zarr_format": 2,

--- a/test/core/zarrstore/test_logging.py
+++ b/test/core/zarrstore/test_logging.py
@@ -12,7 +12,7 @@ from xcube.core.zarrstore import LoggingZarrStore
 
 class LoggingZarrStoreTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.zattrs_value = bytes()
+        self.zattrs_value = b''
         self.original_store = MemoryStore()
         self.original_store.update({"chl/.zattrs": self.zattrs_value})
 
@@ -34,7 +34,7 @@ class LoggingZarrStoreTest(unittest.TestCase):
     def test_write(self):
         logging_store = LoggingZarrStore(self.original_store)
 
-        zarray_value = bytes()
+        zarray_value = b''
         logging_store["chl/.zarray"] = zarray_value
         self.assertEqual(
             {"chl/.zattrs", "chl/.zarray"}, set(self.original_store.keys())

--- a/test/server/mocks.py
+++ b/test/server/mocks.py
@@ -4,15 +4,13 @@
 
 from typing import (
     Optional,
-    Sequence,
     Tuple,
     Dict,
     Any,
     Union,
     Callable,
-    Awaitable,
-    Mapping,
 )
+from collections.abc import Sequence, Awaitable, Mapping
 
 from tornado import concurrent
 
@@ -30,7 +28,7 @@ from xcube.server.framework import Framework
 from xcube.server.server import Server
 from xcube.util.extension import ExtensionRegistry
 
-ApiSpec = Union[Api, str, Tuple[str, Dict[str, Any]]]
+ApiSpec = Union[Api, str, tuple[str, dict[str, Any]]]
 
 ApiSpecs = Sequence[ApiSpec]
 

--- a/test/server/webservers/test_tornado.py
+++ b/test/server/webservers/test_tornado.py
@@ -4,16 +4,15 @@
 
 import unittest
 from typing import (
-    Sequence,
     Optional,
     Callable,
     Any,
-    Awaitable,
     Union,
     Tuple,
     Type,
     Dict,
 )
+from collections.abc import Sequence, Awaitable
 
 import pytest
 import tornado.httputil
@@ -431,10 +430,10 @@ class MockContext(Context):
         self._config = {}
 
     @property
-    def apis(self) -> Tuple[Api]:
+    def apis(self) -> tuple[Api]:
         return (self._api,)
 
-    def get_open_api_doc(self, include_all: bool = False) -> Dict[str, Any]:
+    def get_open_api_doc(self, include_all: bool = False) -> dict[str, Any]:
         return {}
 
     @property
@@ -443,7 +442,7 @@ class MockContext(Context):
         return self._config
 
     def get_api_ctx(
-        self, api_name: str, cls: Optional[Type[ApiContextT]] = None
+        self, api_name: str, cls: Optional[type[ApiContextT]] = None
     ) -> Optional[ApiContextT]:
         return self._api if api_name == "test" else None
 

--- a/test/util/test_cache.py
+++ b/test/util/test_cache.py
@@ -143,15 +143,15 @@ class TracingCacheStore(CacheStore):
         raise ValueError()
 
     def store_value(self, key, value):
-        self.trace += "store(%s, %s);" % (key, value)
+        self.trace += f"store({key}, {value});"
         return "S/" + value, 100 * len(value)
 
     def restore_value(self, key, stored_value):
-        self.trace += "restore(%s, %s);" % (key, stored_value)
+        self.trace += f"restore({key}, {stored_value});"
         return stored_value[2:]
 
     def discard_value(self, key, stored_value):
-        self.trace += "discard(%s, %s);" % (key, stored_value)
+        self.trace += f"discard({key}, {stored_value});"
 
 
 class CacheTest(unittest.TestCase):

--- a/test/util/test_jsonschema.py
+++ b/test/util/test_jsonschema.py
@@ -514,7 +514,7 @@ class JsonObjectSchemaTest(unittest.TestCase):
 
         Person = namedtuple("Person", ["name", "age", "deleted"])
 
-        def serialize(person: Person) -> Dict[str, Any]:
+        def serialize(person: Person) -> dict[str, Any]:
             return person._asdict()
 
         person_schema.serializer = serialize

--- a/test/util/test_progress.py
+++ b/test/util/test_progress.py
@@ -3,7 +3,7 @@
 # https://opensource.org/licenses/MIT.
 
 import unittest
-from typing import Sequence
+from collections.abc import Sequence
 
 import dask
 import dask.array.random

--- a/test/webapi/auth/test_context.py
+++ b/test/webapi/auth/test_context.py
@@ -6,7 +6,8 @@ import json
 import os
 import types
 import unittest
-from typing import Mapping, Any
+from typing import Any
+from collections.abc import Mapping
 
 import requests
 

--- a/test/webapi/compute/test_context.py
+++ b/test/webapi/compute/test_context.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import unittest
-from typing import Union, Mapping, Any
+from typing import Union, Any
+from collections.abc import Mapping
 
 from test.webapi.helpers import get_api_ctx
 from xcube.server.api import Context

--- a/test/webapi/compute/test_controllers.py
+++ b/test/webapi/compute/test_controllers.py
@@ -21,7 +21,7 @@ class ComputeControllersTest(unittest.TestCase):
 
     def test_get_compute_operations_entry(self):
         result = get_compute_operations(get_compute_ctx())
-        operations: List = result["operations"]
+        operations: list = result["operations"]
 
         operations_map = {op.get("operationId"): op for op in operations}
         self.assertIn("spatial_subset", operations_map)

--- a/test/webapi/datasets/test_context.py
+++ b/test/webapi/datasets/test_context.py
@@ -4,7 +4,8 @@
 
 import os.path
 import unittest
-from typing import Union, Mapping, Any
+from typing import Union, Any
+from collections.abc import Mapping
 
 import pytest
 import xarray as xr

--- a/test/webapi/helpers.py
+++ b/test/webapi/helpers.py
@@ -4,7 +4,8 @@
 
 import collections.abc
 import os
-from typing import Any, Mapping
+from typing import Any
+from collections.abc import Mapping
 from typing import Optional, Type, TypeVar
 from typing import Union
 
@@ -74,7 +75,7 @@ def get_server(
 
 def get_api_ctx(
     api_name: str,
-    api_ctx_cls: Type[T],
+    api_ctx_cls: type[T],
     server_config: Optional[Union[str, Mapping[str, Any]]] = None,
     framework: Optional[Framework] = None,
     extension_registry: Optional[ExtensionRegistry] = None,

--- a/test/webapi/ows/coverages/test_context.py
+++ b/test/webapi/ows/coverages/test_context.py
@@ -4,7 +4,8 @@
 
 
 import unittest
-from typing import Optional, Union, Mapping, Any
+from typing import Optional, Union, Any
+from collections.abc import Mapping
 
 from test.webapi.helpers import get_api_ctx
 from xcube.server.api import Context

--- a/test/webapi/ows/coverages/test_controllers.py
+++ b/test/webapi/ows/coverages/test_controllers.py
@@ -34,7 +34,7 @@ class CoveragesControllersTest(unittest.TestCase):
         path = Path(__file__).parent / "expected.json"
         # with open(path, mode="w") as fp:
         #    json.dump(result, fp, indent=2)
-        with open(path, mode="r") as fp:
+        with open(path) as fp:
             expected_result = json.load(fp)
         self.assertEqual(expected_result, result)
 

--- a/test/webapi/ows/stac/test_context.py
+++ b/test/webapi/ows/stac/test_context.py
@@ -4,7 +4,8 @@
 
 
 import unittest
-from typing import Optional, Union, Mapping, Any
+from typing import Optional, Union, Any
+from collections.abc import Mapping
 
 from test.webapi.helpers import get_api_ctx
 from xcube.server.api import Context

--- a/test/webapi/ows/stac/test_controllers.py
+++ b/test/webapi/ows/stac/test_controllers.py
@@ -152,7 +152,7 @@ EXPECTED_DATASETS_COLLECTION = {
 class StacControllersTest(unittest.TestCase):
     @functools.lru_cache
     def read_json(self, filename):
-        with open(Path(__file__).parent / filename, mode="r") as fp:
+        with open(Path(__file__).parent / filename) as fp:
             content = json.load(fp)
         return content
 
@@ -230,7 +230,7 @@ class StacControllersTest(unittest.TestCase):
         expected_item = self.read_json("stac-single-item.json")
         self.assertEqual("FeatureCollection", result["type"])
         self.assertEqual(
-            {"root", "self"}, set([link["rel"] for link in result["links"]])
+            {"root", "self"}, {link["rel"] for link in result["links"]}
         )
         self.assertLess(
             datetime.datetime.now().astimezone()

--- a/test/webapi/ows/stac/test_routes.py
+++ b/test/webapi/ows/stac/test_routes.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Any, Mapping
+from typing import Any
+from collections.abc import Mapping
 
 from xcube.webapi.ows.stac.config import DEFAULT_COLLECTION_ID
 from ...helpers import RoutesTestCase, get_res_test_dir

--- a/test/webapi/viewer/test_context.py
+++ b/test/webapi/viewer/test_context.py
@@ -4,7 +4,8 @@
 
 import collections.abc
 import unittest
-from typing import Optional, Union, Mapping, Any
+from typing import Optional, Union, Any
+from collections.abc import Mapping
 
 from test.webapi.helpers import get_api_ctx
 from xcube.webapi.viewer.context import ViewerContext

--- a/test/webapi/viewer/test_viewer.py
+++ b/test/webapi/viewer/test_viewer.py
@@ -4,7 +4,8 @@
 
 import os
 import unittest
-from typing import Optional, Mapping, Any
+from typing import Optional, Any
+from collections.abc import Mapping
 
 import pytest
 

--- a/xcube/cli/common.py
+++ b/xcube/cli/common.py
@@ -4,7 +4,8 @@
 
 import logging
 import sys
-from typing import Dict, Any, Optional, Union, Sequence, Type, Tuple
+from typing import Dict, Any, Optional, Union, Type, Tuple
+from collections.abc import Sequence
 
 import click
 
@@ -156,7 +157,7 @@ def cli_option_scheduler(func):
     )(func)
 
 
-def parse_cli_kwargs(value: str, metavar: str = None) -> Dict[str, Any]:
+def parse_cli_kwargs(value: str, metavar: str = None) -> dict[str, Any]:
     """Parse a string value of the form [<kw>=<arg>{,<kw>=<arg>}] into a dictionary.
     <kw> must be a valid Python identifier, <arg> must be a Python literal.
 
@@ -193,8 +194,8 @@ def parse_cli_sequence(
     num_items_min: int = None,
     num_items_max: int = None,
     separator: str = ",",
-    error_type: Type[Exception] = click.ClickException,
-) -> Optional[Tuple[Any, ...]]:
+    error_type: type[Exception] = click.ClickException,
+) -> Optional[tuple[Any, ...]]:
     """Parse a CLI argument that is supposed to be a sequence.
 
     Args:

--- a/xcube/cli/compute.py
+++ b/xcube/cli/compute.py
@@ -66,7 +66,7 @@ DEFAULT_OUTPUT_PATH = "out.zarr"
 )
 def compute(
     script: str,
-    cube: List[str],
+    cube: list[str],
     input_var_names: str,
     input_params: str,
     output_path: str,
@@ -142,7 +142,7 @@ def compute(
     initialize_function_name = "initialize"
     finalize_function_name = "finalize"
 
-    with open(script, "r") as fp:
+    with open(script) as fp:
         code = fp.read()
 
     locals_dict = dict()

--- a/xcube/cli/gen.py
+++ b/xcube/cli/gen.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import List, Sequence
+from typing import List
+from collections.abc import Sequence
 
 import click
 
@@ -188,7 +189,7 @@ def _format_info():
     return help_text
 
 
-def _format_input_processors(input_processors: List[Extension]):
+def _format_input_processors(input_processors: list[Extension]):
     help_text = ""
     for input_processor in input_processors:
         name = input_processor.name
@@ -198,7 +199,7 @@ def _format_input_processors(input_processors: List[Extension]):
     return help_text
 
 
-def _format_dataset_ios(dataset_ios: List[Extension]):
+def _format_dataset_ios(dataset_ios: list[Extension]):
     help_text = ""
     for ds_io in dataset_ios:
         name = ds_io.name

--- a/xcube/cli/gen2.py
+++ b/xcube/cli/gen2.py
@@ -126,7 +126,7 @@ def gen2(
 
     error = None
 
-    result: Dict[str, Any]
+    result: dict[str, Any]
 
     # noinspection PyBroadException
     try:

--- a/xcube/cli/grid.py
+++ b/xcube/cli/grid.py
@@ -31,7 +31,7 @@ def find_close_resolutions(
     min_level: int = _DEFAULT_MIN_LEVEL,
     int_inv_res: bool = False,
     sort_by: str = _DEFAULT_SORT_BY,
-) -> List[Tuple]:
+) -> list[tuple]:
     if target_res <= 0.0:
         raise ValueError("illegal target_res")
     if delta_res < 0.0 or delta_res >= target_res:
@@ -119,7 +119,7 @@ def find_close_resolutions(
 
 def get_levels(
     height: int, coverage: Union[int, fractions.Fraction], level_min: int = None
-) -> List[Tuple]:
+) -> list[tuple]:
     res = coverage / fractions.Fraction(height)
     height_0, level = factor_out_two(height)
     data = []
@@ -139,7 +139,7 @@ def get_levels(
 
 def get_adjusted_box(
     x1: float, y1: float, x2: float, y2: float, res: float
-) -> Tuple[float, float, float, float]:
+) -> tuple[float, float, float, float]:
     # TODO: clamp values
     adj_x1 = res * math.floor(x1 / res)
     adj_y1 = res * math.floor(y1 / res)
@@ -164,7 +164,7 @@ def _round(x: float, n: int) -> float:
     return round(n * x) / n
 
 
-def factor_out_two(x: int) -> Tuple[int, int]:
+def factor_out_two(x: int) -> tuple[int, int]:
     if x < 0:
         raise ValueError("x must not be negative")
     if x == 0:
@@ -386,7 +386,7 @@ def adjust_box(
     (Geometry WKT and GeoJSON support may be added later.)
     """
     try:
-        x1, y1, x2, y2 = [float(c) for c in geom.split(",")]
+        x1, y1, x2, y2 = (float(c) for c in geom.split(","))
     except (ValueError, TypeError) as e:
         raise click.ClickException(f"Invalid GEOM: {geom}") from e
 
@@ -440,7 +440,7 @@ def adjust_box(
 
 def _fetch_height_and_coverage_from_options(
     res_str: Optional[str], height: Optional[int], coverage_str: str
-) -> Tuple[int, fractions.Fraction]:
+) -> tuple[int, fractions.Fraction]:
     coverage = _fetch_coverage_from_option(coverage_str)
     if res_str is not None:
         if height is not None:

--- a/xcube/cli/io.py
+++ b/xcube/cli/io.py
@@ -4,7 +4,8 @@
 
 import json
 import sys
-from typing import List, Sequence, Optional, Dict, AbstractSet, Set, Any
+from typing import List, Optional, Dict, AbstractSet, Set, Any
+from collections.abc import Sequence
 
 import click
 
@@ -70,7 +71,7 @@ def writer_list():
 )
 def store_info(
     store_id: str,
-    store_params: List[str],
+    store_params: list[str],
     show_params: bool,
     show_openers: bool,
     show_writers: bool,
@@ -148,7 +149,7 @@ def store_info(
 @click.argument("store_id", metavar="STORE")
 @click.argument("data_id", metavar="DATA")
 @click.argument("store_params", metavar="PARAMS", nargs=-1)
-def store_data(store_id: str, data_id: str, store_params: List[str]):
+def store_data(store_id: str, data_id: str, store_params: list[str]):
     """Show data resource information.
 
     Show the data descriptor for data resource DATA in data store STORE.
@@ -494,7 +495,7 @@ def _get_store_data_var_tuples(store_pool, data_type, include_props, exclude_pro
 
         print(
             f'Done generating entries for store "{store_instance_id}" after '
-            + "{:.2f} seconds".format(time.perf_counter() - t0)
+            + f"{time.perf_counter() - t0:.2f} seconds"
         )
 
     # yield Terminator
@@ -502,11 +503,11 @@ def _get_store_data_var_tuples(store_pool, data_type, include_props, exclude_pro
 
 
 def _filter_dict(
-    data: Dict[str, Any],
+    data: dict[str, Any],
     selector: str,
-    include_props: Dict[str, Set[str]] = None,
-    exclude_props: Dict[str, Set[str]] = None,
-) -> Dict[str, Any]:
+    include_props: dict[str, set[str]] = None,
+    exclude_props: dict[str, set[str]] = None,
+) -> dict[str, Any]:
     includes = (
         (include_props.get(selector) or None) if include_props is not None else None
     )
@@ -523,7 +524,7 @@ def _filter_dict(
     }
 
 
-def _parse_props(props: str) -> Dict[str, AbstractSet]:
+def _parse_props(props: str) -> dict[str, AbstractSet]:
     parsed_props = dict(store=set(), data=set(), var=set())
     for p in props.split(","):
         try:
@@ -706,7 +707,7 @@ def _dump_data_resources(data_store: "xcube.core.store.DataStore") -> int:
 
 # noinspection PyUnresolvedReferences
 def _new_data_store(
-    store_id: str, store_params: List[str]
+    store_id: str, store_params: list[str]
 ) -> "xcube.core.store.DataStore":
     from xcube.core.store import get_data_store_params_schema
     from xcube.core.store import new_data_store

--- a/xcube/cli/level.py
+++ b/xcube/cli/level.py
@@ -194,7 +194,7 @@ def level(
     )
 
 
-def _split_protocol_and_path(path) -> Tuple[str, str]:
+def _split_protocol_and_path(path) -> tuple[str, str]:
     if "://" in path:
         protocol, path = path.split("://", 2)
         if protocol == "https":

--- a/xcube/cli/patch.py
+++ b/xcube/cli/patch.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import warnings
-from typing import Dict, Any, MutableMapping
+from typing import Dict, Any
+from collections.abc import MutableMapping
 
 import click
 
@@ -113,8 +114,8 @@ def load_storage_options(options_path):
 
 def patch_dataset(
     dataset_path: str,
-    storage_options: Dict[str, Any],
-    metadata: Dict[str, Any],
+    storage_options: dict[str, Any],
+    metadata: dict[str, Any],
     dry_run: bool,
 ):
     if dataset_path.endswith(".levels"):
@@ -130,8 +131,8 @@ def patch_dataset(
 
 def _patch_dataset(
     dataset_path: str,
-    storage_options: Dict[str, Any],
-    metadata: Dict[str, Any],
+    storage_options: dict[str, Any],
+    metadata: dict[str, Any],
     dry_run: bool,
 ):
     import zarr
@@ -180,13 +181,13 @@ def _patch_dataset(
 
 
 def _open_zarr_store(
-    dataset_path: str, storage_options: Dict[str, Any]
+    dataset_path: str, storage_options: dict[str, Any]
 ) -> MutableMapping[str, bytes]:
     fs, root = get_fs_and_root(dataset_path, storage_options)
     return fs.get_mapper(root=root)
 
 
-def get_fs_and_root(dataset_path: str, storage_options: Dict[str, Any]):
+def get_fs_and_root(dataset_path: str, storage_options: dict[str, Any]):
     import fsspec
 
     protocol, root = fsspec.core.split_protocol(dataset_path)

--- a/xcube/cli/rectify.py
+++ b/xcube/cli/rectify.py
@@ -4,7 +4,8 @@
 
 import functools
 import operator
-from typing import Sequence, Optional, Tuple
+from typing import Optional, Tuple
+from collections.abc import Sequence
 
 import click
 
@@ -197,13 +198,13 @@ def rectify(
 
 def _rectify(
     input_path: str,
-    xy_names: Optional[Tuple[str, str]],
+    xy_names: Optional[tuple[str, str]],
     var_names: Optional[Sequence[str]],
     output_path: str,
     output_format: Optional[str],
-    output_size: Optional[Tuple[int, int]],
-    output_tile_size: Optional[Tuple[int, int]],
-    output_point: Optional[Tuple[float, float]],
+    output_size: Optional[tuple[int, int]],
+    output_tile_size: Optional[tuple[int, int]],
+    output_point: Optional[tuple[float, float]],
     output_res: Optional[float],
     output_crs: Optional[str],
     delta: float,

--- a/xcube/cli/resample.py
+++ b/xcube/cli/resample.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import warnings
-from typing import Sequence, Dict, Any
+from typing import Dict, Any
+from collections.abc import Sequence
 
 import click
 
@@ -205,7 +206,7 @@ def resample(
 def _resample_in_time(
     input_path: str = None,
     variables: Sequence[str] = None,
-    metadata: Dict[str, Any] = None,
+    metadata: dict[str, Any] = None,
     output_path: str = DEFAULT_OUTPUT_PATH,
     output_format: str = None,
     methods: Sequence[str] = (DEFAULT_RESAMPLING_METHOD,),

--- a/xcube/cli/serve.py
+++ b/xcube/cli/serve.py
@@ -138,7 +138,7 @@ def serve(
     framework_name: str,
     port: int,
     address: str,
-    config_paths: List[str],
+    config_paths: list[str],
     base_dir: Optional[str],
     url_prefix: Optional[str],
     reverse_url_prefix: Optional[str],
@@ -149,7 +149,7 @@ def serve(
     open_viewer: bool,
     quiet: bool,
     verbosity: int,
-    paths: List[str],
+    paths: list[str],
 ):
     """Run the xcube Server for the given configuration and/or the given
     raster dataset paths given by PATHS.
@@ -231,7 +231,7 @@ def serve(
         config["trace_perf"] = trace_perf
 
     if paths:
-        data_stores: Dict[Path, Dict[str, Any]] = dict()
+        data_stores: dict[Path, dict[str, Any]] = dict()
         for path in paths:
             if Path(path).exists():
                 path = Path(path)
@@ -279,8 +279,8 @@ def serve(
 
 
 def _add_dir_to_data_stores(
-    data_stores: Dict[Path, Dict[str, Any]], dir_path: Path
-) -> Dict[str, Any]:
+    data_stores: dict[Path, dict[str, Any]], dir_path: Path
+) -> dict[str, Any]:
     root = dir_path.resolve().absolute()
     if root in data_stores:
         data_store = data_stores[root]
@@ -291,7 +291,7 @@ def _add_dir_to_data_stores(
     return data_store
 
 
-def _add_path_to_data_stores(data_stores: Dict[Path, Dict[str, Any]], path: Path):
+def _add_path_to_data_stores(data_stores: dict[Path, dict[str, Any]], path: Path):
     path = path.resolve().absolute()
     data_store = _add_dir_to_data_stores(data_stores, path.parent)
     if "Datasets" in data_store:

--- a/xcube/core/ancvar.py
+++ b/xcube/core/ancvar.py
@@ -17,7 +17,7 @@ def find_ancillary_var_names(
     var_name: str,
     same_shape: bool = False,
     same_dims: bool = False,
-) -> Dict[str, Set[str]]:
+) -> dict[str, set[str]]:
     variable = dataset.data_vars.get(var_name)
 
     results = {}

--- a/xcube/core/byoa/config.py
+++ b/xcube/core/byoa/config.py
@@ -56,7 +56,7 @@ class CodeConfig(JsonObject):
         self,
         _callable: Callable = None,
         callable_ref: str = None,
-        callable_params: Dict[str, Any] = None,
+        callable_params: dict[str, Any] = None,
         inline_code: str = None,
         file_set: FileSet = None,
         install_required: bool = None,
@@ -110,7 +110,7 @@ class CodeConfig(JsonObject):
         *code: Union[str, Callable],
         callable_name: str = None,
         module_name: str = None,
-        callable_params: Dict[str, Any] = None,
+        callable_params: dict[str, Any] = None,
     ) -> "CodeConfig":
         """Create a code configuration from the given *code* which may be
         given as one or more plain text strings or callables.
@@ -145,7 +145,7 @@ class CodeConfig(JsonObject):
 
     @classmethod
     def from_callable(
-        cls, _callable: Callable, callable_params: Optional[Dict[str, Any]] = None
+        cls, _callable: Callable, callable_params: Optional[dict[str, Any]] = None
     ) -> "CodeConfig":
         """Create a code configuration from the callable *_callable*.
 
@@ -173,7 +173,7 @@ class CodeConfig(JsonObject):
         cls,
         file_set: Union[FileSet, str, Any],
         callable_ref: str,
-        callable_params: Optional[Dict[str, Any]] = None,
+        callable_params: Optional[dict[str, Any]] = None,
         install_required: Optional[bool] = None,
     ) -> "CodeConfig":
         """Create a code configuration from a file set.
@@ -210,7 +210,7 @@ class CodeConfig(JsonObject):
         gh_tag: str,
         gh_release: str,
         callable_ref: str,
-        callable_params: Optional[Dict[str, Any]] = None,
+        callable_params: Optional[dict[str, Any]] = None,
         gh_username: Optional[str] = None,
         gh_token: Optional[str] = None,
     ):
@@ -462,7 +462,7 @@ def _next_user_module_name() -> str:
 
 
 def _callable_to_module(
-    _callable: Callable, callable_params: Dict[str, Any] = None
+    _callable: Callable, callable_params: dict[str, Any] = None
 ) -> CodeConfig:
     """Create a code configuration from the callable *_callable*.
 
@@ -512,7 +512,7 @@ def _callable_to_module(
 
 
 def _inline_code_to_module(
-    inline_code: str, callable_ref: str, callable_params: Dict[str, Any] = None
+    inline_code: str, callable_ref: str, callable_params: dict[str, Any] = None
 ):
     module_name, callable_name = _normalize_callable_ref(callable_ref)
     dir_path = new_temp_dir(prefix=TEMP_FILE_PREFIX)
@@ -532,10 +532,10 @@ def _normalize_file_set(file_set: Union[FileSet, str, Any]) -> FileSet:
 
 
 def _normalize_inline_code(
-    code: Tuple[Union[str, Callable], ...],
+    code: tuple[Union[str, Callable], ...],
     callable_name: str = None,
     module_name: str = None,
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     if not callable_name:
         first_callable = next(filter(callable, code), None)
         if first_callable is not None:
@@ -552,7 +552,7 @@ def _normalize_inline_code(
     return inline_code, f"{module_name}:{callable_name}"
 
 
-def _normalize_callable_ref(callable_ref: str) -> Tuple[Optional[str], str]:
+def _normalize_callable_ref(callable_ref: str) -> tuple[Optional[str], str]:
     """Normalize a callable reference *callable_ref* of the form
     "[module_name:]callable_name" into a pair.
     """
@@ -560,7 +560,7 @@ def _normalize_callable_ref(callable_ref: str) -> Tuple[Optional[str], str]:
 
     splits = callable_ref.split(":")
     if len(splits) == 2:
-        module_name, callable_name = [s.strip() for s in splits]
+        module_name, callable_name = (s.strip() for s in splits)
     else:
         module_name, callable_name = "", ""
 

--- a/xcube/core/byoa/fileset.py
+++ b/xcube/core/byoa/fileset.py
@@ -6,7 +6,8 @@ import fnmatch
 import os.path
 import re
 import zipfile
-from typing import Any, Dict, Optional, List, Collection, Iterator, Union
+from typing import Any, Dict, Optional, List, Union
+from collections.abc import Collection, Iterator
 
 import fsspec
 import fsspec.implementations.zip
@@ -42,7 +43,7 @@ class _FileSetDetails:
         self._mapper: Optional[fsspec.FSMap] = None
 
     @classmethod
-    def new(cls, path: str, storage_params: Dict[str, Any] = None) -> "_FileSetDetails":
+    def new(cls, path: str, storage_params: dict[str, Any] = None) -> "_FileSetDetails":
         try:
             fs, root = fsspec.core.url_to_fs(path, **(storage_params or {}))
         except (ImportError, OSError) as e:
@@ -128,7 +129,7 @@ class FileSet(JsonObject):
         sub_path: str = None,
         includes: Collection[str] = None,
         excludes: Collection[str] = None,
-        storage_params: Dict[str, Any] = None,
+        storage_params: dict[str, Any] = None,
     ):
         assert_instance(path, str, "path")
         assert_given(path, "path")
@@ -174,19 +175,19 @@ class FileSet(JsonObject):
         return self._sub_path
 
     @property
-    def storage_params(self) -> Optional[Dict[str, Any]]:
+    def storage_params(self) -> Optional[dict[str, Any]]:
         """Get optional parameters for the file system
         :attribute:path is referring to.
         """
         return self._storage_params
 
     @property
-    def includes(self) -> Optional[List[str]]:
+    def includes(self) -> Optional[list[str]]:
         """Wildcard patterns used to include a file."""
         return self._includes
 
     @property
-    def excludes(self) -> Optional[List[str]]:
+    def excludes(self) -> Optional[list[str]]:
         """Wildcard patterns used to exclude a file."""
         return self._excludes
 
@@ -395,7 +396,7 @@ class FileSet(JsonObject):
         return self._get_details().fs
 
 
-def _key_matches(key: str, patterns: List[re.Pattern], empty_value: bool) -> bool:
+def _key_matches(key: str, patterns: list[re.Pattern], empty_value: bool) -> bool:
     if not patterns:
         return empty_value
     for pattern in patterns:
@@ -404,7 +405,7 @@ def _key_matches(key: str, patterns: List[re.Pattern], empty_value: bool) -> boo
     return False
 
 
-def _translate_patterns(patterns: Optional[Collection[str]]) -> List[re.Pattern]:
+def _translate_patterns(patterns: Optional[Collection[str]]) -> list[re.Pattern]:
     return [
         re.compile(fnmatch.translate(np))
         for p in patterns
@@ -423,7 +424,7 @@ def _normalize_sub_path(sub_path: str) -> str:
     return sub_path or ""
 
 
-def _normalize_pattern(pattern: str) -> List[str]:
+def _normalize_pattern(pattern: str) -> list[str]:
     pattern = pattern.replace(os.path.sep, "/")
     start_sep = pattern.startswith("/")
     end_sep = pattern.endswith("/")

--- a/xcube/core/chunk.py
+++ b/xcube/core/chunk.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import itertools
-from typing import Dict, Tuple, Iterable, Iterator
+from typing import Dict, Tuple
+from collections.abc import Iterable, Iterator
 
 import numpy as np
 import xarray as xr
@@ -13,7 +14,7 @@ from xcube.core.update import update_dataset_chunk_encoding
 
 def chunk_dataset(
     dataset: xr.Dataset,
-    chunk_sizes: Dict[str, int] = None,
+    chunk_sizes: dict[str, int] = None,
     format_name: str = None,
     data_vars_only: bool = False,
 ) -> xr.Dataset:
@@ -47,7 +48,7 @@ def chunk_dataset(
 
 def get_empty_dataset_chunks(
     dataset: xr.Dataset,
-) -> Iterator[Tuple[str, Iterator[Tuple[int, ...]]]]:
+) -> Iterator[tuple[str, Iterator[tuple[int, ...]]]]:
     """Identify empty dataset chunks and return their indices.
 
     Args:
@@ -63,7 +64,7 @@ def get_empty_dataset_chunks(
     )
 
 
-def get_empty_var_chunks(var: xr.DataArray) -> Iterator[Tuple[int, ...]]:
+def get_empty_var_chunks(var: xr.DataArray) -> Iterator[tuple[int, ...]]:
     """Identify empty variable chunks and return their indices.
 
     Args:
@@ -84,7 +85,7 @@ def get_empty_var_chunks(var: xr.DataArray) -> Iterator[Tuple[int, ...]]:
             yield chunk_index
 
 
-def compute_chunk_slices(chunks: Tuple[Tuple[int, ...], ...]) -> Iterable:
+def compute_chunk_slices(chunks: tuple[tuple[int, ...], ...]) -> Iterable:
     chunk_indices = []
     for c in chunks:
         chunk_indices.append(tuple(i for i in range(len(c))))

--- a/xcube/core/chunkstore.py
+++ b/xcube/core/chunkstore.py
@@ -5,7 +5,8 @@
 import itertools
 import json
 from collections.abc import MutableMapping
-from typing import Dict, Tuple, Callable, Any, Sequence
+from typing import Dict, Tuple, Callable, Any
+from collections.abc import Sequence
 from typing import Union
 
 import numpy as np
@@ -17,12 +18,13 @@ from xcube.constants import LOG_LEVEL_TRACE
 from xcube.core.zarrstore import LoggingZarrStore
 import collections.abc
 from logging import Logger
-from typing import Iterator, Iterable, KeysView, Optional
+from typing import Optional
+from collections.abc import Iterator, Iterable, KeysView
 
 from xcube.constants import LOG
 from xcube.util.assertions import assert_instance
 
-GetChunk = Callable[["ChunkStore", str, Tuple[int, ...]], bytes]
+GetChunk = Callable[["ChunkStore", str, tuple[int, ...]], bytes]
 
 
 # Note, we cannot remove this deprecated code as long as
@@ -65,7 +67,7 @@ class ChunkStore(MutableMapping):
         dims: Sequence[str],
         shape: Sequence[int],
         chunks: Sequence[int],
-        attrs: Dict[str, Any] = None,
+        attrs: dict[str, Any] = None,
         get_chunk: GetChunk = None,
         trace_store_calls: bool = False,
     ):
@@ -87,18 +89,18 @@ class ChunkStore(MutableMapping):
         return self._ndim
 
     @property
-    def dims(self) -> Tuple[str, ...]:
+    def dims(self) -> tuple[str, ...]:
         return self._dims
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> tuple[int, ...]:
         return self._shape
 
     @property
-    def chunks(self) -> Tuple[int, ...]:
+    def chunks(self) -> tuple[int, ...]:
         return self._chunks
 
-    def add_array(self, name: str, array: np.ndarray, attrs: Dict):
+    def add_array(self, name: str, array: np.ndarray, attrs: dict):
         shape = list(map(int, array.shape))
         dtype = str(array.dtype.str)
         array_metadata = {
@@ -121,10 +123,10 @@ class ChunkStore(MutableMapping):
         name: str,
         dtype: str,
         fill_value: Union[int, float] = None,
-        compressor: Dict[str, Any] = None,
+        compressor: dict[str, Any] = None,
         filters=None,
         order: str = "C",
-        attrs: Dict[str, Any] = None,
+        attrs: dict[str, Any] = None,
         get_chunk: GetChunk = None,
     ):
         get_chunk = get_chunk or self._get_chunk
@@ -226,7 +228,7 @@ def _trace(msg: str):
     LOG.log(LOG_LEVEL_TRACE, msg)
 
 
-def _dict_to_bytes(d: Dict):
+def _dict_to_bytes(d: dict):
     return _str_to_bytes(json.dumps(d, indent=2))
 
 

--- a/xcube/core/compute.py
+++ b/xcube/core/compute.py
@@ -4,7 +4,8 @@
 
 import inspect
 import warnings
-from typing import Tuple, Sequence, Dict, Any, Callable, Union, AbstractSet
+from typing import Tuple, Dict, Any, Callable, Union, AbstractSet
+from collections.abc import Sequence
 
 import numpy as np
 import xarray as xr
@@ -29,10 +30,10 @@ def compute_cube(
     *input_cubes: xr.Dataset,
     input_cube_schema: CubeSchema = None,
     input_var_names: Sequence[str] = None,
-    input_params: Dict[str, Any] = None,
+    input_params: dict[str, Any] = None,
     output_var_name: str = "output",
     output_var_dtype: Any = np.float64,
-    output_var_attrs: Dict[str, Any] = None,
+    output_var_attrs: dict[str, Any] = None,
     vectorize: bool = None,
     cube_asserted: bool = False,
 ) -> xr.Dataset:
@@ -86,11 +87,11 @@ def compute_dataset(
     *input_cubes: xr.Dataset,
     input_cube_schema: CubeSchema = None,
     input_var_names: Sequence[str] = None,
-    input_params: Dict[str, Any] = None,
+    input_params: dict[str, Any] = None,
     output_var_name: str = "output",
     output_var_dims: AbstractSet[str] = None,
     output_var_dtype: Any = np.float64,
-    output_var_attrs: Dict[str, Any] = None,
+    output_var_attrs: dict[str, Any] = None,
     vectorize: bool = None,
     cube_asserted: bool = False,
 ) -> xr.Dataset:
@@ -341,7 +342,7 @@ def _gen_index_var(cube_schema: CubeSchema):
     chunks = cube_schema.chunks
 
     # noinspection PyUnusedLocal
-    def get_chunk(cube_store: ChunkStore, name: str, index: Tuple[int, ...]) -> bytes:
+    def get_chunk(cube_store: ChunkStore, name: str, index: tuple[int, ...]) -> bytes:
         data = np.zeros(cube_store.chunks, dtype=np.uint64)
         data_view = data.ravel()
         if data_view.base is not data:

--- a/xcube/core/extract.py
+++ b/xcube/core/extract.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Dict, Union, Tuple, Any, Optional, Mapping, Sequence, Hashable
+from typing import Dict, Union, Tuple, Any, Optional
+from collections.abc import Mapping, Sequence, Hashable
 
 import dask.array as da
 import numpy as np
@@ -427,7 +428,7 @@ def _normalize_series(
     col_names: Sequence[str],
     force_dataset: bool = False,
     param_name: str = "points",
-) -> Tuple[PointsLike, int]:
+) -> tuple[PointsLike, int]:
     if not isinstance(points, (xr.Dataset, pd.DataFrame)):
         new_points = {}
         for col_name in col_names:
@@ -470,7 +471,7 @@ def _normalize_series(
     return points, num_points
 
 
-def _get_coord_bounds_var_names(dataset: xr.Dataset) -> Dict[Hashable, Any]:
+def _get_coord_bounds_var_names(dataset: xr.Dataset) -> dict[Hashable, Any]:
     bnds_var_names = {}
     for var_name in dataset.coords:
         var = dataset[var_name]
@@ -482,7 +483,7 @@ def _get_coord_bounds_var_names(dataset: xr.Dataset) -> Dict[Hashable, Any]:
     return bnds_var_names
 
 
-def _get_cube_data_var_dims(cube: xr.Dataset) -> Tuple[Hashable, ...]:
+def _get_cube_data_var_dims(cube: xr.Dataset) -> tuple[Hashable, ...]:
     for var in cube.data_vars.values():
         return var.dims
     raise ValueError("cube dataset is empty")

--- a/xcube/core/gen/config.py
+++ b/xcube/core/gen/config.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018-2024 by xcube team and contributors
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
-from typing import Sequence
+from collections.abc import Sequence
 
 from xcube.util.config import flatten_dict, load_configs, to_name_dict_pairs
 

--- a/xcube/core/gen/gen.py
+++ b/xcube/core/gen/gen.py
@@ -11,7 +11,8 @@ import sys
 import time
 import traceback
 import warnings
-from typing import Any, Callable, Dict, Sequence, Tuple
+from typing import Any, Callable, Dict, Tuple
+from collections.abc import Sequence
 
 import xarray as xr
 
@@ -40,15 +41,15 @@ from xcube.util.config import NameAnyDict, NameDictPairList, to_resolved_name_di
 def gen_cube(
     input_paths: Sequence[str] = None,
     input_processor_name: str = None,
-    input_processor_params: Dict = None,
+    input_processor_params: dict = None,
     input_reader_name: str = None,
-    input_reader_params: Dict[str, Any] = None,
-    output_region: Tuple[float, float, float, float] = None,
-    output_size: Tuple[int, int] = DEFAULT_OUTPUT_SIZE,
+    input_reader_params: dict[str, Any] = None,
+    output_region: tuple[float, float, float, float] = None,
+    output_size: tuple[int, int] = DEFAULT_OUTPUT_SIZE,
     output_resampling: str = DEFAULT_OUTPUT_RESAMPLING,
     output_path: str = DEFAULT_OUTPUT_PATH,
     output_writer_name: str = None,
-    output_writer_params: Dict[str, Any] = None,
+    output_writer_params: dict[str, Any] = None,
     output_metadata: NameAnyDict = None,
     output_variables: NameDictPairList = None,
     processed_variables: NameDictPairList = None,
@@ -199,12 +200,12 @@ def gen_cube(
 def _process_input(
     input_processor: InputProcessor,
     input_reader: DatasetIO,
-    input_reader_params: Dict[str, Any],
+    input_reader_params: dict[str, Any],
     output_writer: DatasetIO,
-    output_writer_params: Dict[str, Any],
+    output_writer_params: dict[str, Any],
     input_file: str,
-    output_size: Tuple[int, int],
-    output_region: Tuple[float, float, float, float],
+    output_size: tuple[int, int],
+    output_region: tuple[float, float, float, float],
     output_resampling: str,
     output_path: str,
     output_metadata: NameAnyDict = None,
@@ -291,7 +292,7 @@ def _process_input(
     # noinspection PyShadowingNames
     def step3(input_slice):
         extra_vars = input_processor.get_extra_vars(input_slice)
-        selected_variables = set([var_name for var_name, _ in output_variables])
+        selected_variables = {var_name for var_name, _ in output_variables}
         selected_variables.update(extra_vars or set())
         return select_variables_subset(input_slice, selected_variables)
 
@@ -435,7 +436,7 @@ def _get_tile_size(output_writer_params):
 def _update_cube(
     output_writer: DatasetIO,
     output_path: str,
-    global_attrs: Dict = None,
+    global_attrs: dict = None,
     temporal_only: bool = False,
 ):
     cube = output_writer.read(output_path)
@@ -455,7 +456,7 @@ def _update_cube(
 def _get_sorted_input_paths(
     input_processor,
     input_reader: DatasetIO,
-    input_reader_params: Dict[str, Any],
+    input_reader_params: dict[str, Any],
     input_paths: Sequence[str],
 ):
     input_path_list = []

--- a/xcube/core/gen/iproc.py
+++ b/xcube/core/gen/iproc.py
@@ -4,7 +4,8 @@
 
 import warnings
 from abc import ABCMeta, abstractmethod
-from typing import Any, Collection, Dict, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
+from collections.abc import Collection, Mapping
 
 import numpy as np
 import xarray as xr
@@ -40,11 +41,11 @@ class ReprojectionInfo:
 
     def __init__(
         self,
-        xy_names: Tuple[str, str] = None,
-        xy_tp_names: Tuple[str, str] = None,
+        xy_names: tuple[str, str] = None,
+        xy_tp_names: tuple[str, str] = None,
         xy_crs: Any = None,
-        xy_gcp_step: Union[int, Tuple[int, int]] = None,
-        xy_tp_gcp_step: Union[int, Tuple[int, int]] = None,
+        xy_gcp_step: Union[int, tuple[int, int]] = None,
+        xy_tp_gcp_step: Union[int, tuple[int, int]] = None,
     ):
         self._xy_names = self._assert_name_pair("xy_names", xy_names)
         self._xy_tp_names = self._assert_name_pair("xy_tp_names", xy_tp_names)
@@ -54,11 +55,11 @@ class ReprojectionInfo:
 
     def derive(
         self,
-        xy_names: Tuple[str, str] = None,
-        xy_tp_names: Tuple[str, str] = None,
+        xy_names: tuple[str, str] = None,
+        xy_tp_names: tuple[str, str] = None,
         xy_crs: Any = None,
-        xy_gcp_step: Union[int, Tuple[int, int]] = None,
-        xy_tp_gcp_step: Union[int, Tuple[int, int]] = None,
+        xy_gcp_step: Union[int, tuple[int, int]] = None,
+        xy_tp_gcp_step: Union[int, tuple[int, int]] = None,
     ):
         return ReprojectionInfo(
             self.xy_names if xy_names is None else xy_names,
@@ -71,11 +72,11 @@ class ReprojectionInfo:
         )
 
     @property
-    def xy_names(self) -> Optional[Tuple[str, str]]:
+    def xy_names(self) -> Optional[tuple[str, str]]:
         return self._xy_names
 
     @property
-    def xy_tp_names(self) -> Optional[Tuple[str, str]]:
+    def xy_tp_names(self) -> Optional[tuple[str, str]]:
         return self._xy_tp_names
 
     @property
@@ -147,7 +148,7 @@ class InputProcessor(ExtensionComponent, metaclass=ABCMeta):
         return self.get_metadata_attr("description", "")
 
     @property
-    def default_parameters(self) -> Dict[str, Any]:
+    def default_parameters(self) -> dict[str, Any]:
         return {}
 
     @property
@@ -166,7 +167,7 @@ class InputProcessor(ExtensionComponent, metaclass=ABCMeta):
         return self.parameters.get("input_reader_params", {})
 
     @abstractmethod
-    def get_time_range(self, dataset: xr.Dataset) -> Optional[Tuple[float, float]]:
+    def get_time_range(self, dataset: xr.Dataset) -> Optional[tuple[float, float]]:
         """Return a tuple of two floats representing start/stop time (which may be same) in days since 1970.
 
         Args:
@@ -281,7 +282,7 @@ class XYInputProcessor(InputProcessor, metaclass=ABCMeta):
     """
 
     @property
-    def default_parameters(self) -> Dict[str, Any]:
+    def default_parameters(self) -> dict[str, Any]:
         default_parameters = super().default_parameters
         default_parameters.update(xy_names=("lon", "lat"))
         return default_parameters
@@ -422,7 +423,7 @@ class DefaultInputProcessor(XYInputProcessor):
         super().__init__("default", **parameters)
 
     @property
-    def default_parameters(self) -> Dict[str, Any]:
+    def default_parameters(self) -> dict[str, Any]:
         default_parameters = super().default_parameters
         default_parameters.update(
             input_reader="netcdf4", xy_names=("lon", "lat"), xy_crs=CRS_WKT_EPSG_4326
@@ -438,7 +439,7 @@ class DefaultInputProcessor(XYInputProcessor):
 
         return _normalize_lon_360(dataset)
 
-    def get_time_range(self, dataset: xr.Dataset) -> Tuple[float, float]:
+    def get_time_range(self, dataset: xr.Dataset) -> tuple[float, float]:
         time_coverage_start, time_coverage_end = get_time_range_from_data(dataset)
         if time_coverage_start is not None:
             time_coverage_start = str(time_coverage_start)

--- a/xcube/core/gen2/config.py
+++ b/xcube/core/gen2/config.py
@@ -4,7 +4,8 @@
 
 import collections.abc
 import numbers
-from typing import Optional, Any, Sequence, Mapping, Tuple, Union, Iterable
+from typing import Optional, Any, Tuple, Union
+from collections.abc import Sequence, Mapping, Iterable
 
 import pyproj
 
@@ -126,10 +127,10 @@ class CubeConfig(JsonObject):
         self,
         variable_names: Sequence[str] = None,
         crs: str = None,
-        bbox: Tuple[float, float, float, float] = None,
-        spatial_res: Union[float, Tuple[float]] = None,
-        tile_size: Union[int, Tuple[int, int]] = None,
-        time_range: Tuple[str, Optional[str]] = None,
+        bbox: tuple[float, float, float, float] = None,
+        spatial_res: Union[float, tuple[float]] = None,
+        tile_size: Union[int, tuple[int, int]] = None,
+        time_range: tuple[str, Optional[str]] = None,
         time_period: str = None,
         chunks: Mapping[str, Optional[int]] = None,
         metadata: Mapping[str, Any] = None,

--- a/xcube/core/gen2/error.py
+++ b/xcube/core/gen2/error.py
@@ -26,8 +26,8 @@ class CubeGeneratorError(ValueError):
         self,
         *args,
         status_code: Optional[int] = None,
-        remote_traceback: Optional[List[str]] = None,
-        remote_output: Optional[List[str]] = None,
+        remote_traceback: Optional[list[str]] = None,
+        remote_output: Optional[list[str]] = None,
         **kwargs
     ):
         # noinspection PyArgumentList
@@ -46,14 +46,14 @@ class CubeGeneratorError(ValueError):
         return self._status_code
 
     @property
-    def remote_traceback(self) -> Optional[List[str]]:
+    def remote_traceback(self) -> Optional[list[str]]:
         """Traceback of an error occurred in a remote process.
         May be None.
         """
         return self._remote_traceback
 
     @property
-    def remote_output(self) -> Optional[List[str]]:
+    def remote_output(self) -> Optional[list[str]]:
         """Terminal output of a remote process.
         May be None.
         """

--- a/xcube/core/gen2/generator.py
+++ b/xcube/core/gen2/generator.py
@@ -222,7 +222,7 @@ class CubeGenerator(ABC):
 
     @classmethod
     def _new_cube_generator_error_result(
-        cls, result_type: Type[R], e: CubeGeneratorError
+        cls, result_type: type[R], e: CubeGeneratorError
     ) -> R:
         tb = e.remote_traceback
         if tb is None and e.__traceback__ is not None:

--- a/xcube/core/gen2/local/combiner.py
+++ b/xcube/core/gen2/local/combiner.py
@@ -2,7 +2,7 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import xarray as xr
 

--- a/xcube/core/gen2/local/describer.py
+++ b/xcube/core/gen2/local/describer.py
@@ -2,7 +2,7 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from xcube.core.store import DATASET_TYPE
 from xcube.core.store import DataStoreError

--- a/xcube/core/gen2/local/informant.py
+++ b/xcube/core/gen2/local/informant.py
@@ -6,7 +6,8 @@ import datetime
 import numbers
 import traceback
 import warnings
-from typing import Optional, Sequence, Any, Tuple
+from typing import Optional, Any, Tuple
+from collections.abc import Sequence
 
 import pandas as pd
 import pyproj
@@ -147,7 +148,7 @@ class CubeInformant:
 
     def _compute_effective_cube_config(
         self,
-    ) -> Tuple[CubeConfig, pyproj.crs.CRS, Sequence[pd.Timestamp]]:
+    ) -> tuple[CubeConfig, pyproj.crs.CRS, Sequence[pd.Timestamp]]:
         """Compute the effective cube configuration.
 
         This method reflects the behaviour of the LocalCubeGenerator
@@ -264,7 +265,7 @@ def _idiv(x: int, y: int) -> int:
 
 def _parse_time_range(
     time_range: Any,
-) -> Tuple[Optional[pd.Timestamp], Optional[pd.Timestamp]]:
+) -> tuple[Optional[pd.Timestamp], Optional[pd.Timestamp]]:
     try:
         start_date, end_date = time_range
     except (TypeError, ValueError):

--- a/xcube/core/gen2/local/mdadjuster.py
+++ b/xcube/core/gen2/local/mdadjuster.py
@@ -50,7 +50,7 @@ class CubeMetadataAdjuster(CubeTransformer):
         return cube, gm, cube_config
 
     @staticmethod
-    def _check_for_self_destruction(metadata: Dict[str, Any]):
+    def _check_for_self_destruction(metadata: dict[str, Any]):
         key = "inverse_fine_structure_constant"
         value = 137
         if key in metadata and metadata[key] != value:
@@ -59,5 +59,5 @@ class CubeMetadataAdjuster(CubeTransformer):
             raise ValueError(f"{key} must be {value}" f" or running in wrong universe")
 
 
-def get_geospatial_attrs(gm: GridMapping) -> Dict[str, Any]:
+def get_geospatial_attrs(gm: GridMapping) -> dict[str, Any]:
     return dict(gm.to_dataset_attrs())

--- a/xcube/core/gen2/local/transformer.py
+++ b/xcube/core/gen2/local/transformer.py
@@ -13,7 +13,7 @@ from .helpers import is_empty_cube
 from .helpers import strip_cube
 from ..config import CubeConfig
 
-TransformedCube = Tuple[xr.Dataset, GridMapping, CubeConfig]
+TransformedCube = tuple[xr.Dataset, GridMapping, CubeConfig]
 
 
 class CubeTransformer(ABC):

--- a/xcube/core/gen2/local/usercode.py
+++ b/xcube/core/gen2/local/usercode.py
@@ -42,8 +42,8 @@ class CubeUserCodeExecutor(CubeTransformer):
     @classmethod
     def _get_callable_from_class(
         cls,
-        process_class: Type[Any],
-        process_params: Dict[str, Any],
+        process_class: type[Any],
+        process_params: dict[str, Any],
     ) -> Callable:
         process_object = process_class()
         process_params_schema = None

--- a/xcube/core/gen2/local/writer.py
+++ b/xcube/core/gen2/local/writer.py
@@ -19,7 +19,7 @@ class CubeWriter:
         self._output_config = output_config
         self._store_pool = store_pool
 
-    def write_cube(self, cube: xr.Dataset, gm: GridMapping) -> Tuple[str, xr.Dataset]:
+    def write_cube(self, cube: xr.Dataset, gm: GridMapping) -> tuple[str, xr.Dataset]:
         output_config = self._output_config
         dataset = encode_cube(cube, grid_mapping=gm)
         with observe_dask_progress("writing cube", 100):

--- a/xcube/core/gen2/progress.py
+++ b/xcube/core/gen2/progress.py
@@ -5,7 +5,7 @@
 import threading
 from time import sleep
 from timeit import default_timer
-from typing import Sequence
+from collections.abc import Sequence
 
 import requests
 
@@ -29,11 +29,11 @@ def _format_time(t):
     m, s = divmod(t, 60)
     h, m = divmod(m, 60)
     if h:
-        return "{0:2.0f}hr {1:2.0f}min {2:4.1f}s".format(h, m, s)
+        return f"{h:2.0f}hr {m:2.0f}min {s:4.1f}s"
     elif m:
-        return "{0:2.0f}min {1:4.1f}s".format(m, s)
+        return f"{m:2.0f}min {s:4.1f}s"
     else:
-        return "{0:4.1f}s".format(s)
+        return f"{s:4.1f}s"
 
 
 class _ThreadedProgressObserver(ProgressObserver):
@@ -230,6 +230,6 @@ class ConsoleProgressObserver(ProgressObserver):
     @classmethod
     def _format_state(cls, state: ProgressState, marker=None) -> str:
         if marker is None:
-            return "{} - {:3.1%}".format(state.label, state.progress)
+            return f"{state.label} - {state.progress:3.1%}"
         else:
-            return "{} - {}".format(state.label, marker)
+            return f"{state.label} - {marker}"

--- a/xcube/core/gen2/remote/config.py
+++ b/xcube/core/gen2/remote/config.py
@@ -12,7 +12,7 @@ from xcube.util.jsonschema import JsonStringSchema
 
 DEFAULT_ENDPOINT_URL = "https://xcube-gen.brockmann-consult.de/api/v2/"
 
-ServiceConfigLike = Union[str, Dict, "ServiceConfig"]
+ServiceConfigLike = Union[str, dict, "ServiceConfig"]
 
 
 class ServiceConfig(JsonObject):

--- a/xcube/core/gen2/remote/generator.py
+++ b/xcube/core/gen2/remote/generator.py
@@ -68,7 +68,7 @@ class RemoteCubeGenerator(CubeGenerator):
         return f"{self._service_config.endpoint_url}{op_path}"
 
     @property
-    def auth_headers(self) -> Dict:
+    def auth_headers(self) -> dict:
         access_token = self.access_token
         if access_token is not None:
             return {
@@ -190,9 +190,9 @@ class RemoteCubeGenerator(CubeGenerator):
         return data_id if data_id else default
 
     def _get_cube_generator_result(
-        self, response: requests.Response, request_data: Dict[str, Any] = None
-    ) -> Tuple[
-        str, Optional[CubeGeneratorResult], Optional[List[CubeGeneratorProgress]]
+        self, response: requests.Response, request_data: dict[str, Any] = None
+    ) -> tuple[
+        str, Optional[CubeGeneratorResult], Optional[list[CubeGeneratorProgress]]
     ]:
         state = self._get_cube_generator_state(response, request_data)
         result = None
@@ -215,7 +215,7 @@ class RemoteCubeGenerator(CubeGenerator):
         return state.job_id, result, state.progress
 
     def _get_cube_generator_state(
-        self, response: requests.Response, request_data: Dict[str, Any] = None
+        self, response: requests.Response, request_data: dict[str, Any] = None
     ) -> CubeGeneratorState:
         return self._parse_response(
             response, CubeGeneratorState, request_data=request_data
@@ -224,8 +224,8 @@ class RemoteCubeGenerator(CubeGenerator):
     def _parse_response(
         self,
         response: requests.Response,
-        response_type: Type[R],
-        request_data: Dict[str, Any] = None,
+        response_type: type[R],
+        request_data: dict[str, Any] = None,
     ) -> R:
         # noinspection PyBroadException
         try:

--- a/xcube/core/gen2/remote/response.py
+++ b/xcube/core/gen2/remote/response.py
@@ -33,7 +33,7 @@ class CubeGeneratorToken(JsonObject):
         )
 
     @classmethod
-    def from_dict(cls, value: Dict) -> "CubeGeneratorToken":
+    def from_dict(cls, value: dict) -> "CubeGeneratorToken":
         return cls.get_schema().from_instance(value)
 
 
@@ -46,7 +46,7 @@ class CubeGeneratorJobStatus(JsonObject):
         active: int = None,
         start_time: str = None,
         completion_time: str = None,
-        conditions: List[Dict[str, Any]] = None,
+        conditions: list[dict[str, Any]] = None,
         **additional_properties
     ):
         self.succeeded: Optional[int] = succeeded
@@ -54,8 +54,8 @@ class CubeGeneratorJobStatus(JsonObject):
         self.active: Optional[int] = active
         self.start_time: Optional[str] = start_time
         self.completion_time: Optional[str] = completion_time
-        self.conditions: Optional[Dict[str, Any]] = conditions
-        self.additional_properties: Dict[str, Any] = additional_properties
+        self.conditions: Optional[dict[str, Any]] = conditions
+        self.additional_properties: dict[str, Any] = additional_properties
 
     @classmethod
     def get_schema(cls) -> JsonObjectSchema:
@@ -75,7 +75,7 @@ class CubeGeneratorJobStatus(JsonObject):
         )
 
     @classmethod
-    def from_dict(cls, value: Dict) -> "CubeGeneratorJobStatus":
+    def from_dict(cls, value: dict) -> "CubeGeneratorJobStatus":
         return cls.get_schema().from_instance(value)
 
 
@@ -112,7 +112,7 @@ class CubeGeneratorProgressState(JsonObject):
         )
 
     @classmethod
-    def from_dict(cls, value: Dict) -> "CubeGeneratorProgressState":
+    def from_dict(cls, value: dict) -> "CubeGeneratorProgressState":
         return cls.get_schema().from_instance(value)
 
 
@@ -139,7 +139,7 @@ class CubeGeneratorProgress(JsonObject):
         )
 
     @classmethod
-    def from_dict(cls, value: Dict) -> "CubeGeneratorProgress":
+    def from_dict(cls, value: dict) -> "CubeGeneratorProgress":
         return cls.get_schema().from_instance(value)
 
 
@@ -151,8 +151,8 @@ class CubeGeneratorState(JsonObject):
         job_id: str,
         job_status: CubeGeneratorJobStatus,
         job_result: Optional[CubeGeneratorResult] = None,
-        output: Optional[List[str]] = None,
-        progress: Optional[List[CubeGeneratorProgress]] = None,
+        output: Optional[list[str]] = None,
+        progress: Optional[list[CubeGeneratorProgress]] = None,
         **additional_properties
     ):
         self.job_id = job_id
@@ -180,7 +180,7 @@ class CubeGeneratorState(JsonObject):
         )
 
     @classmethod
-    def from_dict(cls, value: Dict) -> "CubeGeneratorState":
+    def from_dict(cls, value: dict) -> "CubeGeneratorState":
         return cls.get_schema().from_instance(value)
 
 
@@ -204,7 +204,7 @@ class CostEstimation(JsonObject):
         )
 
     @classmethod
-    def from_dict(cls, value: Dict) -> "CostEstimation":
+    def from_dict(cls, value: dict) -> "CostEstimation":
         return cls.get_schema().from_instance(value)
 
 

--- a/xcube/core/gen2/request.py
+++ b/xcube/core/gen2/request.py
@@ -5,7 +5,8 @@
 import json
 import os.path
 import sys
-from typing import Optional, Dict, Any, Sequence, Union
+from typing import Optional, Dict, Any, Union
+from collections.abc import Sequence
 
 import jsonschema
 import yaml
@@ -24,7 +25,7 @@ from .config import OutputConfig
 from .error import CubeGeneratorError
 from ...constants import LOG
 
-CubeGeneratorRequestLike = Union[str, Dict, "CubeGeneratorRequest"]
+CubeGeneratorRequestLike = Union[str, dict, "CubeGeneratorRequest"]
 
 
 class CubeGeneratorRequest(JsonObject):
@@ -148,7 +149,7 @@ class CubeGeneratorRequest(JsonObject):
             "request must be a str, dict, " "or a CubeGeneratorRequest instance"
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert into a JSON-serializable dictionary"""
         d = {}
 
@@ -172,7 +173,7 @@ class CubeGeneratorRequest(JsonObject):
         return d
 
     @classmethod
-    def from_dict(cls, request_dict: Dict[str, Any]) -> "CubeGeneratorRequest":
+    def from_dict(cls, request_dict: dict[str, Any]) -> "CubeGeneratorRequest":
         """Create new instance from a JSON-serializable dictionary"""
         try:
             return cls.get_schema().from_instance(request_dict)
@@ -195,7 +196,7 @@ class CubeGeneratorRequest(JsonObject):
     @classmethod
     def _load_request_file(
         cls, gen_config_file: Optional[str], verbosity: int = 0
-    ) -> Dict:
+    ) -> dict:
         if gen_config_file is not None and not os.path.exists(gen_config_file):
             raise CubeGeneratorError(
                 f"Cube generator request " f'"{gen_config_file}" not found.'
@@ -208,7 +209,7 @@ class CubeGeneratorRequest(JsonObject):
                         LOG.info("Awaiting generator" " request JSON from TTY...")
                     return json.load(sys.stdin)
             else:
-                with open(gen_config_file, "r") as fp:
+                with open(gen_config_file) as fp:
                     if gen_config_file.endswith(".json"):
                         return json.load(fp)
                     else:

--- a/xcube/core/gen2/response.py
+++ b/xcube/core/gen2/response.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 from abc import abstractmethod
-from typing import Dict, Any, Optional, List, Sequence, TypeVar, Generic, Type
+from typing import Dict, Any, Optional, List, TypeVar, Generic, Type
+from collections.abc import Sequence
 
 from xcube.core.store import DatasetDescriptor
 from xcube.util.assertions import assert_in
@@ -28,7 +29,7 @@ class GenericCubeGeneratorResult(Generic[R], JsonObject):
         message: Optional[str] = None,
         output: Optional[Sequence[str]] = None,
         traceback: Optional[Sequence[str]] = None,
-        versions: Optional[Dict[str, str]] = None,
+        versions: Optional[dict[str, str]] = None,
     ):
         assert_instance(status, str, name="status")
         assert_in(status, STATUS_IDS, name="status")
@@ -49,7 +50,7 @@ class GenericCubeGeneratorResult(Generic[R], JsonObject):
         message: Optional[str] = None,
         output: Optional[Sequence[str]] = None,
         traceback: Optional[Sequence[str]] = None,
-        versions: Optional[Dict[str, str]] = None,
+        versions: Optional[dict[str, str]] = None,
     ) -> R:
         return self.__class__(
             status or self.status,
@@ -67,7 +68,7 @@ class GenericCubeGeneratorResult(Generic[R], JsonObject):
         """Get the JSON schema of the result object"""
 
     @classmethod
-    def from_dict(cls, value: Dict) -> R:
+    def from_dict(cls, value: dict) -> R:
         return cls.get_schema().from_instance(value)
 
     @classmethod
@@ -89,8 +90,8 @@ class GenericCubeGeneratorResult(Generic[R], JsonObject):
 
 
 def make_cube_generator_result_class(
-    result_type: Type[R],
-) -> Type[GenericCubeGeneratorResult[R]]:
+    result_type: type[R],
+) -> type[GenericCubeGeneratorResult[R]]:
     class SpecificCubeGeneratorResult(GenericCubeGeneratorResult[R]):
         @classmethod
         def get_result_schema(cls) -> JsonObjectSchema:
@@ -122,7 +123,7 @@ class CubeInfo(JsonObject):
     def __init__(
         self,
         dataset_descriptor: DatasetDescriptor,
-        size_estimation: Dict[str, Any],
+        size_estimation: dict[str, Any],
         **kwargs,
     ):
         self.dataset_descriptor: DatasetDescriptor = dataset_descriptor

--- a/xcube/core/geom.py
+++ b/xcube/core/geom.py
@@ -4,7 +4,8 @@
 
 import math
 import warnings
-from typing import Optional, Union, Dict, Tuple, Sequence, Any, Mapping, List
+from typing import Optional, Union, Dict, Tuple, Any, List
+from collections.abc import Sequence, Mapping
 
 import affine
 import dask.array as da
@@ -24,10 +25,10 @@ from xcube.util.geojson import GeoJSON
 from xcube.util.types import normalize_scalar_or_pair
 
 GeometryLike = Union[
-    shapely.geometry.base.BaseGeometry, Dict[str, Any], str, Sequence[Union[float, int]]
+    shapely.geometry.base.BaseGeometry, dict[str, Any], str, Sequence[Union[float, int]]
 ]
-Bounds = Tuple[float, float, float, float]
-SplitBounds = Tuple[Bounds, Optional[Bounds]]
+Bounds = tuple[float, float, float, float]
+SplitBounds = tuple[Bounds, Optional[Bounds]]
 
 Name = str
 Attrs = Mapping[Name, Any]
@@ -50,8 +51,8 @@ def rasterize_features(
     dataset: xr.Dataset,
     features: Union[GeoDataFrame, GeoJSONFeatures],
     feature_props: Sequence[Name],
-    var_props: Dict[Name, VarProps] = None,
-    tile_size: Union[int, Tuple[int, int]] = None,
+    var_props: dict[Name, VarProps] = None,
+    tile_size: Union[int, tuple[int, int]] = None,
     all_touched: bool = False,
     in_place: bool = False,
 ) -> Optional[xr.Dataset]:
@@ -235,9 +236,9 @@ def rasterize_features(
 
 
 def _rasterize_features_into_block(
-    block_info: Dict[Union[str, None], Any] = None,
-    geometries: List[Dict[str, Any]] = None,
-    feature_data: List[np.ndarray] = None,
+    block_info: dict[Union[str, None], Any] = None,
+    geometries: list[dict[str, Any]] = None,
+    feature_data: list[np.ndarray] = None,
     x_offset: float = None,
     y_offset: float = None,
     x_res: float = None,
@@ -282,7 +283,7 @@ def _rasterize_features_into_block(
 def mask_dataset_by_geometry(
     dataset: xr.Dataset,
     geometry: GeometryLike,
-    tile_size: Union[int, Tuple[int, int]] = None,
+    tile_size: Union[int, tuple[int, int]] = None,
     excluded_vars: Sequence[str] = None,
     no_clip: bool = False,
     all_touched: bool = False,
@@ -391,8 +392,8 @@ def mask_dataset_by_geometry(
 
 
 def _mask_block(
-    block_info: Dict[Union[str, None], Any] = None,
-    geometry: Dict[str, Any] = None,
+    block_info: dict[Union[str, None], Any] = None,
+    geometry: dict[str, Any] = None,
     x_offset: float = None,
     y_offset: float = None,
     x_res: float = None,
@@ -418,7 +419,7 @@ def _get_spatial_chunks(
     dataset: xr.Dataset,
     x_var_name: str,
     y_var_name: str,
-    tile_size: Union[None, int, Tuple[int, int]],
+    tile_size: Union[None, int, tuple[int, int]],
 ):
     width = dataset[x_var_name].size
     height = dataset[y_var_name].size
@@ -472,7 +473,7 @@ def clip_dataset_by_geometry(
 def _clip_dataset_by_geometry(
     dataset: xr.Dataset,
     intersection_geometry: shapely.geometry.base.BaseGeometry,
-    xy_var_names: Tuple[str, str],
+    xy_var_names: tuple[str, str],
     save_geometry_wkt: bool = False,
 ) -> Optional[xr.Dataset]:
     # TODO (forman): the following code is wrong,
@@ -622,7 +623,7 @@ def normalize_geometry(
 
 
 def is_lon_lat_dataset(
-    dataset: Union[xr.Dataset, xr.DataArray], xy_var_names: Tuple[str, str] = None
+    dataset: Union[xr.Dataset, xr.DataArray], xy_var_names: tuple[str, str] = None
 ) -> bool:
     if xy_var_names is None:
         xy_var_names = get_dataset_xy_var_names(dataset, must_exist=True)
@@ -638,7 +639,7 @@ def is_lon_lat_dataset(
 
 
 def get_dataset_geometry(
-    dataset: Union[xr.Dataset, xr.DataArray], xy_var_names: Tuple[str, str] = None
+    dataset: Union[xr.Dataset, xr.DataArray], xy_var_names: tuple[str, str] = None
 ) -> shapely.geometry.base.BaseGeometry:
     if xy_var_names is None:
         xy_var_names = get_dataset_xy_var_names(dataset, must_exist=True)
@@ -651,7 +652,7 @@ def get_dataset_geometry(
 
 def get_dataset_bounds(
     dataset: Union[xr.Dataset, xr.DataArray],
-    xy_var_names: Optional[Tuple[str, str]] = None,
+    xy_var_names: Optional[tuple[str, str]] = None,
 ) -> Bounds:
     if xy_var_names is None:
         xy_var_names = get_dataset_xy_var_names(dataset, must_exist=True)

--- a/xcube/core/gridmapping/base.py
+++ b/xcube/core/gridmapping/base.py
@@ -8,7 +8,7 @@ import math
 import threading
 from typing import Any
 from typing import Callable
-from typing import Mapping
+from collections.abc import Mapping
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -68,13 +68,13 @@ class GridMapping(abc.ABC):
     def __init__(
         self,
         /,
-        size: Union[int, Tuple[int, int]],
-        tile_size: Optional[Union[int, Tuple[int, int]]],
-        xy_bbox: Tuple[Number, Number, Number, Number],
-        xy_res: Union[Number, Tuple[Number, Number]],
+        size: Union[int, tuple[int, int]],
+        tile_size: Optional[Union[int, tuple[int, int]]],
+        xy_bbox: tuple[Number, Number, Number, Number],
+        xy_res: Union[Number, tuple[Number, Number]],
         crs: pyproj.crs.CRS,
-        xy_var_names: Tuple[str, str],
-        xy_dim_names: Tuple[str, str],
+        xy_var_names: tuple[str, str],
+        xy_dim_names: tuple[str, str],
         is_regular: Optional[bool],
         is_lon_360: Optional[bool],
         is_j_axis_up: Optional[bool],
@@ -140,9 +140,9 @@ class GridMapping(abc.ABC):
     def derive(
         self,
         /,
-        xy_var_names: Tuple[str, str] = None,
-        xy_dim_names: Tuple[str, str] = None,
-        tile_size: Union[int, Tuple[int, int]] = None,
+        xy_var_names: tuple[str, str] = None,
+        xy_dim_names: tuple[str, str] = None,
+        tile_size: Union[int, tuple[int, int]] = None,
         is_j_axis_up: bool = None,
     ):
         """Derive a new grid mapping from this one with some properties changed.
@@ -186,8 +186,8 @@ class GridMapping(abc.ABC):
 
     def scale(
         self,
-        xy_scale: Union[Number, Tuple[Number, Number]],
-        tile_size: Union[int, Tuple[int, int]] = None,
+        xy_scale: Union[Number, tuple[Number, Number]],
+        tile_size: Union[int, tuple[int, int]] = None,
     ) -> "GridMapping":
         """Derive a scaled version of this regular grid mapping.
 
@@ -226,7 +226,7 @@ class GridMapping(abc.ABC):
         ).derive(xy_dim_names=self.xy_dim_names, xy_var_names=self.xy_var_names)
 
     @property
-    def size(self) -> Tuple[int, int]:
+    def size(self) -> tuple[int, int]:
         """Image size (width, height) in pixels."""
         return self._size
 
@@ -241,7 +241,7 @@ class GridMapping(abc.ABC):
         return self.size[1]
 
     @property
-    def tile_size(self) -> Tuple[int, int]:
+    def tile_size(self) -> tuple[int, int]:
         """Image tile size (width, height) in pixels."""
         return self._tile_size
 
@@ -296,7 +296,7 @@ class GridMapping(abc.ABC):
         return xy_coords
 
     @property
-    def xy_coords_chunks(self) -> Tuple[int, int, int]:
+    def xy_coords_chunks(self) -> tuple[int, int, int]:
         """Get the chunks for the *xy_coords* array."""
         return 2, self.tile_height, self.tile_width
 
@@ -321,21 +321,21 @@ class GridMapping(abc.ABC):
             return value
 
     @property
-    def xy_var_names(self) -> Tuple[str, str]:
+    def xy_var_names(self) -> tuple[str, str]:
         """The variable names of the x,y coordinates as
         tuple (x_var_name, y_var_name).
         """
         return self._xy_var_names
 
     @property
-    def xy_dim_names(self) -> Tuple[str, str]:
+    def xy_dim_names(self) -> tuple[str, str]:
         """The dimension names of the x,y coordinates as
         tuple (x_dim_name, y_dim_name).
         """
         return self._xy_dim_names
 
     @property
-    def xy_bbox(self) -> Tuple[float, float, float, float]:
+    def xy_bbox(self) -> tuple[float, float, float, float]:
         """The image's bounding box in CRS coordinates."""
         return self._xy_bbox
 
@@ -360,7 +360,7 @@ class GridMapping(abc.ABC):
         return self._xy_bbox[3]
 
     @property
-    def xy_res(self) -> Tuple[Number, Number]:
+    def xy_res(self) -> tuple[Number, Number]:
         """Pixel size in x and y direction."""
         return self._xy_res
 
@@ -476,7 +476,7 @@ class GridMapping(abc.ABC):
         return _from_affine(~a)
 
     @property
-    def ij_bbox(self) -> Tuple[int, int, int, int]:
+    def ij_bbox(self) -> tuple[int, int, int, int]:
         """The image's bounding box in pixel coordinates."""
         return 0, 0, self.width, self.height
 
@@ -514,10 +514,10 @@ class GridMapping(abc.ABC):
 
     def ij_bbox_from_xy_bbox(
         self,
-        xy_bbox: Tuple[float, float, float, float],
+        xy_bbox: tuple[float, float, float, float],
         xy_border: float = 0.0,
         ij_border: int = 0,
-    ) -> Tuple[int, int, int, int]:
+    ) -> tuple[int, int, int, int]:
         """Compute bounding box in i,j pixel coordinates given a
         bounding box *xy_bbox* in x,y coordinates.
 
@@ -645,8 +645,8 @@ class GridMapping(abc.ABC):
 
     def to_coords(
         self,
-        xy_var_names: Tuple[str, str] = None,
-        xy_dim_names: Tuple[str, str] = None,
+        xy_var_names: tuple[str, str] = None,
+        xy_dim_names: tuple[str, str] = None,
         exclude_bounds: bool = False,
         reuse_coords: bool = False,
     ) -> Mapping[str, xr.DataArray]:
@@ -683,8 +683,8 @@ class GridMapping(abc.ABC):
         self,
         crs: Union[str, pyproj.crs.CRS],
         *,
-        tile_size: Union[int, Tuple[int, int]] = None,
-        xy_var_names: Tuple[str, str] = None,
+        tile_size: Union[int, tuple[int, int]] = None,
+        xy_var_names: tuple[str, str] = None,
         tolerance: float = DEFAULT_TOLERANCE,
     ) -> "GridMapping":
         """Transform this grid mapping so it uses the given
@@ -714,12 +714,12 @@ class GridMapping(abc.ABC):
     @classmethod
     def regular(
         cls,
-        size: Union[int, Tuple[int, int]],
-        xy_min: Tuple[float, float],
-        xy_res: Union[float, Tuple[float, float]],
+        size: Union[int, tuple[int, int]],
+        xy_min: tuple[float, float],
+        xy_res: Union[float, tuple[float, float]],
         crs: Union[str, pyproj.crs.CRS],
         *,
-        tile_size: Union[int, Tuple[int, int]] = None,
+        tile_size: Union[int, tuple[int, int]] = None,
         is_j_axis_up: bool = False,
     ) -> "GridMapping":
         """Create a new regular grid mapping.
@@ -748,7 +748,7 @@ class GridMapping(abc.ABC):
         )
 
     def to_regular(
-        self, tile_size: Union[int, Tuple[int, int]] = None, is_j_axis_up: bool = False
+        self, tile_size: Union[int, tuple[int, int]] = None, is_j_axis_up: bool = False
     ) -> "GridMapping":
         """Transform this grid mapping into one that is regular.
 
@@ -773,7 +773,7 @@ class GridMapping(abc.ABC):
         dataset: xr.Dataset,
         *,
         crs: Union[str, pyproj.crs.CRS] = None,
-        tile_size: Union[int, Tuple[int, int]] = None,
+        tile_size: Union[int, tuple[int, int]] = None,
         prefer_is_regular: bool = True,
         prefer_crs: Union[str, pyproj.crs.CRS] = None,
         emit_warnings: bool = False,
@@ -817,7 +817,7 @@ class GridMapping(abc.ABC):
         y_coords: xr.DataArray,
         crs: Union[str, pyproj.crs.CRS],
         *,
-        tile_size: Union[int, Tuple[int, int]] = None,
+        tile_size: Union[int, tuple[int, int]] = None,
         tolerance: float = DEFAULT_TOLERANCE,
     ) -> "GridMapping":
         """Create a grid mapping from given x- and y-coordinates

--- a/xcube/core/gridmapping/bboxes.py
+++ b/xcube/core/gridmapping/bboxes.py
@@ -92,7 +92,7 @@ def compute_ij_bboxes(
 
 def compute_xy_bbox(
     xy_coords: Union[xr.DataArray, np.ndarray, da.Array]
-) -> Tuple[float, float, float, float]:
+) -> tuple[float, float, float, float]:
     xy_coords = da.asarray(xy_coords)
     result = da.reduction(
         xy_coords,

--- a/xcube/core/gridmapping/cfconv.py
+++ b/xcube/core/gridmapping/cfconv.py
@@ -4,7 +4,8 @@
 
 import warnings
 from collections.abc import MutableMapping
-from typing import Optional, Dict, Any, Hashable, Union, Set, List, Tuple
+from typing import Optional, Dict, Any, Union, Set, List, Tuple
+from collections.abc import Hashable
 
 import numpy as np
 import pyproj
@@ -38,7 +39,7 @@ class GridMappingProxy:
         crs: Optional[pyproj.crs.CRS] = None,
         name: Optional[str] = None,
         coords: Optional[GridCoords] = None,
-        tile_size: Optional[Tuple[int, int]] = None,
+        tile_size: Optional[tuple[int, int]] = None,
     ):
         self.crs = crs
         self.name = name
@@ -53,7 +54,7 @@ def get_dataset_grid_mapping_proxies(
     missing_rotated_latitude_longitude_crs: pyproj.crs.CRS = None,
     missing_projected_crs: pyproj.crs.CRS = None,
     emit_warnings: bool = False,
-) -> Dict[Union[Hashable, None], GridMappingProxy]:
+) -> dict[Union[Hashable, None], GridMappingProxy]:
     """Find grid mappings encoded as described in the CF conventions
     [Horizontal Coordinate Reference Systems, Grid Mappings, and Projections]
     (http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#grid-mappings-and-projections).
@@ -68,7 +69,7 @@ def get_dataset_grid_mapping_proxies(
     Returns:
 
     """
-    grid_mapping_proxies: Dict[Union[Hashable, None], GridMappingProxy] = dict()
+    grid_mapping_proxies: dict[Union[Hashable, None], GridMappingProxy] = dict()
 
     # Find any grid mapping variables by CF 'grid_mapping' attribute
     #
@@ -207,7 +208,7 @@ def get_dataset_grid_mapping_proxies(
     return complete_grid_mappings
 
 
-def _parse_crs_from_attrs(attrs: Dict[Hashable, Any]) -> Optional[GridMappingProxy]:
+def _parse_crs_from_attrs(attrs: dict[Hashable, Any]) -> Optional[GridMappingProxy]:
     # noinspection PyBroadException
     try:
         crs = pyproj.crs.CRS.from_cf(attrs)
@@ -220,7 +221,7 @@ def _complement_grid_mapping_coords(
     coords: GridCoords,
     grid_mapping_name: Optional[str],
     missing_crs: Optional[pyproj.crs.CRS],
-    grid_mappings: Dict[Optional[str], GridMappingProxy],
+    grid_mappings: dict[Optional[str], GridMappingProxy],
 ):
     if coords.x is not None or coords.y is not None:
         grid_mapping = next(
@@ -246,7 +247,7 @@ def _complement_grid_mapping_coords(
                 grid_mapping.coords.y = coords.y
 
 
-def _find_potential_coord_vars(dataset: xr.Dataset) -> List[Hashable]:
+def _find_potential_coord_vars(dataset: xr.Dataset) -> list[Hashable]:
     """Find potential coordinate variables.
 
     We need this function as we can not rely on xarray.Dataset.coords,
@@ -292,7 +293,7 @@ def _find_potential_coord_vars(dataset: xr.Dataset) -> List[Hashable]:
 
 
 def _is_potential_coord_var(
-    dataset: xr.Dataset, bounds_var_names: Set[str], var_name: Hashable
+    dataset: xr.Dataset, bounds_var_names: set[str], var_name: Hashable
 ) -> bool:
     if var_name in dataset:
         var = dataset[var_name]
@@ -302,7 +303,7 @@ def _is_potential_coord_var(
 
 def _find_dataset_tile_size(
     dataset: xr.Dataset, x_dim_name: Hashable, y_dim_name: Hashable
-) -> Optional[Tuple[int, int]]:
+) -> Optional[tuple[int, int]]:
     """Find the most likely tile size in *dataset*"""
     dataset_chunks = get_dataset_chunks(dataset)
     tile_width = dataset_chunks.get(x_dim_name)
@@ -316,7 +317,7 @@ def add_spatial_ref(
     dataset_store: zarr.convenience.StoreLike,
     crs: pyproj.CRS,
     crs_var_name: Optional[str] = "spatial_ref",
-    xy_dim_names: Optional[Tuple[str, str]] = None,
+    xy_dim_names: Optional[tuple[str, str]] = None,
 ):
     """Helper function that allows adding a spatial reference to an
     existing Zarr dataset.

--- a/xcube/core/gridmapping/coords.py
+++ b/xcube/core/gridmapping/coords.py
@@ -78,7 +78,7 @@ def new_grid_mapping_from_coords(
     y_coords: xr.DataArray,
     crs: Union[str, pyproj.crs.CRS],
     *,
-    tile_size: Union[int, Tuple[int, int]] = None,
+    tile_size: Union[int, tuple[int, int]] = None,
     tolerance: float = DEFAULT_TOLERANCE,
 ) -> GridMapping:
     crs = _normalize_crs(crs)
@@ -289,11 +289,11 @@ def _abs_no_nan(array: Union[xr.DataArray, da.Array, np.ndarray]):
 
 def grid_mapping_to_coords(
     grid_mapping: GridMapping,
-    xy_var_names: Tuple[str, str] = None,
-    xy_dim_names: Tuple[str, str] = None,
+    xy_var_names: tuple[str, str] = None,
+    xy_dim_names: tuple[str, str] = None,
     reuse_coords: bool = False,
     exclude_bounds: bool = False,
-) -> Dict[str, xr.DataArray]:
+) -> dict[str, xr.DataArray]:
     """Get CF-compliant axis coordinate variables and cell
     boundary coordinate variables.
 

--- a/xcube/core/gridmapping/dataset.py
+++ b/xcube/core/gridmapping/dataset.py
@@ -19,7 +19,7 @@ def new_grid_mapping_from_dataset(
     dataset: xr.Dataset,
     *,
     crs: Union[str, pyproj.crs.CRS] = None,
-    tile_size: Union[int, Tuple[str, str]] = None,
+    tile_size: Union[int, tuple[str, str]] = None,
     prefer_crs: Union[str, pyproj.crs.CRS] = None,
     prefer_is_regular: bool = None,
     emit_warnings: bool = False,

--- a/xcube/core/gridmapping/helpers.py
+++ b/xcube/core/gridmapping/helpers.py
@@ -19,8 +19,8 @@ from xcube.util.assertions import assert_true
 from xcube.util.undefined import UNDEFINED
 
 Number = Union[int, float]
-AffineTransformMatrix = Tuple[
-    Tuple[Number, Number, Number], Tuple[Number, Number, Number]
+AffineTransformMatrix = tuple[
+    tuple[Number, Number, Number], tuple[Number, Number, Number]
 ]
 
 
@@ -52,8 +52,8 @@ def _normalize_crs(crs: Union[str, pyproj.CRS]) -> pyproj.CRS:
 
 
 def _normalize_int_pair(
-    value: Any, name: str = None, default: Optional[Tuple[int, int]] = UNDEFINED
-) -> Optional[Tuple[int, int]]:
+    value: Any, name: str = None, default: Optional[tuple[int, int]] = UNDEFINED
+) -> Optional[tuple[int, int]]:
     if isinstance(value, int):
         return value, value
     elif value is not None:
@@ -67,8 +67,8 @@ def _normalize_int_pair(
 
 
 def _normalize_number_pair(
-    value: Any, name: str = None, default: Optional[Tuple[Number, Number]] = UNDEFINED
-) -> Optional[Tuple[Number, Number]]:
+    value: Any, name: str = None, default: Optional[tuple[Number, Number]] = UNDEFINED
+) -> Optional[tuple[Number, Number]]:
     if isinstance(value, (float, int)):
         x, y = value, value
         return _to_int_or_float(x), _to_int_or_float(y)
@@ -98,11 +98,11 @@ def from_lon_360(lon_var: Union[np.ndarray, da.Array, xr.DataArray]):
         return da.where(lon_var <= 180.0, lon_var, lon_var - 360.0)
 
 
-def _default_xy_var_names(crs: pyproj.crs.CRS) -> Tuple[str, str]:
+def _default_xy_var_names(crs: pyproj.crs.CRS) -> tuple[str, str]:
     return ("lon", "lat") if crs.is_geographic else ("x", "y")
 
 
-def _default_xy_dim_names(crs: pyproj.crs.CRS) -> Tuple[str, str]:
+def _default_xy_dim_names(crs: pyproj.crs.CRS) -> tuple[str, str]:
     return _default_xy_var_names(crs)
 
 
@@ -134,7 +134,7 @@ _RESOLUTIONS = {
     100: (1, -1),
 }
 
-_RESOLUTION_SET = set(k / 100 for k in _RESOLUTIONS.keys())
+_RESOLUTION_SET = {k / 100 for k in _RESOLUTIONS.keys()}
 
 
 def round_to_fraction(value: float, digits: int = 2, resolution: float = 1) -> Fraction:
@@ -177,8 +177,8 @@ def round_to_fraction(value: float, digits: int = 2, resolution: float = 1) -> F
 
 
 def scale_xy_res_and_size(
-    xy_res: Tuple[float, float], size: Tuple[int, int], xy_scale: Tuple[float, float]
-) -> Tuple[Tuple[float, float], Tuple[int, int]]:
+    xy_res: tuple[float, float], size: tuple[int, int], xy_scale: tuple[float, float]
+) -> tuple[tuple[float, float], tuple[int, int]]:
     """Scale given *xy_res* and *size* using *xy_scale*.
     Make sure, size components are not less than 2.
     """

--- a/xcube/core/gridmapping/regular.py
+++ b/xcube/core/gridmapping/regular.py
@@ -58,12 +58,12 @@ class RegularGridMapping(GridMapping):
 
 
 def new_regular_grid_mapping(
-    size: Union[int, Tuple[int, int]],
-    xy_min: Tuple[float, float],
-    xy_res: Union[float, Tuple[float, float]],
+    size: Union[int, tuple[int, int]],
+    xy_min: tuple[float, float],
+    xy_res: Union[float, tuple[float, float]],
     crs: Union[str, pyproj.crs.CRS],
     *,
-    tile_size: Union[int, Tuple[int, int]] = None,
+    tile_size: Union[int, tuple[int, int]] = None,
     is_j_axis_up: bool = False
 ) -> GridMapping:
     width, height = _normalize_int_pair(size, name="size")
@@ -105,7 +105,7 @@ def new_regular_grid_mapping(
 def to_regular_grid_mapping(
     grid_mapping: GridMapping,
     *,
-    tile_size: Union[int, Tuple[int, int]] = None,
+    tile_size: Union[int, tuple[int, int]] = None,
     is_j_axis_up: bool = False
 ) -> GridMapping:
     if grid_mapping.is_regular:

--- a/xcube/core/gridmapping/transform.py
+++ b/xcube/core/gridmapping/transform.py
@@ -40,8 +40,8 @@ def transform_grid_mapping(
     grid_mapping: GridMapping,
     crs: Union[str, pyproj.crs.CRS],
     *,
-    tile_size: Union[int, Tuple[int, int]] = None,
-    xy_var_names: Tuple[str, str] = None,
+    tile_size: Union[int, tuple[int, int]] = None,
+    xy_var_names: tuple[str, str] = None,
     tolerance: float = DEFAULT_TOLERANCE,
 ) -> GridMapping:
     target_crs = _normalize_crs(crs)

--- a/xcube/core/level.py
+++ b/xcube/core/level.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import os
-from typing import List, Callable, Sequence, Optional, Tuple
+from typing import List, Callable, Optional, Tuple
+from collections.abc import Sequence
 
 import xarray as xr
 from deprecated import deprecated
@@ -29,14 +30,14 @@ _DEPRECATED_WRITE = (
 @deprecated(version="0.10.2", reason=_DEPRECATED_WRITE)
 def compute_levels(
     dataset: xr.Dataset,
-    spatial_dims: Tuple[str, str] = None,
-    spatial_shape: Tuple[int, int] = None,
-    spatial_tile_shape: Tuple[int, int] = None,
+    spatial_dims: tuple[str, str] = None,
+    spatial_shape: tuple[int, int] = None,
+    spatial_tile_shape: tuple[int, int] = None,
     var_names: Sequence[str] = None,
     num_levels_max: int = None,
     post_process_level: PyramidLevelCallback = None,
     progress_monitor: PyramidLevelCallback = None,
-) -> List[xr.Dataset]:
+) -> list[xr.Dataset]:
     """
     Transform the given *dataset* into the levels of a multi-level
     pyramid with spatial resolution decreasing by a factor of two
@@ -142,7 +143,7 @@ def write_levels(
     link_input: bool = False,
     progress_monitor: PyramidLevelCallback = None,
     **kwargs,
-) -> List[xr.Dataset]:
+) -> list[xr.Dataset]:
     """Transform the given dataset given by a *dataset* instance
     or *input_path* string into the levels of a multi-level pyramid
     with spatial resolution decreasing by a factor of two in both
@@ -205,7 +206,7 @@ def write_levels(
 @deprecated(version="0.10.2", reason=_DEPRECATED_READ)
 def read_levels(
     dir_path: str, progress_monitor: PyramidLevelCallback = None
-) -> List[xr.Dataset]:
+) -> list[xr.Dataset]:
     """Read the of a multi-level pyramid with spatial resolution
     decreasing by a factor of two in both spatial dimensions.
 
@@ -243,7 +244,7 @@ def read_levels(
     for index in range(num_levels):
         ext, file_path = level_paths[index]
         if ext == ".link":
-            with open(file_path, "r") as fp:
+            with open(file_path) as fp:
                 link_file_path = fp.read()
             if not os.path.isabs(link_file_path):
                 parent_dir_path = os.path.abspath(os.path.dirname(dir_path) or ".")
@@ -300,7 +301,7 @@ def _tile_level_dataset(level_dataset, spatial_tile_shape):
 
 def _compute_level_shapes(
     spatial_shape, spatial_tile_shape, num_levels_max=None
-) -> List[Tuple[int, int]]:
+) -> list[tuple[int, int]]:
     height, width = spatial_shape
     tile_height, tile_width = spatial_tile_shape
     num_levels_max = num_levels_max or -1

--- a/xcube/core/maskset.py
+++ b/xcube/core/maskset.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Dict, Any, Iterable
+from typing import Dict, Any
+from collections.abc import Iterable
 
 import dask.array as da
 import numpy as np
@@ -76,7 +77,7 @@ class MaskSet:
         )
 
     @classmethod
-    def get_mask_sets(cls, dataset: xr.Dataset) -> Dict[str, "MaskSet"]:
+    def get_mask_sets(cls, dataset: xr.Dataset) -> dict[str, "MaskSet"]:
         """For each "flag" variable in given *dataset*, turn it into a ``MaskSet``,
         store it in a dictionary.
 
@@ -110,9 +111,9 @@ class MaskSet:
         return "\n".join(lines)
 
     def __str__(self):
-        return "%s(%s)" % (
+        return "{}({})".format(
             self._flag_var.name,
-            ", ".join(["%s=%s" % (n, v) for n, v in self._flags.items()]),
+            ", ".join([f"{n}={v}" for n, v in self._flags.items()]),
         )
 
     def __dir__(self) -> Iterable[str]:

--- a/xcube/core/mldataset/abc.py
+++ b/xcube/core/mldataset/abc.py
@@ -5,7 +5,8 @@
 import math
 from abc import abstractmethod, ABCMeta
 from functools import cached_property
-from typing import Sequence, Any, Dict, Callable, Tuple
+from typing import Any, Dict, Callable, Tuple
+from collections.abc import Sequence
 
 import xarray as xr
 
@@ -57,7 +58,7 @@ class MultiLevelDataset(metaclass=ABCMeta):
         """
 
     @cached_property
-    def resolutions(self) -> Sequence[Tuple[float, float]]:
+    def resolutions(self) -> Sequence[tuple[float, float]]:
         """Returns:
         the x,y resolutions for each level given in the spatial
         units of the dataset's CRS (i.e. ``self.grid_mapping.crs``).
@@ -111,8 +112,8 @@ class MultiLevelDataset(metaclass=ABCMeta):
 
     def apply(
         self,
-        function: Callable[[xr.Dataset, Dict[str, Any]], xr.Dataset],
-        kwargs: Dict[str, Any] = None,
+        function: Callable[[xr.Dataset, dict[str, Any]], xr.Dataset],
+        kwargs: dict[str, Any] = None,
         ds_id: str = None,
     ) -> "MultiLevelDataset":
         """Apply function to all level datasets

--- a/xcube/core/mldataset/base.py
+++ b/xcube/core/mldataset/base.py
@@ -67,7 +67,7 @@ class BaseMultiLevelDataset(LazyMultiLevelDataset):
         gm = self.grid_mapping
         return get_num_levels(gm.size, gm.tile_size)
 
-    def _get_dataset_lazily(self, index: int, parameters: Dict[str, Any]) -> xr.Dataset:
+    def _get_dataset_lazily(self, index: int, parameters: dict[str, Any]) -> xr.Dataset:
         """Compute the dataset at level *index*: If *index* is zero, return
         the base image passed to constructor, otherwise down-sample the
         dataset for the level at given *index*.

--- a/xcube/core/mldataset/combined.py
+++ b/xcube/core/mldataset/combined.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Sequence, Any, Dict, Callable, Optional
+from typing import Any, Dict, Callable, Optional
+from collections.abc import Sequence
 
 import xarray as xr
 
@@ -34,7 +35,7 @@ class CombinedMultiLevelDataset(LazyMultiLevelDataset):
         ml_datasets: Sequence[MultiLevelDataset],
         ds_id: Optional[str] = None,
         combiner_function: Optional[Callable] = None,
-        combiner_params: Optional[Dict[str, Any]] = None,
+        combiner_params: Optional[dict[str, Any]] = None,
     ):
         if not ml_datasets or len(ml_datasets) < 2:
             raise ValueError("ml_datasets must have at least two elements")
@@ -46,7 +47,7 @@ class CombinedMultiLevelDataset(LazyMultiLevelDataset):
         return self._ml_datasets[0].num_levels
 
     def _get_dataset_lazily(
-        self, index: int, combiner_params: Dict[str, Any]
+        self, index: int, combiner_params: dict[str, Any]
     ) -> xr.Dataset:
         datasets = [ml_dataset.get_dataset(index) for ml_dataset in self._ml_datasets]
         if self._combiner_function is None:

--- a/xcube/core/mldataset/computed.py
+++ b/xcube/core/mldataset/computed.py
@@ -4,7 +4,8 @@
 
 import os.path
 import uuid
-from typing import Sequence, Any, Dict, Callable, Mapping, Optional, Tuple
+from typing import Any, Dict, Callable, Optional, Tuple
+from collections.abc import Sequence, Mapping
 
 import xarray as xr
 
@@ -67,7 +68,7 @@ class ComputedMultiLevelDataset(LazyMultiLevelDataset):
         input_parameters: Optional[Mapping[str, Any]] = None,
         ds_id: str = "",
         exception_type: type = ValueError,
-    ) -> Tuple[str, Callable]:
+    ) -> tuple[str, Callable]:
         assert_instance(script_path, str, name="script_path")
         assert_given(script_path, name="script_path")
         assert_true(
@@ -134,7 +135,7 @@ class ComputedMultiLevelDataset(LazyMultiLevelDataset):
     def _get_grid_mapping_lazily(self) -> GridMapping:
         return self.get_input_dataset(0).grid_mapping
 
-    def _get_dataset_lazily(self, index: int, parameters: Dict[str, Any]) -> xr.Dataset:
+    def _get_dataset_lazily(self, index: int, parameters: dict[str, Any]) -> xr.Dataset:
         input_datasets = [
             self._input_ml_dataset_getter(ds_id).get_dataset(index)
             for ds_id in self._input_ml_dataset_ids

--- a/xcube/core/mldataset/fs.py
+++ b/xcube/core/mldataset/fs.py
@@ -8,7 +8,8 @@ import math
 import pathlib
 import warnings
 from functools import cached_property
-from typing import Any, Optional, List, Union, Mapping, Dict, Sequence
+from typing import Any, Optional, List, Union, Dict
+from collections.abc import Mapping, Sequence
 
 import fsspec
 import fsspec.core
@@ -192,7 +193,7 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
                 )
         return num_levels
 
-    def _get_levels(self) -> List[int]:
+    def _get_levels(self) -> list[int]:
         levels = []
         paths = [
             self._get_path(entry["name"])
@@ -286,7 +287,7 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
             num_levels_max = min(num_levels, ml_dataset.num_levels)
 
         with fs.open(str(data_path / ".zlevels"), mode="w") as fp:
-            levels_data: Dict[str, Any] = dict(
+            levels_data: dict[str, Any] = dict(
                 version=LEVELS_FORMAT_VERSION, num_levels=num_levels_max
             )
             if use_saved_levels is not None:

--- a/xcube/core/mldataset/lazy.py
+++ b/xcube/core/mldataset/lazy.py
@@ -5,7 +5,8 @@
 import threading
 import uuid
 from abc import abstractmethod, ABCMeta
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Optional
+from collections.abc import Mapping
 
 import xarray as xr
 
@@ -39,7 +40,7 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
         self._grid_mapping = grid_mapping
         self._num_levels = num_levels
         self._ds_id = ds_id
-        self._level_datasets: Dict[int, xr.Dataset] = {}
+        self._level_datasets: dict[int, xr.Dataset] = {}
         self._parameters = parameters or {}
         self._lock = threading.RLock()
 
@@ -116,7 +117,7 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def _get_dataset_lazily(self, index: int, parameters: Dict[str, Any]) -> xr.Dataset:
+    def _get_dataset_lazily(self, index: int, parameters: dict[str, Any]) -> xr.Dataset:
         """Retrieve, i.e. read or compute, the dataset for the
         level at given *index*.
 

--- a/xcube/core/mldataset/mapped.py
+++ b/xcube/core/mldataset/mapped.py
@@ -16,7 +16,7 @@ class MappedMultiLevelDataset(LazyMultiLevelDataset):
         ml_dataset: MultiLevelDataset,
         mapper_function: Callable[[xr.Dataset], xr.Dataset],
         ds_id: str = None,
-        mapper_params: Dict[str, Any] = None,
+        mapper_params: dict[str, Any] = None,
     ):
         """"""
         super().__init__(ds_id=ds_id, parameters=mapper_params)
@@ -27,7 +27,7 @@ class MappedMultiLevelDataset(LazyMultiLevelDataset):
         return self._ml_dataset.num_levels
 
     def _get_dataset_lazily(
-        self, index: int, mapper_params: Dict[str, Any]
+        self, index: int, mapper_params: dict[str, Any]
     ) -> xr.Dataset:
         return self._mapper_function(
             self._ml_dataset.get_dataset(index), **mapper_params

--- a/xcube/core/normalize.py
+++ b/xcube/core/normalize.py
@@ -4,7 +4,8 @@
 
 import warnings
 from datetime import datetime
-from typing import Optional, Sequence, Union, Tuple
+from typing import Optional, Union, Tuple
+from collections.abc import Sequence
 
 import cftime
 import numpy as np
@@ -146,7 +147,7 @@ def decode_cube(
     force_copy: bool = False,
     force_non_empty: bool = False,
     force_geographic: bool = False,
-) -> Tuple[xr.Dataset, GridMapping, xr.Dataset]:
+) -> tuple[xr.Dataset, GridMapping, xr.Dataset]:
     """Decode a *dataset* into a cube variable subset, a grid mapping, and
     the non-cube variables of *dataset*.
 
@@ -769,10 +770,10 @@ def get_geo_spatial_attrs_from_var(
         return None
 
     var = ds[var_name]
-    res_name = "geospatial_{}_resolution".format(var_name)
-    min_name = "geospatial_{}_min".format(var_name)
-    max_name = "geospatial_{}_max".format(var_name)
-    units_name = "geospatial_{}_units".format(var_name)
+    res_name = f"geospatial_{var_name}_resolution"
+    min_name = f"geospatial_{var_name}_min"
+    max_name = f"geospatial_{var_name}_max"
+    units_name = f"geospatial_{var_name}_units"
 
     if "bounds" in var.attrs:
         # According to CF Conventions the corresponding 'bounds' coordinate variable name

--- a/xcube/core/optimize.py
+++ b/xcube/core/optimize.py
@@ -4,7 +4,8 @@
 
 import os.path
 import shutil
-from typing import Type, Union, Sequence
+from typing import Type, Union
+from collections.abc import Sequence
 
 import zarr
 
@@ -16,7 +17,7 @@ def optimize_dataset(
     output_path: str = None,
     in_place: bool = False,
     unchunk_coords: Union[bool, str, Sequence[str]] = False,
-    exception_type: Type[Exception] = ValueError,
+    exception_type: type[Exception] = ValueError,
 ):
     """Optimize a dataset for faster access.
 

--- a/xcube/core/reproject.py
+++ b/xcube/core/reproject.py
@@ -17,19 +17,19 @@ gdal.PushErrorHandler("CPLQuietErrorHandler")
 DEFAULT_RESAMPLING = "Nearest"
 DEFAULT_TP_RESAMPLING = "Bilinear"
 
-CoordRange = Tuple[float, float, float, float]
+CoordRange = tuple[float, float, float, float]
 
 
 def reproject_xy_to_wgs84(
     src_dataset: xr.Dataset,
-    src_xy_var_names: Tuple[str, str],
-    src_xy_tp_var_names: Tuple[str, str] = None,
+    src_xy_var_names: tuple[str, str],
+    src_xy_tp_var_names: tuple[str, str] = None,
     src_xy_crs: str = None,
-    src_xy_gcp_step: Union[int, Tuple[int, int]] = 10,
-    src_xy_tp_gcp_step: Union[int, Tuple[int, int]] = 1,
-    dst_size: Tuple[int, int] = None,
+    src_xy_gcp_step: Union[int, tuple[int, int]] = 10,
+    src_xy_tp_gcp_step: Union[int, tuple[int, int]] = 1,
+    dst_size: tuple[int, int] = None,
     dst_region: CoordRange = None,
-    dst_resampling: Union[str, Dict[str, str]] = DEFAULT_RESAMPLING,
+    dst_resampling: Union[str, dict[str, str]] = DEFAULT_RESAMPLING,
     include_xy_vars: bool = False,
     include_non_spatial_vars: bool = False,
 ) -> xr.Dataset:
@@ -358,7 +358,7 @@ def _get_resample_alg(dst_resampling, var_name, default):
     return resample_alg, resample_alg_name
 
 
-NAME_TO_GDAL_RESAMPLE_ALG: Dict[str, Any] = dict(
+NAME_TO_GDAL_RESAMPLE_ALG: dict[str, Any] = dict(
     # Up-sampling
     Nearest=gdal.GRA_NearestNeighbour,
     Bilinear=gdal.GRA_Bilinear,
@@ -409,7 +409,7 @@ def _ensure_valid_region(
 
 def _get_gcps(
     x_var: xr.DataArray, y_var: xr.DataArray, i_step: int, j_step: int
-) -> List[gdal.GCP]:
+) -> list[gdal.GCP]:
     x_values = x_var.values
     y_values = y_var.values
     i_size = x_var.shape[-1]
@@ -422,7 +422,7 @@ def _get_gcps(
         for i in np.linspace(0, i_size - 1, i_count, dtype=np.int32):
             x, y = float(x_values[j, i]), float(y_values[j, i])
             gcps.append(
-                gdal.GCP(x, y, 0.0, i + 0.5, j + 0.5, "%s,%s" % (i, j), str(gcp_id))
+                gdal.GCP(x, y, 0.0, i + 0.5, j + 0.5, f"{i},{j}", str(gcp_id))
             )
             gcp_id += 1
     return gcps

--- a/xcube/core/resampling/affine.py
+++ b/xcube/core/resampling/affine.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import math
-from typing import Union, Callable, Optional, Sequence, Tuple, Mapping, Hashable, Any
+from typing import Union, Callable, Optional, Tuple, Any
+from collections.abc import Sequence, Mapping, Hashable
 
 import numpy as np
 import xarray as xr
@@ -88,9 +89,9 @@ def affine_transform_dataset(
 def resample_dataset(
     dataset: xr.Dataset,
     matrix: AffineTransformMatrix,
-    size: Tuple[int, int],
-    tile_size: Tuple[int, int],
-    xy_dim_names: Tuple[str, str],
+    size: tuple[int, int],
+    tile_size: tuple[int, int],
+    xy_dim_names: tuple[str, str],
     var_configs: Mapping[Hashable, Mapping[str, Any]] = None,
 ) -> xr.Dataset:
     """Resample dataset according to an affine transformation.
@@ -151,9 +152,9 @@ def resample_dataset(
 
 def resample_ndimage(
     image: NDImage,
-    scale: Union[float, Tuple[float, float]] = 1,
-    offset: Union[float, Tuple[float, float]] = None,
-    shape: Union[int, Tuple[int, int]] = None,
+    scale: Union[float, tuple[float, float]] = 1,
+    offset: Union[float, tuple[float, float]] = None,
+    shape: Union[int, tuple[int, int]] = None,
     chunks: Sequence[int] = None,
     spline_order: int = 1,
     aggregator: Optional[Aggregator] = np.nanmean,
@@ -212,10 +213,10 @@ def resample_ndimage(
 
 def _transform_array(
     image: da.Array,
-    scale: Tuple[float, ...],
-    offset: Tuple[float, ...],
-    shape: Tuple[int, ...],
-    chunks: Optional[Tuple[int, ...]],
+    scale: tuple[float, ...],
+    offset: tuple[float, ...],
+    shape: tuple[int, ...],
+    chunks: Optional[tuple[int, ...]],
     spline_order: int,
     recover_nan: bool,
 ) -> da.Array:
@@ -279,10 +280,10 @@ def _transform_array(
 
 def resize_shape(
     shape: Sequence[int],
-    scale: Union[float, Tuple[float, ...]],
+    scale: Union[float, tuple[float, ...]],
     divisor_x: int = 1,
     divisor_y: int = 1,
-) -> Tuple[int, ...]:
+) -> tuple[int, ...]:
     scale = _normalize_scale(scale, len(shape))
     height, width = shape[-2], shape[-1]
     scale_y, scale_x = scale[-2], scale[-1]
@@ -294,8 +295,8 @@ def resize_shape(
 
 
 def _make_divisible_tiles(
-    larger_shape: Tuple[int, ...], divisor_x: int, divisor_y: int
-) -> Tuple[int, ...]:
+    larger_shape: tuple[int, ...], divisor_x: int, divisor_y: int
+) -> tuple[int, ...]:
     w = min(larger_shape[-1], divisor_x * ((2048 + divisor_x - 1) // divisor_x))
     h = min(larger_shape[-2], divisor_y * ((2048 + divisor_y - 1) // divisor_y))
     return (len(larger_shape) - 2) * (1,) + (h, w)
@@ -305,17 +306,17 @@ def _normalize_image(im: NDImage) -> da.Array:
     return da.asarray(im)
 
 
-def _normalize_offset(offset: Optional[Sequence[float]], ndim: int) -> Tuple[int, ...]:
+def _normalize_offset(offset: Optional[Sequence[float]], ndim: int) -> tuple[int, ...]:
     return _normalize_pair(offset, 0.0, ndim, "offset")
 
 
-def _normalize_scale(scale: Optional[Sequence[float]], ndim: int) -> Tuple[int, ...]:
+def _normalize_scale(scale: Optional[Sequence[float]], ndim: int) -> tuple[int, ...]:
     return _normalize_pair(scale, 1.0, ndim, "scale")
 
 
 def _normalize_pair(
     pair: Optional[Sequence[float]], default: float, ndim: int, name: str
-) -> Tuple[int, ...]:
+) -> tuple[int, ...]:
     if pair is None:
         pair = [default, default]
     elif isinstance(pair, (int, float)):
@@ -325,7 +326,7 @@ def _normalize_pair(
     return (ndim - 2) * (default,) + tuple(pair)
 
 
-def _normalize_shape(shape: Optional[Sequence[int]], im: NDImage) -> Tuple[int, ...]:
+def _normalize_shape(shape: Optional[Sequence[int]], im: NDImage) -> tuple[int, ...]:
     if shape is None:
         return im.shape
     if len(shape) != 2:
@@ -334,8 +335,8 @@ def _normalize_shape(shape: Optional[Sequence[int]], im: NDImage) -> Tuple[int, 
 
 
 def _normalize_chunks(
-    chunks: Optional[Sequence[int]], shape: Tuple[int, ...]
-) -> Optional[Tuple[int, ...]]:
+    chunks: Optional[Sequence[int]], shape: tuple[int, ...]
+) -> Optional[tuple[int, ...]]:
     if chunks is None:
         return None
     if len(chunks) < 2 or len(chunks) > len(shape):
@@ -344,7 +345,7 @@ def _normalize_chunks(
 
 
 def _is_no_op(
-    im: NDImage, scale: Sequence[float], offset: Sequence[float], shape: Tuple[int, ...]
+    im: NDImage, scale: Sequence[float], offset: Sequence[float], shape: tuple[int, ...]
 ):
     return (
         shape == im.shape

--- a/xcube/core/resampling/cf.py
+++ b/xcube/core/resampling/cf.py
@@ -55,13 +55,13 @@ def encode_grid_mapping(
         if (var.ndim >= 2 and var.dims[-1] == x_dim_name and var.dims[-2] == y_dim_name)
     ]
 
-    old_gm_names = set(
+    old_gm_names = {
         old_gm_name
         for old_gm_name in (
             var.attrs.get("grid_mapping") for var_name, var in spatial_vars
         )
         if old_gm_name and old_gm_name in ds_copy
-    )
+    }
     if old_gm_names:
         force = True if force is None else force
         gm_name = gm_name or next(iter(old_gm_names))

--- a/xcube/core/resampling/rectify.py
+++ b/xcube/core/resampling/rectify.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Mapping, Optional, Sequence, Tuple, Union
+from typing import Optional, Tuple, Union
+from collections.abc import Mapping, Sequence
 import warnings
 
 import dask.array as da
@@ -27,13 +28,13 @@ def rectify_dataset(
     target_gm: GridMapping = None,
     encode_cf: bool = True,
     gm_name: Optional[str] = None,
-    tile_size: Union[int, Tuple[int, int]] = None,
+    tile_size: Union[int, tuple[int, int]] = None,
     is_j_axis_up: bool = None,
-    output_ij_names: Tuple[str, str] = None,
+    output_ij_names: tuple[str, str] = None,
     compute_subset: bool = True,
     uv_delta: float = 1e-3,
     interpolation: Optional[str] = None,
-    xy_var_names: Tuple[str, str] = None,
+    xy_var_names: tuple[str, str] = None,
 ) -> Optional[xr.Dataset]:
     """Reproject dataset *source_ds* using its per-pixel
     x,y coordinates or the given *source_gm*.
@@ -333,8 +334,8 @@ def _compute_ij_images_xarray_dask(
 def _compute_ij_images_xarray_dask_block(
     dtype: np.dtype,
     block_id: int,
-    block_shape: Tuple[int, int],
-    block_slices: Tuple[Tuple[int, int], Tuple[int, int], Tuple[int, int]],
+    block_shape: tuple[int, int],
+    block_slices: tuple[tuple[int, int], tuple[int, int], tuple[int, int]],
     src_xy_coords: xr.DataArray,
     src_ij_bboxes: np.ndarray,
     dst_x_min: float,

--- a/xcube/core/resampling/spatial.py
+++ b/xcube/core/resampling/spatial.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Union, Callable, Mapping, Hashable, Any, Optional
+from typing import Union, Callable, Any, Optional
+from collections.abc import Mapping, Hashable
 
 import numpy as np
 import xarray as xr

--- a/xcube/core/resampling/temporal.py
+++ b/xcube/core/resampling/temporal.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import warnings
-from typing import Dict, Any, Sequence, Union
+from typing import Dict, Any, Union
+from collections.abc import Sequence
 
 import numpy as np
 import xarray as xr
@@ -22,7 +23,7 @@ def resample_in_time(
     interp_kind=None,
     time_chunk_size=None,
     var_names: Sequence[str] = None,
-    metadata: Dict[str, Any] = None,
+    metadata: dict[str, Any] = None,
     cube_asserted: bool = False,
 ) -> xr.Dataset:
     """Resample a dataset in the time dimension.

--- a/xcube/core/schema.py
+++ b/xcube/core/schema.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Tuple, Sequence, Dict, Optional, Mapping, Union, Hashable
+from typing import Tuple, Dict, Optional, Union
+from collections.abc import Sequence, Mapping, Hashable
 
 import numpy as np
 import xarray as xr
@@ -103,7 +104,7 @@ class CubeSchema:
         return len(self._dims)
 
     @property
-    def dims(self) -> Tuple[str, ...]:
+    def dims(self) -> tuple[str, ...]:
         """Tuple of dimension names."""
         return self._dims
 
@@ -168,17 +169,17 @@ class CubeSchema:
         return self._shape[0]
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> tuple[int, ...]:
         """Tuple of dimension sizes."""
         return self._shape
 
     @property
-    def chunks(self) -> Optional[Tuple[int]]:
+    def chunks(self) -> Optional[tuple[int]]:
         """Tuple of dimension chunk sizes."""
         return self._chunks
 
     @property
-    def coords(self) -> Dict[str, xr.DataArray]:
+    def coords(self) -> dict[str, xr.DataArray]:
         """Dictionary of coordinate variables."""
         return self._coords
 
@@ -284,7 +285,7 @@ def get_dataset_xy_var_names(
     coords: Union[xr.Dataset, xr.DataArray, Mapping[Hashable, xr.DataArray]],
     must_exist: bool = False,
     dataset_arg_name: str = "dataset",
-) -> Optional[Tuple[str, str]]:
+) -> Optional[tuple[str, str]]:
     if hasattr(coords, "coords"):
         coords = coords.coords
     x_var_name = None
@@ -377,7 +378,7 @@ def get_dataset_bounds_var_name(
     return None
 
 
-def get_dataset_chunks(dataset: xr.Dataset) -> Dict[Hashable, int]:
+def get_dataset_chunks(dataset: xr.Dataset) -> dict[Hashable, int]:
     """Get the most common chunk sizes for each
     chunked dimension of *dataset*.
 
@@ -392,7 +393,7 @@ def get_dataset_chunks(dataset: xr.Dataset) -> Dict[Hashable, int]:
 
     # Record the frequencies of chunk sizes for
     # each dimension d in each data variable var
-    dim_size_counts: Dict[Hashable, Dict[int, int]] = {}
+    dim_size_counts: dict[Hashable, dict[int, int]] = {}
     for var_name, var in dataset.data_vars.items():
         if var.chunks:
             for d, c in zip(var.dims, var.chunks):
@@ -413,7 +414,7 @@ def get_dataset_chunks(dataset: xr.Dataset) -> Dict[Hashable, int]:
 
     # For each dimension d, determine the most frequently
     # seen chunk size max_c
-    dim_sizes: Dict[Hashable, int] = {}
+    dim_sizes: dict[Hashable, int] = {}
     for d, size_counts in dim_size_counts.items():
         max_count = 0
         best_max_c = 0
@@ -431,9 +432,9 @@ def get_dataset_chunks(dataset: xr.Dataset) -> Dict[Hashable, int]:
 def rechunk_cube(
     cube: xr.Dataset,
     gm: GridMapping,
-    chunks: Optional[Dict[str, int]] = None,
-    tile_size: Optional[Tuple[int, int]] = None,
-) -> Tuple[xr.Dataset, GridMapping]:
+    chunks: Optional[dict[str, int]] = None,
+    tile_size: Optional[tuple[int, int]] = None,
+) -> tuple[xr.Dataset, GridMapping]:
     """Re-chunk data variables of *cube* so they all share the same chunk
     sizes for their dimensions.
 

--- a/xcube/core/select.py
+++ b/xcube/core/select.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import warnings
-from typing import Collection, Optional, Tuple, Callable, Dict, Any, List, Mapping
+from typing import Optional, Tuple, Callable, Dict, Any, List
+from collections.abc import Collection, Mapping
 from typing import Union
 
 import cftime
@@ -16,10 +17,10 @@ from xcube.core.gridmapping import GridMapping
 from xcube.util.assertions import assert_given
 from xcube.util.timeindex import ensure_time_index_compatible
 
-Bbox = Tuple[float, float, float, float]
+Bbox = tuple[float, float, float, float]
 TimeRange = Union[
-    Tuple[Optional[str], Optional[str]],
-    Tuple[Optional[pd.Timestamp], Optional[pd.Timestamp]],
+    tuple[Optional[str], Optional[str]],
+    tuple[Optional[pd.Timestamp], Optional[pd.Timestamp]],
 ]
 
 
@@ -86,9 +87,9 @@ def select_variables_subset(
 
 def select_spatial_subset(
     dataset: xr.Dataset,
-    ij_bbox: Optional[Tuple[int, int, int, int]] = None,
+    ij_bbox: Optional[tuple[int, int, int, int]] = None,
     ij_border: int = 0,
-    xy_bbox: Optional[Tuple[float, float, float, float]] = None,
+    xy_bbox: Optional[tuple[float, float, float, float]] = None,
     xy_border: float = 0.0,
     grid_mapping: Optional[GridMapping] = None,
 ) -> Optional[xr.Dataset]:
@@ -217,7 +218,7 @@ _PREDICATE_SIGNATURE = (
     "predicate(" "slice_array: xr.DataArray, " "slice_info: Dict" ") -> bool"
 )
 
-Predicate = Callable[[xr.DataArray, Dict[str, Any]], bool]
+Predicate = Callable[[xr.DataArray, dict[str, Any]], bool]
 
 
 def select_label_subset(
@@ -327,7 +328,7 @@ def _is_label_valid(
     dataset: xr.Dataset, predicate_lookup: Mapping[str, Predicate], dim: str, index: int
 ) -> da.Array:
     label = dataset[dim][index] if dim in dataset else None
-    results: List[da.Array] = []
+    results: list[da.Array] = []
     for var_name, var in dataset.data_vars.items():
         if dim in var.dims:
             predicate = predicate_lookup.get(var_name)

--- a/xcube/core/sentinel3.py
+++ b/xcube/core/sentinel3.py
@@ -3,15 +3,16 @@
 # https://opensource.org/licenses/MIT.
 
 import os
-from typing import Set, Mapping, Tuple, Union
+from typing import Set, Tuple, Union
+from collections.abc import Mapping
 
 import xarray as xr
 
 
 def open_sentinel3_product(
     path: str,
-    var_names: Set[str] = None,
-    chunks: Mapping[str, Union[int, Tuple[int, ...]]] = None,
+    var_names: set[str] = None,
+    chunks: Mapping[str, Union[int, tuple[int, ...]]] = None,
 ) -> xr.Dataset:
     """Open a Sentinel-3 product from given path.
 
@@ -28,9 +29,9 @@ def open_sentinel3_product(
     y_name = "latitude"
     data_vars = {}
     geo_vars_file_name = "geo_coordinates.nc"
-    file_names = set(
+    file_names = {
         file_name for file_name in os.listdir(path) if file_name.endswith(".nc")
-    )
+    }
     if geo_vars_file_name not in file_names:
         raise ValueError(f"missing file {geo_vars_file_name!r} in {path}")
     file_names.remove(geo_vars_file_name)

--- a/xcube/core/store/accessor.py
+++ b/xcube/core/store/accessor.py
@@ -86,7 +86,7 @@ def new_data_writer(
 def find_data_opener_extensions(
     predicate: ExtensionPredicate = None,
     extension_registry: Optional[ExtensionRegistry] = None,
-) -> List[Extension]:
+) -> list[Extension]:
     """Get registered data opener extensions using the optional
     filter function *predicate*.
 
@@ -107,7 +107,7 @@ def find_data_opener_extensions(
 def find_data_writer_extensions(
     predicate: ExtensionPredicate = None,
     extension_registry: Optional[ExtensionRegistry] = None,
-) -> List[Extension]:
+) -> list[Extension]:
     """Get registered data writer extensions using the optional filter
     function *predicate*.
 

--- a/xcube/core/store/assertions.py
+++ b/xcube/core/store/assertions.py
@@ -12,7 +12,7 @@ from .error import DataStoreError
 
 
 def assert_valid_params(
-    params: Optional[Dict[str, Any]],
+    params: Optional[dict[str, Any]],
     schema: Optional[JsonObjectSchema] = None,
     name: str = "params",
 ):
@@ -28,7 +28,7 @@ def assert_valid_params(
 
 
 def assert_valid_config(
-    config: Optional[Dict[str, Any]],
+    config: Optional[dict[str, Any]],
     schema: Optional[JsonObjectSchema] = None,
     name: str = "config",
 ):
@@ -42,25 +42,25 @@ def assert_valid_config(
     _assert_valid(config, schema, name, "configuration", _validate_config)
 
 
-def _validate_params(params: Dict[str, Any], schema: JsonObjectSchema):
+def _validate_params(params: dict[str, Any], schema: JsonObjectSchema):
     # Note, params is a dictionary of Python objects.
     # Convert them to a JSON instance
     # and perform JSON Schema validation
     schema.validate_instance(params)
 
 
-def _validate_config(config: Dict[str, Any], schema: JsonObjectSchema):
+def _validate_config(config: dict[str, Any], schema: JsonObjectSchema):
     # Note, config is already a JSON object.
     # Perform JSON Schema validation directly.
     schema.validate_instance(config)
 
 
 def _assert_valid(
-    obj: Optional[Dict[str, Any]],
+    obj: Optional[dict[str, Any]],
     schema: Optional[JsonObjectSchema],
     name: str,
     kind: str,
-    validator: Callable[[Dict[str, Any], JsonObjectSchema], Any],
+    validator: Callable[[dict[str, Any], JsonObjectSchema], Any],
 ):
     if obj is None:
         return

--- a/xcube/core/store/datatype.py
+++ b/xcube/core/store/datatype.py
@@ -5,7 +5,8 @@
 import os
 from abc import ABC, abstractmethod
 
-from typing import Sequence, Tuple, Iterator, Generic, TypeVar, Any
+from typing import Tuple, Generic, TypeVar, Any
+from collections.abc import Sequence, Iterator
 from typing import Type, List
 from typing import Union
 
@@ -30,14 +31,14 @@ class DataType:
     """
 
     _READTHEDOCS = os.environ.get("READTHEDOCS") == "True"
-    _REGISTERED_DATA_TYPES: List["DataType"] = []
+    _REGISTERED_DATA_TYPES: list["DataType"] = []
 
     @classmethod
     def register_data_type(cls, data_type: "DataType"):
         assert_instance(data_type, DataType, name="data_type")
         cls._REGISTERED_DATA_TYPES.append(data_type)
 
-    def __init__(self, dtype: Type, alias: Union[None, str, Sequence[str]] = None):
+    def __init__(self, dtype: type, alias: Union[None, str, Sequence[str]] = None):
         """
         Args:
             dtype: The Python data type.
@@ -69,7 +70,7 @@ class DataType:
         return hash(self.dtype) + 16 * hash(self.aliases)
 
     @property
-    def dtype(self) -> Type:
+    def dtype(self) -> type:
         """The Python data type."""
         return self._dtype
 
@@ -79,7 +80,7 @@ class DataType:
         return self._aliases[0]
 
     @property
-    def aliases(self) -> Tuple[str, ...]:
+    def aliases(self) -> tuple[str, ...]:
         """All alias names."""
         return tuple(self._aliases)
 
@@ -140,7 +141,7 @@ class DataType:
         return JsonStringSchema(min_length=1, factory=cls.normalize, serializer=str)
 
     @classmethod
-    def _normalize_dtype(cls, data_type: DataTypeLike) -> Type:
+    def _normalize_dtype(cls, data_type: DataTypeLike) -> type:
         if isinstance(data_type, DataType):
             return data_type.dtype
         if isinstance(data_type, type):
@@ -148,7 +149,7 @@ class DataType:
         return cls.normalize(data_type).dtype
 
     @staticmethod
-    def _get_fully_qualified_type_name(data_type: Type) -> str:
+    def _get_fully_qualified_type_name(data_type: type) -> str:
         return f"{data_type.__module__}.{data_type.__name__}"
 
 

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import warnings
-from typing import Tuple, Sequence, Mapping, Optional, Dict, Any, Union, Hashable
+from typing import Tuple, Optional, Dict, Any, Union
+from collections.abc import Sequence, Mapping, Hashable
 
 import dask.array
 import geopandas as gpd
@@ -74,7 +75,7 @@ def new_data_descriptor(
 
 def _get_common_dataset_descriptor_props(
     data_id: str, dataset: Union[xr.Dataset, MultiLevelDataset]
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     dims = {str(k): v for k, v in dataset.sizes.items()}
     coords = _build_variable_descriptor_dict(dataset.coords)
     data_vars = _build_variable_descriptor_dict(dataset.data_vars)
@@ -119,8 +120,8 @@ class DataDescriptor(JsonObject):
         data_type: DataTypeLike,
         *,
         crs: str = None,
-        bbox: Tuple[float, float, float, float] = None,
-        time_range: Tuple[Optional[str], Optional[str]] = None,
+        bbox: tuple[float, float, float, float] = None,
+        time_range: tuple[Optional[str], Optional[str]] = None,
         time_period: str = None,
         open_params_schema: JsonObjectSchema = None,
         **additional_properties,
@@ -199,8 +200,8 @@ class DatasetDescriptor(DataDescriptor):
         *,
         data_type: DataTypeLike = DATASET_TYPE,
         crs: str = None,
-        bbox: Tuple[float, float, float, float] = None,
-        time_range: Tuple[Optional[str], Optional[str]] = None,
+        bbox: tuple[float, float, float, float] = None,
+        time_range: tuple[Optional[str], Optional[str]] = None,
         time_period: str = None,
         spatial_res: float = None,
         dims: Mapping[str, int] = None,
@@ -424,7 +425,7 @@ def _build_variable_descriptor_dict(variables) -> Mapping[str, "VariableDescript
     }
 
 
-def _determine_bbox(data: xr.Dataset) -> Optional[Tuple[float, float, float, float]]:
+def _determine_bbox(data: xr.Dataset) -> Optional[tuple[float, float, float, float]]:
     try:
         return get_dataset_bounds(data)
     except ValueError:
@@ -493,8 +494,8 @@ def _determine_time_period(data: xr.Dataset):
             return time_period.split("T")[0]
 
 
-def _attrs_to_json(attrs: Mapping[Hashable, Any]) -> Optional[Dict[str, Any]]:
-    new_attrs: Dict[str, Any] = {}
+def _attrs_to_json(attrs: Mapping[Hashable, Any]) -> Optional[dict[str, Any]]:
+    new_attrs: dict[str, Any] = {}
     for k, v in attrs.items():
         if isinstance(v, np.ndarray):
             v = v.tolist()

--- a/xcube/core/store/fs/accessor.py
+++ b/xcube/core/store/fs/accessor.py
@@ -58,8 +58,8 @@ class FsAccessor:
 
     @classmethod
     def load_fs(
-        cls, params: Dict[str, Any]
-    ) -> Tuple[fsspec.AbstractFileSystem, Optional[str], Dict[str, Any]]:
+        cls, params: dict[str, Any]
+    ) -> tuple[fsspec.AbstractFileSystem, Optional[str], dict[str, Any]]:
         """
         Load a filesystem instance from *params*.
 

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -350,7 +350,7 @@ class DatasetGeoTiffFsDataAccessor(DatasetFsDataAccessor):
         cls,
         fs,
         file_path: str,
-        tile_size: Tuple[int, int],
+        tile_size: tuple[int, int],
         overview_level: Optional[int] = None,
     ) -> xr.Dataset:
         """

--- a/xcube/core/store/fs/impl/geotiff.py
+++ b/xcube/core/store/fs/impl/geotiff.py
@@ -35,7 +35,7 @@ class GeoTIFFMultiLevelDataset(LazyMultiLevelDataset):
         fs: fsspec.AbstractFileSystem,
         root: Optional[str],
         data_id: str,
-        **open_params: Dict[str, Any]
+        **open_params: dict[str, Any]
     ):
         super().__init__(ds_id=data_id)
         self._fs = fs

--- a/xcube/core/store/fs/registry.py
+++ b/xcube/core/store/fs/registry.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Type, Dict, Optional, Any, Sequence
+from typing import Type, Dict, Optional, Any
+from collections.abc import Sequence
 
 import fsspec
 
@@ -28,10 +29,10 @@ from ..error import DataStoreError
 ############################################
 # FsAccessor
 
-_FS_ACCESSOR_CLASSES: Dict[str, Type[FsAccessor]] = {}
+_FS_ACCESSOR_CLASSES: dict[str, type[FsAccessor]] = {}
 
 
-def register_fs_accessor_class(fs_accessor_class: Type[FsAccessor]):
+def register_fs_accessor_class(fs_accessor_class: type[FsAccessor]):
     """Register a concrete filesystem accessor class.
 
     Args:
@@ -52,7 +53,7 @@ for cls in (
     register_fs_accessor_class(cls)
 
 
-def get_fs_accessor_class(protocol: str) -> Type[FsAccessor]:
+def get_fs_accessor_class(protocol: str) -> type[FsAccessor]:
     """Get the class for a filesystem accessor.
 
     Args:
@@ -88,10 +89,10 @@ def get_fs_accessor_class(protocol: str) -> Type[FsAccessor]:
 ############################################
 # FsDataAccessor
 
-_FS_DATA_ACCESSOR_CLASSES: Dict[str, Type[FsDataAccessor]] = {}
+_FS_DATA_ACCESSOR_CLASSES: dict[str, type[FsDataAccessor]] = {}
 
 
-def register_fs_data_accessor_class(fs_data_accessor_class: Type[FsDataAccessor]):
+def register_fs_data_accessor_class(fs_data_accessor_class: type[FsDataAccessor]):
     """Register an abstract filesystem data accessor class.
 
     Such data accessor classes are used to dynamically
@@ -123,7 +124,7 @@ for cls in (
 
 def get_fs_data_accessor_class(
     protocol: str, data_type_alias: str, format_id: str
-) -> Type[FsDataAccessor]:
+) -> type[FsDataAccessor]:
     """Get the class for a filesystem data accessor.
 
     Args:
@@ -158,7 +159,7 @@ def get_fs_data_accessor_class(
 # FsDataStore
 
 
-def get_fs_data_store_class(protocol: str) -> Type[FsDataStore]:
+def get_fs_data_store_class(protocol: str) -> type[FsDataStore]:
     """Get the class for of a filesystem-based data store.
 
     Args:
@@ -185,7 +186,7 @@ def new_fs_data_store(
     read_only: bool = False,
     includes: Optional[Sequence[str]] = None,
     excludes: Optional[Sequence[str]] = None,
-    storage_options: Dict[str, Any] = None,
+    storage_options: dict[str, Any] = None,
 ) -> FsDataStore:
     """Create a new instance of a filesystem-based data store.
 

--- a/xcube/core/store/fs/store.py
+++ b/xcube/core/store/fs/store.py
@@ -10,16 +10,14 @@ import warnings
 from threading import RLock
 from typing import (
     Optional,
-    Iterator,
     Any,
     Tuple,
     List,
     Dict,
     Union,
-    Container,
     Callable,
-    Sequence,
 )
+from collections.abc import Iterator, Container, Sequence
 
 import fsspec
 import geopandas as gpd
@@ -91,7 +89,7 @@ _FORMAT_TO_DATA_TYPE_ALIASES = {
 }
 
 _DataId = str
-_DataIdTuple = Tuple[_DataId, Dict[str, Any]]
+_DataIdTuple = tuple[_DataId, dict[str, Any]]
 _DataIdIter = Iterator[_DataId]
 _DataIdTupleIter = Iterator[_DataIdTuple]
 _DataIds = Union[_DataIdIter, _DataIdTupleIter]
@@ -203,12 +201,12 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
         return self._read_only
 
     @property
-    def includes(self) -> Tuple[str]:
+    def includes(self) -> tuple[str]:
         """Wildcard patterns that include paths."""
         return self._includes
 
     @property
-    def excludes(self) -> Tuple[str]:
+    def excludes(self) -> tuple[str]:
         """Wildcard patterns that exclude paths."""
         return self._excludes
 
@@ -236,16 +234,16 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
         )
 
     @classmethod
-    def get_data_types(cls) -> Tuple[str, ...]:
+    def get_data_types(cls) -> tuple[str, ...]:
         return tuple(
-            set(
+            {
                 data_type
                 for types_tuple in _FORMAT_TO_DATA_TYPE_ALIASES.values()
                 for data_type in types_tuple
-            )
+            }
         )
 
-    def get_data_types_for_data(self, data_id: str) -> Tuple[str, ...]:
+    def get_data_types_for_data(self, data_id: str) -> tuple[str, ...]:
         self._assert_valid_data_id(data_id)
         data_type_alias, format_id, protocol = self._guess_accessor_id_parts(data_id)
         data_type_aliases = [data_type_alias]
@@ -290,7 +288,7 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
 
     def get_data_opener_ids(
         self, data_id: str = None, data_type: DataTypeLike = None
-    ) -> Tuple[str, ...]:
+    ) -> tuple[str, ...]:
         data_type = DataType.normalize(data_type)
         format_id = None
         storage_id = self.protocol
@@ -325,7 +323,7 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
         fs_path = self._convert_data_id_into_fs_path(data_id)
         return opener.open_data(fs_path, fs=self.fs, root=self.root, **open_params)
 
-    def get_data_writer_ids(self, data_type: str = None) -> Tuple[str, ...]:
+    def get_data_writer_ids(self, data_type: str = None) -> tuple[str, ...]:
         data_type = DataType.normalize(data_type)
         return tuple(
             ext.name
@@ -562,7 +560,7 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
 
     def _find_accessor_extensions(
         self, find_data_accessor_extensions: Callable, data_id: str = None, require=True
-    ) -> List[Extension]:
+    ) -> list[Extension]:
         if data_id:
             accessor_id_parts = self._guess_accessor_id_parts(data_id, require=require)
             if not accessor_id_parts:
@@ -598,7 +596,7 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
 
     def _guess_accessor_id_parts(
         self, data_id: str, require=True
-    ) -> Optional[Tuple[str, str, str]]:
+    ) -> Optional[tuple[str, str, str]]:
         assert_given(data_id, "data_id")
         ext = self._get_filename_ext(data_id)
         data_type_aliases = None
@@ -673,7 +671,7 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
                     yield data_id
 
     @staticmethod
-    def _normalize_wc(wc: Optional[Union[str, Sequence[str]]]) -> Tuple[str]:
+    def _normalize_wc(wc: Optional[Union[str, Sequence[str]]]) -> tuple[str]:
         return tuple() if not wc else (wc,) if isinstance(wc, str) else tuple(wc)
 
 
@@ -716,7 +714,7 @@ class FsDataStore(BaseFsDataStore, FsAccessor):
         read_only: bool = False,
         includes: Optional[Sequence[str]] = None,
         excludes: Optional[Sequence[str]] = None,
-        storage_options: Dict[str, Any] = None,
+        storage_options: dict[str, Any] = None,
     ):
         self._storage_options = storage_options or {}
         super().__init__(
@@ -735,7 +733,7 @@ class FsDataStore(BaseFsDataStore, FsAccessor):
         return self.get_protocol()
 
     @property
-    def storage_options(self) -> Dict[str, Any]:
+    def storage_options(self) -> dict[str, Any]:
         return self._storage_options
 
     def _load_fs(self) -> fsspec.AbstractFileSystem:

--- a/xcube/core/store/ref/store.py
+++ b/xcube/core/store/ref/store.py
@@ -4,7 +4,8 @@
 
 import os
 import warnings
-from typing import Iterator, Any, Tuple, Container, Union, Dict, List
+from typing import Any, Tuple, Union, Dict, List
+from collections.abc import Iterator, Container
 
 import fsspec
 import xarray as xr
@@ -53,7 +54,7 @@ class ReferenceDataStore(DataStore):
 
     def __init__(
         self,
-        refs: List[str],
+        refs: list[str],
         **ref_kwargs,
     ):
         self._refs = dict(self._normalize_ref(ref) for ref in refs)
@@ -64,15 +65,15 @@ class ReferenceDataStore(DataStore):
         return REF_STORE_SCHEMA
 
     @classmethod
-    def get_data_types(cls) -> Tuple[str, ...]:
+    def get_data_types(cls) -> tuple[str, ...]:
         return ("dataset",)
 
-    def get_data_types_for_data(self, data_id: str) -> Tuple[str, ...]:
+    def get_data_types_for_data(self, data_id: str) -> tuple[str, ...]:
         return self.get_data_types()
 
     def get_data_ids(
         self, data_type: DataTypeLike = None, include_attrs: Container[str] = None
-    ) -> Union[Iterator[str], Iterator[Tuple[str, Dict[str, Any]]]]:
+    ) -> Union[Iterator[str], Iterator[tuple[str, dict[str, Any]]]]:
         return iter(self._refs.keys())
 
     def has_data(self, data_id: str, data_type: DataTypeLike = None) -> bool:
@@ -90,7 +91,7 @@ class ReferenceDataStore(DataStore):
 
     def get_data_opener_ids(
         self, data_id: str = None, data_type: DataTypeLike = None
-    ) -> Tuple[str, ...]:
+    ) -> tuple[str, ...]:
         return ("dataset:zarr:reference",)
 
     def get_open_data_params_schema(
@@ -131,8 +132,8 @@ class ReferenceDataStore(DataStore):
 
     @classmethod
     def _normalize_ref(
-        cls, ref: Union[str, Dict[str, Any]]
-    ) -> Tuple[str, Dict[str, Any]]:
+        cls, ref: Union[str, dict[str, Any]]
+    ) -> tuple[str, dict[str, Any]]:
         if isinstance(ref, str):
             ref_path = ref
             data_id = cls._ref_path_to_data_id(ref_path)

--- a/xcube/core/store/search.py
+++ b/xcube/core/store/search.py
@@ -3,7 +3,7 @@
 # https://opensource.org/licenses/MIT.
 
 from abc import abstractmethod, ABC
-from typing import Iterator
+from collections.abc import Iterator
 
 from xcube.util.jsonschema import JsonObjectSchema
 from .assertions import assert_valid_params

--- a/xcube/core/store/store.py
+++ b/xcube/core/store/store.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 from abc import abstractmethod, ABC
-from typing import Iterator, Tuple, Any, Optional, List, Type, Dict, Union, Container
+from typing import Tuple, Any, Optional, List, Type, Dict, Union
+from collections.abc import Iterator, Container
 
 from xcube.constants import EXTENSION_POINT_DATA_STORES
 from xcube.util.extension import Extension
@@ -55,7 +56,7 @@ def new_data_store(
 
 def get_data_store_class(
     data_store_id: str, extension_registry: Optional[ExtensionRegistry] = None
-) -> Union[Type["DataStore"], Type["MutableDataStore"]]:
+) -> Union[type["DataStore"], type["MutableDataStore"]]:
     """Get the class for the data store identified by *data_store_id*.
 
     Args:
@@ -98,7 +99,7 @@ def get_data_store_params_schema(
 def find_data_store_extensions(
     predicate: ExtensionPredicate = None,
     extension_registry: Optional[ExtensionRegistry] = None,
-) -> List[Extension]:
+) -> list[Extension]:
     """Find data store extensions using the optional filter
     function *predicate*.
 
@@ -151,7 +152,7 @@ class DataStore(DataOpener, DataSearcher, ABC):
 
     @classmethod
     @abstractmethod
-    def get_data_types(cls) -> Tuple[str, ...]:
+    def get_data_types(cls) -> tuple[str, ...]:
         """Get alias names for all data types supported by this store.
         The first entry in the tuple represents this store's
         default data type.
@@ -161,7 +162,7 @@ class DataStore(DataOpener, DataSearcher, ABC):
         """
 
     @abstractmethod
-    def get_data_types_for_data(self, data_id: str) -> Tuple[str, ...]:
+    def get_data_types_for_data(self, data_id: str) -> tuple[str, ...]:
         """Get alias names for of data types that are supported
         by this store for the given *data_id*.
 
@@ -179,7 +180,7 @@ class DataStore(DataOpener, DataSearcher, ABC):
     @abstractmethod
     def get_data_ids(
         self, data_type: DataTypeLike = None, include_attrs: Container[str] = None
-    ) -> Union[Iterator[str], Iterator[Tuple[str, Dict[str, Any]]]]:
+    ) -> Union[Iterator[str], Iterator[tuple[str, dict[str, Any]]]]:
         """Get an iterator over the data resource identifiers for the
         given type *data_type*. If *data_type* is omitted, all data
         resource identifiers are returned.
@@ -234,7 +235,7 @@ class DataStore(DataOpener, DataSearcher, ABC):
 
     def list_data_ids(
         self, data_type: DataTypeLike = None, include_attrs: Container[str] = None
-    ) -> Union[List[str], List[Tuple[str, Dict[str, Any]]]]:
+    ) -> Union[list[str], list[tuple[str, dict[str, Any]]]]:
         """Convenience version of `get_data_ids()` that returns a list rather
         than an iterator.
 
@@ -300,7 +301,7 @@ class DataStore(DataOpener, DataSearcher, ABC):
     @abstractmethod
     def get_data_opener_ids(
         self, data_id: str = None, data_type: DataTypeLike = None
-    ) -> Tuple[str, ...]:
+    ) -> tuple[str, ...]:
         """Get identifiers of data openers that can be used to open data
         resources from this store.
 
@@ -445,7 +446,7 @@ class MutableDataStore(DataStore, DataWriter, ABC):
     """
 
     @abstractmethod
-    def get_data_writer_ids(self, data_type: DataTypeLike = None) -> Tuple[str, ...]:
+    def get_data_writer_ids(self, data_type: DataTypeLike = None) -> tuple[str, ...]:
         """Get identifiers of data writers that can be used to write data
         resources to this store.
 

--- a/xcube/core/store/storepool.py
+++ b/xcube/core/store/storepool.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import os.path
-from typing import Any, Dict, Optional, List, Union, Mapping
+from typing import Any, Dict, Optional, List, Union
+from collections.abc import Mapping
 
 from xcube.util.assertions import assert_given
 from xcube.util.assertions import assert_instance
@@ -20,7 +21,7 @@ from ...util.config import load_json_or_yaml_config
 
 def get_data_store_instance(
     store_id: str,
-    store_params: Dict[str, Any] = None,
+    store_params: dict[str, Any] = None,
     store_pool: "DataStorePool" = None,
 ) -> "DataStoreInstance":
     """Get a data store instance for identifier *store_id*.
@@ -126,7 +127,7 @@ class DataStoreConfig:
         return self._store_id
 
     @property
-    def store_params(self) -> Optional[Dict[str, Any]]:
+    def store_params(self) -> Optional[dict[str, Any]]:
         return self._store_params
 
     @property
@@ -142,7 +143,7 @@ class DataStoreConfig:
         return self._user_data
 
     @classmethod
-    def from_dict(cls, data_store_config: Dict[str, Any]) -> "DataStoreConfig":
+    def from_dict(cls, data_store_config: dict[str, Any]) -> "DataStoreConfig":
         assert_valid_config(
             data_store_config, name="data_store_config", schema=DATA_STORE_CONFIG_SCHEMA
         )
@@ -153,7 +154,7 @@ class DataStoreConfig:
             description=data_store_config.get("description"),
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         data_store_config = dict(store_id=self._store_id)
         if self._store_params:
             data_store_config.update(store_params=self._store_params)
@@ -193,10 +194,10 @@ class DataStoreInstance:
             store.close()
 
 
-DataStoreConfigDict = Dict[str, DataStoreConfig]
-DataStoreInstanceDict = Dict[str, DataStoreInstance]
+DataStoreConfigDict = dict[str, DataStoreConfig]
+DataStoreInstanceDict = dict[str, DataStoreInstance]
 
-DataStorePoolLike = Union[str, Dict[str, Any], "DataStorePool"]
+DataStorePoolLike = Union[str, dict[str, Any], "DataStorePool"]
 
 
 class DataStorePool:
@@ -239,11 +240,11 @@ class DataStorePool:
         return len(self._instances) == 0
 
     @property
-    def store_instance_ids(self) -> List[str]:
+    def store_instance_ids(self) -> list[str]:
         return sorted([k for k, v in self._instances.items()])
 
     @property
-    def store_configs(self) -> List[DataStoreConfig]:
+    def store_configs(self) -> list[DataStoreConfig]:
         return [v.store_config for k, v in self._instances.items()]
 
     def get_store_instance_id(
@@ -337,11 +338,11 @@ class DataStorePool:
         return cls.from_dict(store_configs or {})
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "DataStorePool":
+    def from_dict(cls, d: dict[str, Any]) -> "DataStorePool":
         DATA_STORE_POOL_SCHEMA.validate_instance(d)
         return cls({k: DataStoreConfig.from_dict(v) for k, v in d.items()})
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             instance_id: instance.store_config.to_dict()
             for instance_id, instance in self._instances.items()

--- a/xcube/core/subsampling.py
+++ b/xcube/core/subsampling.py
@@ -4,7 +4,8 @@
 
 import collections.abc
 import fnmatch
-from typing import Tuple, Hashable, Optional, Mapping, Union
+from typing import Tuple, Optional, Union
+from collections.abc import Hashable, Mapping
 
 import numpy as np
 import xarray as xr
@@ -22,7 +23,7 @@ AggMethods = Union[AggMethod, Mapping[str, AggMethod]]
 def subsample_dataset(
     dataset: xr.Dataset,
     step: int,
-    xy_dim_names: Optional[Tuple[str, str]] = None,
+    xy_dim_names: Optional[tuple[str, str]] = None,
     agg_methods: Optional[AggMethods] = None,
 ) -> xr.Dataset:
     """Subsample *dataset* with given integer subsampling *step*.
@@ -110,7 +111,7 @@ def subsample_dataset(
 
 def get_dataset_agg_methods(
     dataset: xr.Dataset,
-    xy_dim_names: Optional[Tuple[str, str]] = None,
+    xy_dim_names: Optional[tuple[str, str]] = None,
     agg_methods: Optional[AggMethods] = None,
 ):
     assert_instance(dataset, xr.Dataset, name="dataset")
@@ -172,8 +173,8 @@ _FULL_SLICE = slice(None, None, None)
 
 
 def get_variable_subsampling_slices(
-    variable: xr.DataArray, step: int, xy_dim_names: Optional[Tuple[str, str]] = None
-) -> Optional[Tuple[slice, ...]]:
+    variable: xr.DataArray, step: int, xy_dim_names: Optional[tuple[str, str]] = None
+) -> Optional[tuple[slice, ...]]:
     """
     Compute subsampling slices for *variable*.
     Return None, if *variable* does not contain spatial

--- a/xcube/core/tile.py
+++ b/xcube/core/tile.py
@@ -5,7 +5,8 @@
 import io
 import logging
 import math
-from typing import Optional, Tuple, Dict, Any, Hashable, Union, Sequence, List
+from typing import Optional, Tuple, Dict, Any, Union, List
+from collections.abc import Hashable, Sequence
 
 import PIL
 import matplotlib.colors
@@ -35,21 +36,21 @@ DEFAULT_CMAP_NORM = "lin"
 DEFAULT_FORMAT = "png"
 DEFAULT_TILE_ENLARGEMENT = 1
 
-ValueRange = Tuple[float, float]
+ValueRange = tuple[float, float]
 
 
 def compute_tiles(
     ml_dataset: MultiLevelDataset,
     variable_names: Union[str, Sequence[str]],
-    tile_bbox: Tuple[float, float, float, float],
+    tile_bbox: tuple[float, float, float, float],
     tile_crs: Union[str, pyproj.CRS] = DEFAULT_CRS_NAME,
     tile_size: ScalarOrPair[int] = DEFAULT_TILE_SIZE,
     level: int = 0,
-    non_spatial_labels: Optional[Dict[str, Any]] = None,
+    non_spatial_labels: Optional[dict[str, Any]] = None,
     as_dataset: bool = False,
     tile_enlargement: int = DEFAULT_TILE_ENLARGEMENT,
     trace_perf: bool = False,
-) -> Optional[Union[List[np.ndarray], xr.Dataset]]:
+) -> Optional[Union[list[np.ndarray], xr.Dataset]]:
     """Compute tiles for given *variable_names* in
     given multi-resolution dataset *mr_dataset*.
 
@@ -279,10 +280,10 @@ def compute_tiles(
 
 
 def _new_tile_dataset(
-    original_vars: List[Tuple[xr.DataArray, Tuple[Hashable, ...]]],
-    tiles: List[np.ndarray],
-    xy_names: Tuple[str, str],
-    xy_coords: Tuple[np.ndarray, np.ndarray],
+    original_vars: list[tuple[xr.DataArray, tuple[Hashable, ...]]],
+    tiles: list[np.ndarray],
+    xy_names: tuple[str, str],
+    xy_coords: tuple[np.ndarray, np.ndarray],
     crs: Union[str, pyproj.CRS],
 ):
     data_vars = {}
@@ -344,7 +345,7 @@ def compute_rgba_tile(
     cmap_name: Optional[str] = DEFAULT_CMAP_NAME,
     cmap_norm: Optional[str] = DEFAULT_CMAP_NORM,
     value_ranges: Optional[Union[ValueRange, Sequence[ValueRange]]] = None,
-    non_spatial_labels: Optional[Dict[str, Any]] = None,
+    non_spatial_labels: Optional[dict[str, Any]] = None,
     format: str = DEFAULT_FORMAT,
     tile_enlargement: int = DEFAULT_TILE_ENLARGEMENT,
     trace_perf: bool = False,
@@ -517,7 +518,7 @@ def compute_rgba_tile(
 
 
 def get_continuous_norm(
-    value_range: Tuple[float, float], cmap_norm: Optional[str]
+    value_range: tuple[float, float], cmap_norm: Optional[str]
 ) -> matplotlib.colors.Normalize:
     value_min, value_max = value_range
     if value_max < value_min:
@@ -534,9 +535,9 @@ def get_var_cmap_params(
     var: xr.DataArray,
     cmap_name: Optional[str],
     cmap_norm: Optional[str],
-    cmap_range: Tuple[Optional[float], Optional[float]],
-    valid_range: Optional[Tuple[float, float]],
-) -> Tuple[str, str, Tuple[float, float]]:
+    cmap_range: tuple[Optional[float], Optional[float]],
+    valid_range: Optional[tuple[float, float]],
+) -> tuple[str, str, tuple[float, float]]:
     if cmap_name is None:
         cmap_name = var.attrs.get("color_bar_name")
         if cmap_name is None:
@@ -561,7 +562,7 @@ def get_var_cmap_params(
     return cmap_name, cmap_norm, (cmap_vmin, cmap_vmax)
 
 
-def get_var_valid_range(var: xr.DataArray) -> Optional[Tuple[float, float]]:
+def get_var_valid_range(var: xr.DataArray) -> Optional[tuple[float, float]]:
     valid_min = None
     valid_max = None
     valid_range = var.attrs.get("valid_range")
@@ -624,7 +625,7 @@ class TransparentRgbaTilePool:
     INSTANCE: "TransparentRgbaTilePool"
 
     def __init__(self):
-        self._transparent_tiles: Dict[str, Union[bytes, np.ndarray]] = dict()
+        self._transparent_tiles: dict[str, Union[bytes, np.ndarray]] = dict()
 
     def get(self, tile_size: Pair[int], format: str) -> Union[bytes, np.ndarray]:
         tile_w, tile_h = tile_size
@@ -643,9 +644,9 @@ TransparentRgbaTilePool.INSTANCE = TransparentRgbaTilePool()
 def _get_non_spatial_labels(
     dataset: xr.Dataset,
     variable: xr.DataArray,
-    labels: Optional[Dict[str, Any]],
+    labels: Optional[dict[str, Any]],
     logger: logging.Logger,
-) -> Dict[Hashable, Any]:
+) -> dict[Hashable, Any]:
     labels = labels if labels is not None else {}
 
     new_labels = {}

--- a/xcube/core/tilingscheme.py
+++ b/xcube/core/tilingscheme.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import math
-from typing import Optional, Tuple, Sequence, List, Union
+from typing import Optional, Tuple, List, Union
+from collections.abc import Sequence
 
 import numpy as np
 import pyproj
@@ -62,7 +63,7 @@ class TilingScheme:
 
     def __init__(
         self,
-        num_level_zero_tiles: Tuple[int, int],
+        num_level_zero_tiles: tuple[int, int],
         crs_name: str,
         map_height: float,
         tile_size: ScalarOrPair[int] = DEFAULT_TILE_SIZE,
@@ -122,7 +123,7 @@ class TilingScheme:
         return self._map_height
 
     @property
-    def map_extent(self) -> Tuple[float, float, float, float]:
+    def map_extent(self) -> tuple[float, float, float, float]:
         """The extent of the map in units
         of the map's spatial coordinate reference system.
         """
@@ -131,7 +132,7 @@ class TilingScheme:
         return -map_width_05, -map_height_05, map_width_05, map_height_05
 
     @property
-    def map_origin(self) -> Tuple[float, float]:
+    def map_origin(self) -> tuple[float, float]:
         """The origin of the map (upper, left pixel of the upper left tile)
         in units of the map's spatial coordinate reference system.
         """
@@ -222,7 +223,7 @@ class TilingScheme:
         min_level: Optional[int] = None,
         max_level: Optional[int] = None,
         unit_name: Optional[str] = None,
-    ) -> List[float]:
+    ) -> list[float]:
         """Get spatial resolutions for this tiling scheme.
 
         Args:
@@ -251,7 +252,7 @@ class TilingScheme:
 
     def get_levels_for_resolutions(
         self, resolutions: Sequence[float], unit_name: str
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Get the minimum and maximum level indices into this tiling scheme
         for the given spatial *resolutions*.
 
@@ -334,7 +335,7 @@ class TilingScheme:
 
     def get_tile_extent(
         self, tile_x: int, tile_y: int, tile_z: int
-    ) -> Optional[Tuple[float, float, float, float]]:
+    ) -> Optional[tuple[float, float, float, float]]:
         """Get the extent in units of the CRS for the given tile coordinates.
 
         Args:
@@ -417,8 +418,8 @@ def get_unit_factor(unit_name_from: str, unit_name_to: str) -> float:
 
 
 def subdivide_size(
-    size: Tuple[int, int], tile_size: Tuple[int, int]
-) -> List[Tuple[int, int]]:
+    size: tuple[int, int], tile_size: tuple[int, int]
+) -> list[tuple[int, int]]:
     x_size, y_size = size
     tile_size_x, tile_size_y = tile_size
     sizes = [(x_size, y_size)]
@@ -431,7 +432,7 @@ def subdivide_size(
     return sizes
 
 
-def get_num_levels(size: Tuple[int, int], tile_size: Tuple[int, int]) -> int:
+def get_num_levels(size: tuple[int, int], tile_size: tuple[int, int]) -> int:
     return len(subdivide_size(size, tile_size))
 
 

--- a/xcube/core/timecoord.py
+++ b/xcube/core/timecoord.py
@@ -5,7 +5,7 @@
 import datetime
 import re
 from typing import Optional
-from typing import Sequence
+from collections.abc import Sequence
 from typing import Tuple
 from typing import Union
 
@@ -32,7 +32,7 @@ _RE_TO_DATETIME_FORMATS = patterns = [
 ]
 
 
-def add_time_coords(dataset: xr.Dataset, time_range: Tuple[float, float]) -> xr.Dataset:
+def add_time_coords(dataset: xr.Dataset, time_range: tuple[float, float]) -> xr.Dataset:
     t1, t2 = time_range
     if t1 != t2:
         t_center = (t1 + t2) / 2
@@ -78,7 +78,7 @@ def add_time_coords(dataset: xr.Dataset, time_range: Tuple[float, float]) -> xr.
 
 def get_time_range_from_data(
     dataset: xr.Dataset, maybe_consider_metadata: bool = True
-) -> Tuple[Optional[float], Optional[float]]:
+) -> tuple[Optional[float], Optional[float]]:
     """Determines a time range from a dataset by inspecting its time_bounds or time data arrays.
     In cases where no time bounds are given and no time periodicity can be determined,
     metadata may be considered.
@@ -143,7 +143,7 @@ def _maybe_return_time_range_from_metadata(
     data_start_time: float,
     data_end_time: float,
     maybe_consider_metadata: bool,
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     if maybe_consider_metadata:
         attr_start_time, attr_end_time = get_time_range_from_attrs(dataset)
         attr_start_time = pd.to_datetime(
@@ -177,7 +177,7 @@ def _maybe_return_time_range_from_metadata(
 
 def _get_time_range_from_time_bounds(
     dataset: xr.Dataset, time_bounds_name: str
-) -> Tuple[Optional[float], Optional[float]]:
+) -> tuple[Optional[float], Optional[float]]:
     time_bnds = dataset[time_bounds_name]
     if len(time_bnds.shape) == 2 and time_bnds.shape[1] == 2:
         return time_bnds[0, 0].values, time_bnds[-1, 1].values
@@ -185,7 +185,7 @@ def _get_time_range_from_time_bounds(
 
 def get_time_range_from_attrs(
     dataset: xr.Dataset,
-) -> Tuple[Optional[str], Optional[str]]:
+) -> tuple[Optional[str], Optional[str]]:
     return get_start_time_from_attrs(dataset), get_end_time_from_attrs(dataset)
 
 
@@ -274,7 +274,7 @@ def timestamp_to_iso_string(
     return getattr(timestamp, round_fn)(freq).isoformat() + "Z"
 
 
-def find_datetime_format(line: str) -> Tuple[Optional[str], int, int]:
+def find_datetime_format(line: str) -> tuple[Optional[str], int, int]:
     for regex, time_format in _RE_TO_DATETIME_FORMATS:
         searcher = regex.search(line)
         if searcher:

--- a/xcube/core/timeseries.py
+++ b/xcube/core/timeseries.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import warnings
-from typing import Union, Sequence, Optional, AbstractSet, Set
+from typing import Union, Optional, AbstractSet, Set
+from collections.abc import Sequence
 
 import numpy as np
 import pyproj
@@ -187,7 +188,7 @@ def get_time_series(
 
 def normalize_agg_methods(
     agg_methods: Union[str, Sequence[str]], exception_type=ValueError
-) -> Set[str]:
+) -> set[str]:
     agg_methods = agg_methods or [AGG_MEAN]
     if isinstance(agg_methods, str):
         agg_methods = [agg_methods]

--- a/xcube/core/timeslice.py
+++ b/xcube/core/timeslice.py
@@ -20,7 +20,7 @@ def find_time_slice(
     store: Union[str, MutableMapping],
     time_stamp: Union[np.datetime64, np.ndarray],
     time_eps: np.timedelta64 = DEFAULT_TIME_EPS,
-) -> Tuple[int, str]:
+) -> tuple[int, str]:
     """Find time index and update mode for *time_stamp* in
     Zarr dataset given by *store*.
 
@@ -62,7 +62,7 @@ def find_time_slice(
 def append_time_slice(
     store: Union[str, MutableMapping],
     time_slice: xr.Dataset,
-    chunk_sizes: Dict[str, int] = None,
+    chunk_sizes: dict[str, int] = None,
 ):
     """Append time slice to existing zarr dataset.
 
@@ -95,7 +95,7 @@ def insert_time_slice(
     store: Union[str, MutableMapping],
     insert_index: int,
     time_slice: xr.Dataset,
-    chunk_sizes: Dict[str, int] = None,
+    chunk_sizes: dict[str, int] = None,
 ):
     """Insert time slice into existing zarr dataset.
 
@@ -114,7 +114,7 @@ def replace_time_slice(
     store: Union[str, MutableMapping],
     insert_index: int,
     time_slice: xr.Dataset,
-    chunk_sizes: Dict[str, int] = None,
+    chunk_sizes: dict[str, int] = None,
 ):
     """Replace time slice in existing zarr dataset.
 
@@ -134,7 +134,7 @@ def update_time_slice(
     insert_index: int,
     time_slice: xr.Dataset,
     mode: str,
-    chunk_sizes: Dict[str, int] = None,
+    chunk_sizes: dict[str, int] = None,
 ):
     """Update existing zarr dataset by new time slice.
 

--- a/xcube/core/unchunk.py
+++ b/xcube/core/unchunk.py
@@ -4,7 +4,8 @@
 
 import json
 import os.path
-from typing import List, Sequence
+from typing import List
+from collections.abc import Sequence
 
 import numpy as np
 import xarray as xr
@@ -48,13 +49,13 @@ def unchunk_dataset(
     _unchunk_vars(dataset_path, var_names)
 
 
-def _unchunk_vars(dataset_path: str, var_names: List[str]):
+def _unchunk_vars(dataset_path: str, var_names: list[str]):
     for var_name in var_names:
         var_path = os.path.join(dataset_path, var_name)
 
         # Optimization: if "shape" and "chunks" are equal in ${var}/.zarray, we are done
         var_array_info_path = os.path.join(var_path, ".zarray")
-        with open(var_array_info_path, "r") as fp:
+        with open(var_array_info_path) as fp:
             var_array_info = json.load(fp)
             if var_array_info.get("shape") == var_array_info.get("chunks"):
                 continue

--- a/xcube/core/update.py
+++ b/xcube/core/update.py
@@ -23,7 +23,7 @@ _TIME_ATTRS_DATA = (
 
 def update_dataset_attrs(
     dataset: xr.Dataset,
-    global_attrs: Dict[str, Any] = None,
+    global_attrs: dict[str, Any] = None,
     update_existing: bool = False,
     in_place: bool = False,
 ) -> xr.Dataset:
@@ -219,7 +219,7 @@ def update_dataset_var_attrs(
 
 def update_dataset_chunk_encoding(
     dataset: xr.Dataset,
-    chunk_sizes: Dict[str, int] = None,
+    chunk_sizes: dict[str, int] = None,
     format_name: str = None,
     in_place: bool = False,
     data_vars_only: bool = False,

--- a/xcube/core/verify.py
+++ b/xcube/core/verify.py
@@ -31,7 +31,7 @@ def assert_cube(dataset: xr.Dataset, name=None) -> xr.Dataset:
     return dataset
 
 
-def verify_cube(dataset: xr.Dataset) -> List[str]:
+def verify_cube(dataset: xr.Dataset) -> list[str]:
     """Verify the given *dataset* for being a valid xcube dataset.
 
     The tool verifies that *dataset*

--- a/xcube/core/xarray.py
+++ b/xcube/core/xarray.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import threading
-from typing import Dict, List, Mapping, Any, Union, Sequence, Optional
+from typing import Dict, List, Any, Union, Optional
+from collections.abc import Mapping, Sequence
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -289,7 +290,7 @@ class DatasetAccessor:
         )
 
     def chunk(
-        self, chunk_sizes: Dict[str, int] = None, format_name: str = None
+        self, chunk_sizes: dict[str, int] = None, format_name: str = None
     ) -> xr.Dataset:
         """Chunk this dataset and update encodings for given format.
 
@@ -329,7 +330,7 @@ class DatasetAccessor:
             self._dataset, var_names=var_names, show_var_encoding=show_var_encoding
         )
 
-    def verify(self) -> List[str]:
+    def verify(self) -> list[str]:
         """Verify that this dataset is a valid xcube dataset.
 
         Returns a list of issues, which is empty if this dataset is a valid xcube dataset.

--- a/xcube/core/zarrstore/cached.py
+++ b/xcube/core/zarrstore/cached.py
@@ -4,7 +4,8 @@
 
 import collections.abc
 import warnings
-from typing import Iterator, List
+from typing import List
+from collections.abc import Iterator
 
 import zarr.storage
 
@@ -64,7 +65,7 @@ class CachedZarrStore(zarr.storage.Store):
             assert hasattr(self, "_" + op)
             setattr(self, op, getattr(self, "_" + op))
 
-    def _listdir(self, path: str = "") -> List[str]:
+    def _listdir(self, path: str = "") -> list[str]:
         # noinspection PyUnresolvedReferences
         return self._store.listdir(path=path)
 

--- a/xcube/core/zarrstore/diagnostic.py
+++ b/xcube/core/zarrstore/diagnostic.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import collections.abc
-from typing import Iterator, List
+from typing import List
+from collections.abc import Iterator
 
 import zarr.storage
 
@@ -18,7 +19,7 @@ class DiagnosticZarrStore(zarr.storage.Store):
 
     def __init__(self, store: collections.abc.MutableMapping):
         self.store = store
-        self.records: List[str] = []
+        self.records: list[str] = []
         if hasattr(self.store, "listdir"):
             self.listdir = self._listdir
         if hasattr(self.store, "getsize"):
@@ -27,7 +28,7 @@ class DiagnosticZarrStore(zarr.storage.Store):
     def _add_record(self, record: str):
         self.records.append(record)
 
-    def _listdir(self, path: str = "") -> List[str]:
+    def _listdir(self, path: str = "") -> list[str]:
         self._add_record(f"listdir({path!r})")
         # noinspection PyUnresolvedReferences
         return self.store.listdir(path=path)

--- a/xcube/core/zarrstore/logging.py
+++ b/xcube/core/zarrstore/logging.py
@@ -5,7 +5,8 @@
 
 import collections.abc
 from logging import Logger
-from typing import Iterator, Iterable, KeysView, Optional
+from typing import Optional
+from collections.abc import Iterator, Iterable, KeysView
 
 import zarr.storage
 

--- a/xcube/server/api.py
+++ b/xcube/server/api.py
@@ -13,14 +13,12 @@ from typing import (
     Tuple,
     Dict,
     Type,
-    Sequence,
     Generic,
     TypeVar,
     Union,
     Callable,
-    Awaitable,
-    Mapping,
 )
+from collections.abc import Sequence, Awaitable, Mapping
 
 from .asyncexec import AsyncExecution
 from ..util.assertions import assert_instance
@@ -43,8 +41,8 @@ JSON = Union[
     int,
     float,
     str,
-    List["JSON"],
-    Dict[str, "JSON"],
+    list["JSON"],
+    dict[str, "JSON"],
 ]
 
 ServerConfigObject = FrozenDict[str, Any]
@@ -153,8 +151,8 @@ class Api(Generic[ServerContextT]):
         self._description = description
         self._required_apis = tuple(required_apis or ())
         self._optional_apis = tuple(optional_apis or ())
-        self._routes: List[ApiRoute] = list(routes or [])
-        self._static_routes: List[ApiStaticRoute] = list(static_routes or [])
+        self._routes: list[ApiRoute] = list(routes or [])
+        self._static_routes: list[ApiStaticRoute] = list(static_routes or [])
         self._config_schema = config_schema
         self._create_ctx = create_ctx or ApiContext
         self._on_start = on_start or self._handle_event
@@ -178,12 +176,12 @@ class Api(Generic[ServerContextT]):
         )
 
     @property
-    def required_apis(self) -> Tuple[str]:
+    def required_apis(self) -> tuple[str]:
         """The names of other required APIs."""
         return self._required_apis
 
     @property
-    def optional_apis(self) -> Tuple[str]:
+    def optional_apis(self) -> tuple[str]:
         """The names of other optional APIs."""
         return self._optional_apis
 
@@ -233,7 +231,7 @@ class Api(Generic[ServerContextT]):
             ApiHandler
         """
 
-        def decorator_func(handler_cls: Type[ApiHandler]):
+        def decorator_func(handler_cls: type[ApiHandler]):
             self._routes.append(ApiRoute(self.name, path, handler_cls, handler_kwargs))
             return handler_cls
 
@@ -244,9 +242,9 @@ class Api(Generic[ServerContextT]):
         operation_id: Optional[str] = None,
         summary: Optional[str] = None,
         description: Optional[str] = None,
-        parameters: Optional[List[Dict[str, Any]]] = None,
-        request_body: Optional[Dict[str, Any]] = None,
-        responses: Optional[Dict[str, Dict]] = None,
+        parameters: Optional[list[dict[str, Any]]] = None,
+        request_body: Optional[dict[str, Any]] = None,
+        responses: Optional[dict[str, dict]] = None,
         tags: Optional[str] = None,
         **kwargs,
     ):
@@ -283,7 +281,7 @@ class Api(Generic[ServerContextT]):
         }
         openapi = {k: v for k, v in openapi.items() if v is not None}
 
-        def decorator_func(target: Union[Type[ApiHandler], Callable]):
+        def decorator_func(target: Union[type[ApiHandler], Callable]):
             if (
                 inspect.isfunction(target)
                 and hasattr(target, "__name__")
@@ -302,12 +300,12 @@ class Api(Generic[ServerContextT]):
         return decorator_func
 
     @property
-    def static_routes(self) -> Tuple["ApiStaticRoute"]:
+    def static_routes(self) -> tuple["ApiStaticRoute"]:
         """The static routes provided by this API."""
         return tuple(self._static_routes)
 
     @property
-    def routes(self) -> Tuple["ApiRoute"]:
+    def routes(self) -> tuple["ApiRoute"]:
         """The routes provided by this API."""
         return tuple(self._routes)
 
@@ -382,11 +380,11 @@ class Context(AsyncExecution, ABC):
 
     @property
     @abstractmethod
-    def apis(self) -> Tuple[Api]:
+    def apis(self) -> tuple[Api]:
         """The APIs used by the server."""
 
     @abstractmethod
-    def get_open_api_doc(self, include_all: bool = False) -> Dict[str, Any]:
+    def get_open_api_doc(self, include_all: bool = False) -> dict[str, Any]:
         """The OpenAPI JSON document for the server."""
 
     @property
@@ -396,7 +394,7 @@ class Context(AsyncExecution, ABC):
 
     @abstractmethod
     def get_api_ctx(
-        self, api_name: str, cls: Optional[Type[ApiContextT]] = None
+        self, api_name: str, cls: Optional[type[ApiContextT]] = None
     ) -> Optional[ApiContextT]:
         """Get the API context for *api_name*.
         Can be used to access context objects of other APIs.
@@ -471,11 +469,11 @@ class ApiContext(Context):
         return self._server_ctx
 
     @property
-    def apis(self) -> Tuple[Api]:
+    def apis(self) -> tuple[Api]:
         """Return the server context's ``apis`` property."""
         return self.server_ctx.apis
 
-    def get_open_api_doc(self, include_all: bool = False) -> Dict[str, Any]:
+    def get_open_api_doc(self, include_all: bool = False) -> dict[str, Any]:
         """Return the server context's ``apis`` property."""
         return self.server_ctx.get_open_api_doc(include_all=include_all)
 
@@ -485,7 +483,7 @@ class ApiContext(Context):
         return self.server_ctx.config
 
     def get_api_ctx(
-        self, api_name: str, cls: Optional[Type[ApiContextT]] = None
+        self, api_name: str, cls: Optional[type[ApiContextT]] = None
     ) -> Optional[ApiContextT]:
         """Calls the server context's ``get_api_ctx()`` method."""
         return self.server_ctx.get_api_ctx(api_name, cls=cls)
@@ -579,7 +577,7 @@ class ApiRequest:
     def get_query_arg(
         self,
         name: str,
-        type: Optional[Type[ArgT]] = None,
+        type: Optional[type[ArgT]] = None,
         default: Optional[ArgT] = None,
     ) -> Optional[ArgT]:
         """Get the value of query argument given by *name*. To force
@@ -605,7 +603,7 @@ class ApiRequest:
     # noinspection PyShadowingBuiltins
     @abstractmethod
     def get_query_args(
-        self, name: str, type: Optional[Type[ArgT]] = None
+        self, name: str, type: Optional[type[ArgT]] = None
     ) -> Sequence[ArgT]:
         """Get the values of query argument given by *name*.
         If *type* is given, a sequence of that type will be returned.
@@ -740,8 +738,8 @@ class ApiRoute:
         self,
         api_name: str,
         path: str,
-        handler_cls: Type[ApiHandler],
-        handler_kwargs: Optional[Dict[str, Any]] = None,
+        handler_cls: type[ApiHandler],
+        handler_kwargs: Optional[dict[str, Any]] = None,
     ):
         assert_instance(api_name, str, name="api_name")
         assert_instance(path, str, name="path")
@@ -818,7 +816,7 @@ class ApiStaticRoute:
         dir_path: str,
         default_filename: Optional[str] = None,
         api_name: Optional[str] = None,
-        openapi_metadata: Optional[Dict[str, Any]] = None,
+        openapi_metadata: Optional[dict[str, Any]] = None,
     ):
         assert_instance(path, str, name="path")
         assert_instance(dir_path, str, name="dir_path")
@@ -848,18 +846,18 @@ class ApiError(Exception):
     def __init__(self, status_code: int, message: Optional[str] = None):
         super().__init__(status_code, message)
 
-    BadRequest: Type["_DerivedApiError"]
-    Unauthorized: Type["_DerivedApiError"]
-    Forbidden: Type["_DerivedApiError"]
-    NotFound: Type["_DerivedApiError"]
-    MethodNotAllowed: Type["_DerivedApiError"]
-    Conflict: Type["_DerivedApiError"]
-    Gone: Type["_DerivedApiError"]
-    ContentTooLarge: Type["_DerivedApiError"]
-    InternalServerError: Type["_DerivedApiError"]
-    NotImplemented: Type["_DerivedApiError"]
-    InvalidServerConfig: Type["_DerivedApiError"]
-    UnsupportedMediaType: Type["_DerivedApiError"]
+    BadRequest: type["_DerivedApiError"]
+    Unauthorized: type["_DerivedApiError"]
+    Forbidden: type["_DerivedApiError"]
+    NotFound: type["_DerivedApiError"]
+    MethodNotAllowed: type["_DerivedApiError"]
+    Conflict: type["_DerivedApiError"]
+    Gone: type["_DerivedApiError"]
+    ContentTooLarge: type["_DerivedApiError"]
+    InternalServerError: type["_DerivedApiError"]
+    NotImplemented: type["_DerivedApiError"]
+    InvalidServerConfig: type["_DerivedApiError"]
+    UnsupportedMediaType: type["_DerivedApiError"]
 
     @property
     def status_code(self) -> int:

--- a/xcube/server/asyncexec.py
+++ b/xcube/server/asyncexec.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import abc
-from typing import Union, Callable, Optional, Any, Awaitable, TypeVar
+from typing import Union, Callable, Optional, Any, TypeVar
+from collections.abc import Awaitable
 
 from tornado import concurrent
 

--- a/xcube/server/config.py
+++ b/xcube/server/config.py
@@ -4,7 +4,8 @@
 
 import os.path
 from functools import cache
-from typing import Mapping, Any, Optional
+from typing import Any, Optional
+from collections.abc import Mapping
 
 from xcube.constants import DEFAULT_SERVER_ADDRESS
 from xcube.constants import DEFAULT_SERVER_PORT

--- a/xcube/server/framework.py
+++ b/xcube/server/framework.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import abc
-from typing import Sequence, List, Type, Optional, Tuple
+from typing import List, Type, Optional, Tuple
+from collections.abc import Sequence
 
 from xcube.constants import EXTENSION_POINT_SERVER_FRAMEWORKS
 from xcube.util.extension import get_extension_registry
@@ -72,7 +73,7 @@ class Framework(AsyncExecution, abc.ABC):
         """
 
 
-def get_framework_names() -> List[str]:
+def get_framework_names() -> list[str]:
     """Get the names of possible web server frameworks."""
     extension_registry = get_extension_registry()
     return [
@@ -81,7 +82,7 @@ def get_framework_names() -> List[str]:
     ]
 
 
-def get_framework_class(framework_name: str) -> Type[Framework]:
+def get_framework_class(framework_name: str) -> type[Framework]:
     """Get the web server framework class for the given *framework_name*."""
     extension_registry = get_extension_registry()
     return extension_registry.get_component(

--- a/xcube/server/helpers.py
+++ b/xcube/server/helpers.py
@@ -3,7 +3,7 @@
 # https://opensource.org/licenses/MIT.
 
 import os
-from typing import Sequence
+from collections.abc import Sequence
 
 from xcube.server.server import Server
 from xcube.util.config import load_configs

--- a/xcube/server/server.py
+++ b/xcube/server/server.py
@@ -11,13 +11,11 @@ from typing import (
     Any,
     Union,
     Callable,
-    Sequence,
-    Awaitable,
     Tuple,
     Type,
     List,
-    Mapping,
 )
+from collections.abc import Sequence, Awaitable, Mapping
 
 import jsonschema.exceptions
 
@@ -105,7 +103,7 @@ class Server(AsyncExecution):
         return self._framework
 
     @property
-    def apis(self) -> Tuple[Api]:
+    def apis(self) -> tuple[Api]:
         """The APIs supported by this server."""
         return self._apis
 
@@ -197,7 +195,7 @@ class Server(AsyncExecution):
         cls,
         config: collections.abc.Mapping,
         extension_registry: Optional[ExtensionRegistry] = None,
-    ) -> Tuple[Api]:
+    ) -> tuple[Api]:
         # Collect all registered API extensions
         extension_registry = extension_registry or get_extension_registry()
         api_extensions = extension_registry.find_extensions(EXTENSION_POINT_SERVER_APIS)
@@ -209,7 +207,7 @@ class Server(AsyncExecution):
 
         # Collect effective APIs
         api_names = set(incl_api_names).difference(set(excl_api_names))
-        apis: List[Api] = [
+        apis: list[Api] = [
             ext.component for ext in api_extensions if ext.name in api_names
         ]
 
@@ -246,7 +244,7 @@ class Server(AsyncExecution):
     @classmethod
     def _collect_static_routes(
         cls, config: collections.abc.Mapping
-    ) -> List[ApiStaticRoute]:
+    ) -> list[ApiStaticRoute]:
         static_routes = config.get("static_routes", [])
         api_static_routes = []
         for static_route in static_routes:
@@ -263,14 +261,14 @@ class Server(AsyncExecution):
         return api_static_routes
 
     @classmethod
-    def _collect_api_static_routes(cls, apis: Sequence[Api]) -> List[ApiStaticRoute]:
+    def _collect_api_static_routes(cls, apis: Sequence[Api]) -> list[ApiStaticRoute]:
         static_routes = []
         for api in apis:
             static_routes.extend(api.static_routes)
         return static_routes
 
     @classmethod
-    def _collect_api_routes(cls, apis: Sequence[Api]) -> List[ApiRoute]:
+    def _collect_api_routes(cls, apis: Sequence[Api]) -> list[ApiRoute]:
         handlers = []
         for api in apis:
             handlers.extend(api.routes)
@@ -316,7 +314,7 @@ class Server(AsyncExecution):
                 if r not in config_schema.required:
                     config_schema.required.append(r)
 
-    def get_open_api_doc(self, include_all: bool = False) -> Dict[str, Any]:
+    def get_open_api_doc(self, include_all: bool = False) -> dict[str, Any]:
         """Get the OpenAPI JSON document for this server."""
         error_schema = {
             "type": "object",
@@ -448,17 +446,17 @@ class ServerContext(Context):
     def __init__(self, server: Server, config: collections.abc.Mapping):
         self._server = server
         self._config = FrozenDict.freeze(config)
-        self._api_contexts: Dict[str, Context] = dict()
+        self._api_contexts: dict[str, Context] = dict()
 
     @property
     def server(self) -> Server:
         return self._server
 
     @property
-    def apis(self) -> Tuple[Api]:
+    def apis(self) -> tuple[Api]:
         return self._server.apis
 
-    def get_open_api_doc(self, include_all: bool = False) -> Dict[str, Any]:
+    def get_open_api_doc(self, include_all: bool = False) -> dict[str, Any]:
         return self._server.get_open_api_doc(include_all=include_all)
 
     @property
@@ -466,7 +464,7 @@ class ServerContext(Context):
         return self._config
 
     def get_api_ctx(
-        self, api_name: str, cls: Optional[Type[ApiContextT]] = None
+        self, api_name: str, cls: Optional[type[ApiContextT]] = None
     ) -> Optional[ApiContextT]:
         api_ctx = self._api_contexts.get(api_name)
         if cls is not None:

--- a/xcube/server/testing.py
+++ b/xcube/server/testing.py
@@ -66,17 +66,17 @@ class ServerTestCase(unittest.TestCase, ABC):
         pass
 
     # noinspection PyMethodMayBeStatic
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         return {}
 
-    def add_config(self, config: Dict) -> None:
+    def add_config(self, config: dict) -> None:
         pass
 
     def fetch(
         self,
         path: str,
         method: str = "GET",
-        headers: Optional[Dict[str, str]] = None,
+        headers: Optional[dict[str, str]] = None,
         body: Optional[Any] = None,
     ) -> urllib3.response.HTTPResponse:
         """Fetches the response for given request.
@@ -101,9 +101,9 @@ class ServerTestCase(unittest.TestCase, ABC):
         self,
         path: str,
         method: str = "GET",
-        headers: Optional[Dict[str, str]] = None,
+        headers: Optional[dict[str, str]] = None,
         body: Optional[Any] = None,
-    ) -> Tuple[Union[type(None), bool, int, float, str, list, dict], int]:
+    ) -> tuple[Union[type(None), bool, int, float, str, list, dict], int]:
         """Fetches the response's JSON value for given request.
 
         Args:

--- a/xcube/server/webservers/flask.py
+++ b/xcube/server/webservers/flask.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import concurrent.futures
-from typing import Sequence, Union, Callable, Optional, Any, Awaitable, Tuple
+from typing import Union, Callable, Optional, Any, Tuple
+from collections.abc import Sequence, Awaitable
 
 from xcube.server.api import ApiRoute
 from xcube.server.api import ApiStaticRoute

--- a/xcube/server/webservers/tornado.py
+++ b/xcube/server/webservers/tornado.py
@@ -8,7 +8,8 @@ import functools
 import logging
 import traceback
 import urllib.parse
-from typing import Any, Optional, Sequence, Union, Callable, Type, Awaitable, Mapping
+from typing import Any, Optional, Union, Callable, Type
+from collections.abc import Sequence, Awaitable, Mapping
 
 import tornado.escape
 import tornado.httputil
@@ -387,7 +388,7 @@ class TornadoApiRequest(ApiRequest):
 
     # noinspection PyShadowingBuiltins
     def get_query_args(
-        self, name: str, type: Optional[Type[ArgT]] = None
+        self, name: str, type: Optional[type[ArgT]] = None
     ) -> Sequence[ArgT]:
         name_lc = name.lower() if self._is_query_lower_case else name
         if not self.query or name_lc not in self.query:

--- a/xcube/util/assertions.py
+++ b/xcube/util/assertions.py
@@ -2,13 +2,14 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Any, Union, Tuple, Type, Container
+from typing import Any, Union, Tuple, Type
+from collections.abc import Container
 
 _DEFAULT_NAME = "value"
 
 
 def assert_not_none(
-    value: Any, name: str = None, exception_type: Type[Exception] = ValueError
+    value: Any, name: str = None, exception_type: type[Exception] = ValueError
 ):
     """Assert *value* is not None.
     Otherwise, raise *exception_type*.
@@ -23,7 +24,7 @@ def assert_not_none(
 
 
 def assert_given(
-    value: Any, name: str = None, exception_type: Type[Exception] = ValueError
+    value: Any, name: str = None, exception_type: type[Exception] = ValueError
 ):
     """Assert *value* is not False when converted into a Boolean value.
     Otherwise, raise *exception_type*.
@@ -39,9 +40,9 @@ def assert_given(
 
 def assert_instance(
     value: Any,
-    dtype: Union[Type, Tuple[Type, ...]],
+    dtype: Union[type, tuple[type, ...]],
     name: str = None,
-    exception_type: Type[Exception] = TypeError,
+    exception_type: type[Exception] = TypeError,
 ):
     """Assert *value* is an instance of data type *dtype*.
     Otherwise, raise *exception_type*.
@@ -62,9 +63,9 @@ def assert_instance(
 
 def assert_subclass(
     value: Any,
-    cls: Union[Type, Tuple[Type, ...]],
+    cls: Union[type, tuple[type, ...]],
     name: str = None,
-    exception_type: Type[Exception] = TypeError,
+    exception_type: type[Exception] = TypeError,
 ):
     """Assert *value* is a subclass of class *cls*.
     Otherwise, raise *exception_type*.
@@ -85,7 +86,7 @@ def assert_in(
     value: Any,
     container: Container,
     name: str = None,
-    exception_type: Type[Exception] = ValueError,
+    exception_type: type[Exception] = ValueError,
 ):
     """Assert *value* is a member of *container*.
     Otherwise, raise *exception_type*.
@@ -100,7 +101,7 @@ def assert_in(
         raise exception_type(f"{name or _DEFAULT_NAME} " f"must be one of {container}")
 
 
-def assert_true(value: Any, message: str, exception_type: Type[Exception] = ValueError):
+def assert_true(value: Any, message: str, exception_type: type[Exception] = ValueError):
     """Assert *value* is true after conversion into a Boolean value.
     Otherwise, raise *exception_type*.
 
@@ -114,7 +115,7 @@ def assert_true(value: Any, message: str, exception_type: Type[Exception] = Valu
 
 
 def assert_false(
-    value: Any, message: str, exception_type: Type[Exception] = ValueError
+    value: Any, message: str, exception_type: type[Exception] = ValueError
 ):
     """Assert *value* is false after conversion into a Boolean value.
     Otherwise, raise *exception_type*.

--- a/xcube/util/cache.py
+++ b/xcube/util/cache.py
@@ -166,7 +166,7 @@ class FileCacheStore(CacheStore):
         try:
             os.remove(path)
             # TODO (forman): also remove empty directories up to self.cache_dir
-        except IOError:
+        except OSError:
             pass
 
     def _key_to_path(self, key):

--- a/xcube/util/caseless.py
+++ b/xcube/util/caseless.py
@@ -5,7 +5,7 @@
 from typing import Dict, TypeVar, Optional
 
 
-def caseless_dict(*args, **kwargs) -> Dict:
+def caseless_dict(*args, **kwargs) -> dict:
     """Create a dictionary that compares its string keys in a case-insensitive manner."""
     return _CaselessDict(*args, **kwargs)
 

--- a/xcube/util/cmaps.py
+++ b/xcube/util/cmaps.py
@@ -39,7 +39,7 @@ DEFAULT_CMAP_NAME = "viridis"
 
 
 class ColormapCategory:
-    def __init__(self, name: str, desc: str, cm_names: Optional[List[str]] = None):
+    def __init__(self, name: str, desc: str, cm_names: Optional[list[str]] = None):
         self.name = name
         self.desc = desc
         self.cm_names = cm_names
@@ -189,7 +189,7 @@ CUSTOM_CATEGORY = ColormapCategory(
     "Custom colormaps, e.g. loaded from SNAP *.cpd files.",
 )
 
-TEMPLATE_CATEGORIES: Dict[str, ColormapCategory] = {
+TEMPLATE_CATEGORIES: dict[str, ColormapCategory] = {
     c.name: c
     for c in (
         PERCEPTUALLY_UNIFORM_SEQUENTIAL_CATEGORY,
@@ -221,7 +221,7 @@ class Colormap:
         cmap_reversed: Optional[matplotlib.colors.Colormap] = None,
         cmap_alpha: Optional[matplotlib.colors.Colormap] = None,
         norm: Optional[matplotlib.colors.Normalize] = None,
-        bounds: Optional[List[Union[int, float]]] = None,
+        bounds: Optional[list[Union[int, float]]] = None,
     ):
         self._cm_name = cm_name
         self._cat_name = cat_name
@@ -277,7 +277,7 @@ class Colormap:
         return self._norm
 
     @property
-    def bounds(self) -> Optional[List[Union[int, float]]]:
+    def bounds(self) -> Optional[list[Union[int, float]]]:
         return self._bounds
 
 
@@ -285,7 +285,7 @@ class ColormapProvider(ABC):
     @abstractmethod
     def get_cmap(
         self, cm_name: str, num_colors: Optional[int] = None
-    ) -> Tuple[matplotlib.colors.Colormap, Colormap]:
+    ) -> tuple[matplotlib.colors.Colormap, Colormap]:
         """Get a colormap for the given *cm_name*.
 
         If *cm_name* is not available, the method may choose another
@@ -312,8 +312,8 @@ class ColormapProvider(ABC):
 
 class ColormapRegistry(ColormapProvider):
     def __init__(self, *colormaps: Colormap):
-        self._categories: Dict[str, ColormapCategory] = {}
-        self._colormaps: Dict[str, Colormap] = {}
+        self._categories: dict[str, ColormapCategory] = {}
+        self._colormaps: dict[str, Colormap] = {}
         # Add standard Matplotlib colormaps
         self._register_mpl_cmaps()
         # Add Ocean colormaps, if any
@@ -323,11 +323,11 @@ class ColormapRegistry(ColormapProvider):
             self.register_colormap(colormap)
 
     @property
-    def categories(self) -> Dict[str, ColormapCategory]:
+    def categories(self) -> dict[str, ColormapCategory]:
         return self._categories
 
     @property
-    def colormaps(self) -> Dict[str, Colormap]:
+    def colormaps(self) -> dict[str, Colormap]:
         return self._colormaps
 
     def register_colormap(self, colormap: Colormap):
@@ -347,7 +347,7 @@ class ColormapRegistry(ColormapProvider):
 
     def get_cmap(
         self, cm_name: str, num_colors: Optional[int] = None
-    ) -> Tuple[matplotlib.colors.Colormap, Colormap]:
+    ) -> tuple[matplotlib.colors.Colormap, Colormap]:
         assert_instance(cm_name, str, name="cm_name")
         if num_colors is not None:
             assert_instance(num_colors, int, name="num_colors")
@@ -376,7 +376,7 @@ class ColormapRegistry(ColormapProvider):
             cmap = cmap.resampled(num_colors)
         return cmap, colormap
 
-    def to_json(self) -> List:
+    def to_json(self) -> list:
         result = []
         # Loop through TEMPLATE_CATEGORIES to preserve category order
         for cat_name in TEMPLATE_CATEGORIES.keys():
@@ -441,19 +441,19 @@ class ColormapRegistry(ColormapProvider):
             )
 
 
-def parse_cm_code(cm_code: str) -> Tuple[str, Optional[Colormap]]:
+def parse_cm_code(cm_code: str) -> tuple[str, Optional[Colormap]]:
     # Note, if we get performance issues here, we should
     # cache cm_code -> colormap
     try:
-        user_color_map: Dict[str, Any] = json.loads(cm_code)
+        user_color_map: dict[str, Any] = json.loads(cm_code)
         cm_name = user_color_map["name"]
         cm_items = user_color_map["colors"]
         cm_type = user_color_map.get("type", "node")
         cm_base_name, _, _ = parse_cm_name(cm_name)
         if cm_type == "key" or cm_type == "bound":
             if cm_type == "key":
-                bounds: List[int] = []
-                colors: List[str] = []
+                bounds: list[int] = []
+                colors: list[str] = []
                 n = len(cm_items)
                 for i, (value, color) in enumerate(cm_items):
                     index = int(value)
@@ -464,8 +464,8 @@ def parse_cm_code(cm_code: str) -> Tuple[str, Optional[Colormap]]:
                         bounds.append(index + 1)
                         colors.append("#00000000")
             else:  # cm_type == "bound"
-                bounds: List[Union[int, float]] = list(map(lambda c: c[0], cm_items))
-                colors: List[str] = list(map(lambda c: c[1], cm_items[:-1]))
+                bounds: list[Union[int, float]] = list(map(lambda c: c[0], cm_items))
+                colors: list[str] = list(map(lambda c: c[1], cm_items[:-1]))
             return cm_name, Colormap(
                 cm_base_name,
                 cat_name=CUSTOM_CATEGORY.name,
@@ -494,7 +494,7 @@ def parse_cm_code(cm_code: str) -> Tuple[str, Optional[Colormap]]:
         return "Reds", None
 
 
-def parse_cm_name(cm_name) -> Tuple[str, bool, bool]:
+def parse_cm_name(cm_name) -> tuple[str, bool, bool]:
     assert_given(cm_name, name="cm_name")
     alpha = cm_name.endswith(ALPHA_SUFFIX)
     if alpha:
@@ -507,14 +507,14 @@ def parse_cm_name(cm_name) -> Tuple[str, bool, bool]:
 
 def get_reverse_cmap(
     cm_name: str, cmap: matplotlib.colors.Colormap
-) -> Tuple[str, matplotlib.colors.Colormap]:
+) -> tuple[str, matplotlib.colors.Colormap]:
     new_cm_name = cm_name + REVERSED_SUFFIX
     return new_cm_name, cmap.reversed(name=new_cm_name)
 
 
 def get_alpha_cmap(
     cm_name: str, cmap: matplotlib.colors.Colormap
-) -> Tuple[str, matplotlib.colors.Colormap]:
+) -> tuple[str, matplotlib.colors.Colormap]:
     """Add extra colormaps with alpha gradient.
     See http://matplotlib.org/api/colors_api.html
     """
@@ -617,16 +617,16 @@ def load_snap_cpd_colormap(snap_cpd_path: str) -> Colormap:
 
 
 Sample = float
-Color = Tuple[int, int, int, int]
-Palette = List[Tuple[Sample, Color]]
+Color = tuple[int, int, int, int]
+Palette = list[tuple[Sample, Color]]
 LogScaled = bool
 
 
-def _parse_snap_cpd_file(cpd_file_path: str) -> Tuple[Palette, LogScaled]:
+def _parse_snap_cpd_file(cpd_file_path: str) -> tuple[Palette, LogScaled]:
     with fsspec.open(cpd_file_path, mode="r") as f:
         illegal_format_msg = f"Illegal SNAP *.cpd format: {cpd_file_path}"
 
-        entries: Dict[str, str] = dict()
+        entries: dict[str, str] = dict()
         for line in f.readlines():
             line = line.strip()
             if line and not line.startswith("#"):

--- a/xcube/util/config.py
+++ b/xcube/util/config.py
@@ -9,7 +9,8 @@ import json
 import os
 import os.path
 import string
-from typing import Any, Dict, Optional, Iterable, Tuple, List, Type
+from typing import Any, Dict, Optional, Tuple, List, Type
+from collections.abc import Iterable
 
 import fsspec
 import yaml
@@ -18,8 +19,8 @@ from xcube.constants import LOG
 
 PRIMITIVE_TYPES = (int, float, str, type(None))
 
-NameAnyDict = Dict[str, Any]
-NameDictPairList = List[Tuple[str, Optional[NameAnyDict]]]
+NameAnyDict = dict[str, Any]
+NameDictPairList = list[tuple[str, Optional[NameAnyDict]]]
 
 
 def to_resolved_name_dict_pairs(
@@ -81,7 +82,7 @@ def to_name_dict_pair(name: Any, parent: Any = None, default_key=None):
     return name, value
 
 
-def flatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:
+def flatten_dict(d: dict[str, Any]) -> dict[str, Any]:
     result = dict()
     value = _flatten_dict_value(d, result, None, False)
     if value is not result:
@@ -91,7 +92,7 @@ def flatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _flatten_dict_value(
-    value: Any, result: Dict[str, Any], parent_name: Optional[str], concat: bool
+    value: Any, result: dict[str, Any], parent_name: Optional[str], concat: bool
 ) -> Any:
     if isinstance(value, datetime.datetime):
         return datetime.datetime.isoformat(value)
@@ -123,7 +124,7 @@ def _flatten_dict_value(
     return result
 
 
-def merge_config(first_dict: Dict, *more_dicts):
+def merge_config(first_dict: dict, *more_dicts):
     if not more_dicts:
         output_dict = first_dict
     else:
@@ -141,8 +142,8 @@ def merge_config(first_dict: Dict, *more_dicts):
 
 
 def load_configs(
-    *config_paths: str, exception_type: Type[Exception] = ValueError
-) -> Dict[str, Any]:
+    *config_paths: str, exception_type: type[Exception] = ValueError
+) -> dict[str, Any]:
     config_dicts = []
     for config_path in config_paths:
         config_dict = load_json_or_yaml_config(
@@ -154,8 +155,8 @@ def load_configs(
 
 
 def load_json_or_yaml_config(
-    config_path: str, exception_type: Type[Exception] = ValueError
-) -> Dict[str, Any]:
+    config_path: str, exception_type: type[Exception] = ValueError
+) -> dict[str, Any]:
     try:
         config_dict = _load_json_or_yaml_config(config_path)
         LOG.info(f"Configuration loaded: {config_path}")

--- a/xcube/util/dask.py
+++ b/xcube/util/dask.py
@@ -11,22 +11,20 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Iterable,
     List,
-    Mapping,
     Optional,
-    Sequence,
     Tuple,
     Union,
 )
+from collections.abc import Iterable, Mapping, Sequence
 
 import dask.array as da
 import dask.array.core as dac
 import distributed
 import numpy as np
 
-IntTuple = Tuple[int, ...]
-SliceTuple = Tuple[slice, ...]
+IntTuple = tuple[int, ...]
+SliceTuple = tuple[slice, ...]
 IntIterable = Iterable[int]
 IntTupleIterable = Iterable[IntTuple]
 SliceTupleIterable = Iterable[SliceTuple]
@@ -133,7 +131,7 @@ def compute_array_from_func(
 
 def get_block_iterators(
     chunk_sizes: IntTupleIterable,
-) -> Tuple[IntTupleIterable, IntTupleIterable, SliceTupleIterable]:
+) -> tuple[IntTupleIterable, IntTupleIterable, SliceTupleIterable]:
     chunk_sizes = tuple(chunk_sizes)
     chunk_slices_tuples = get_chunk_slice_tuples(chunk_sizes)
     chunk_ranges = get_chunk_ranges(chunk_sizes)
@@ -181,7 +179,7 @@ def new_cluster(
     name: Optional[str] = None,
     software: Optional[str] = None,
     n_workers: int = 4,
-    resource_tags: Optional[Dict[str, str]] = None,
+    resource_tags: Optional[dict[str, str]] = None,
     account: str = None,
     region: str = "eu-central-1",
     **kwargs,
@@ -282,7 +280,7 @@ def new_cluster(
     raise NotImplementedError(f"Unknown provider {provider!r}")
 
 
-def _collate_cluster_resource_tags(extra_tags: Dict[str, str]) -> Dict[str, str]:
+def _collate_cluster_resource_tags(extra_tags: dict[str, str]) -> dict[str, str]:
     fallback_tags = {
         "cost-center": "unknown",
         "environment": "dev",
@@ -320,7 +318,7 @@ class _NestedList:
     @classmethod
     def _new_data(
         cls, shape: Sequence[int], ndim: int, fill_value: Any, dim: int
-    ) -> Union[List[List], List[Any]]:
+    ) -> Union[list[list], list[Any]]:
         return [
             (
                 cls._new_data(shape, ndim, fill_value, dim + 1)
@@ -331,11 +329,11 @@ class _NestedList:
         ]
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> tuple[int, ...]:
         return self._shape
 
     @property
-    def data(self) -> Union[List[List], List[Any]]:
+    def data(self) -> Union[list[list], list[Any]]:
         return self._data
 
     def __len__(self) -> int:

--- a/xcube/util/expression.py
+++ b/xcube/util/expression.py
@@ -9,7 +9,7 @@ from typing import Dict, Any
 
 def compute_array_expr(
     expr: str,
-    namespace: Dict[str, Any] = None,
+    namespace: dict[str, Any] = None,
     errors: str = "raise",
     result_name: str = None,
 ):
@@ -43,7 +43,7 @@ def compute_array_expr(
 
 def compute_expr(
     expr: str,
-    namespace: Dict[str, Any] = None,
+    namespace: dict[str, Any] = None,
     errors: str = "raise",
     result_name: str = None,
 ):
@@ -213,11 +213,11 @@ class _ExprTranspiler:
 
     def transform_call(self, func: ast.Name, args):
         args = ", ".join(["{x%d}" % i for i in range(len(args))])
-        return "%s(%s)" % (self.transform_function_name(func), args)
+        return f"{self.transform_function_name(func)}({args})"
 
     def transform_function_name(self, func: ast.Name):
         if isinstance(func, ast.Attribute):
-            return "%s.%s" % (func.value.id, func.attr)
+            return f"{func.value.id}.{func.attr}"
         else:
             if func.id in ("where",):
                 return "xr.%s" % func.id
@@ -246,9 +246,9 @@ class _ExprTranspiler:
                 x = "({x})"
 
         if name in self._KEYWORDS:
-            return "%s %s" % (name, x)
+            return f"{name} {x}"
         else:
-            return "%s%s" % (name, x)
+            return f"{name}{x}"
 
     def transform_bin_op(self, op, left, right):
         name, precedence, assoc = _ExprTranspiler.get_op_info(op)
@@ -257,7 +257,7 @@ class _ExprTranspiler:
         y = "{y}"
 
         if name == "**":
-            return "np.power(%s, %s)" % (x, y)
+            return f"np.power({x}, {y})"
 
         left_op = getattr(left, "op", None)
         right_op = getattr(right, "op", None)
@@ -280,7 +280,7 @@ class _ExprTranspiler:
             ):
                 y = "({y})"
 
-        return "%s %s %s" % (x, name, y)
+        return f"{x} {name} {y}"
 
     # noinspection PyUnusedLocal
     def transform_if_exp(self, test, body, orelse):
@@ -366,7 +366,7 @@ class _ExprTranspiler:
             ):
                 y = "(%s)" % y
 
-        return "%s %s %s" % (x, name, y)
+        return f"{x} {name} {y}"
 
     def _is_nan(self, node):
         return isinstance(node, ast.Name) and node.id == "NaN"

--- a/xcube/util/extend.py
+++ b/xcube/util/extend.py
@@ -7,14 +7,13 @@ import threading
 from typing import (
     Type,
     TypeVar,
-    Mapping,
-    Sequence,
     Any,
     Optional,
     Callable,
     Tuple,
     Union,
 )
+from collections.abc import Mapping, Sequence
 
 from xcube.util.assertions import assert_true
 
@@ -23,11 +22,11 @@ GET_EXTENSIONS_ATTR_NAME = "get_extensions"
 Base = TypeVar("Base")
 Ext = TypeVar("Ext")
 
-BaseClass = Type[Base]
-ExtClass = Type[Ext]
+BaseClass = type[Base]
+ExtClass = type[Ext]
 
-ExtClassItem = Tuple[str, ExtClass]
-ExtInstItem = Tuple[str, Ext]
+ExtClassItem = tuple[str, ExtClass]
+ExtInstItem = tuple[str, Ext]
 
 
 def extend(

--- a/xcube/util/extension.py
+++ b/xcube/util/extension.py
@@ -4,7 +4,8 @@
 
 
 import importlib
-from typing import List, Any, Dict, Callable, Mapping, Sequence, Optional
+from typing import List, Any, Dict, Callable, Optional
+from collections.abc import Mapping, Sequence
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
@@ -82,11 +83,11 @@ class Extension:
         return self._name
 
     @property
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         """Extension metadata."""
         return dict(self._metadata)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Get a JSON-serializable dictionary representation of this extension."""
 
         # Note: we avoid loading the component!
@@ -166,7 +167,7 @@ class ExtensionRegistry:
 
     def find_extensions(
         self, point: str, predicate: ExtensionPredicate = None
-    ) -> List[Extension]:
+    ) -> list[Extension]:
         """Find extensions for *point* and optional filter function *predicate*.
 
         The filter function is called with an extension and should return
@@ -190,7 +191,7 @@ class ExtensionRegistry:
 
     def find_components(
         self, point: str, predicate: ExtensionPredicate = None
-    ) -> List[Component]:
+    ) -> list[Component]:
         """Find extension components for *point* and optional filter function *predicate*.
 
         The filter function is called with an extension and should return

--- a/xcube/util/frozen.py
+++ b/xcube/util/frozen.py
@@ -4,7 +4,8 @@
 
 import collections.abc
 from abc import abstractmethod, ABC
-from typing import Generic, TypeVar, Tuple, Any, Iterable, Dict, List, Sequence, Mapping
+from typing import Generic, TypeVar, Tuple, Any, Dict, List
+from collections.abc import Iterable, Sequence, Mapping
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -30,14 +31,14 @@ class Frozen(ABC):
         """
 
 
-class FrozenDict(Dict[K, V], Frozen, Generic[K, V]):
+class FrozenDict(dict[K, V], Frozen, Generic[K, V]):
     """A frozen version of a standard ``dict``."""
 
     @classmethod
     def freeze(cls, other: Mapping) -> "FrozenDict":
         return FrozenDict({key: freeze_value(value) for key, value in other.items()})
 
-    def defrost(self) -> Dict[K, V]:
+    def defrost(self) -> dict[K, V]:
         return {key: defrost_value(value) for key, value in self.items()}
 
     ###########################################################
@@ -49,7 +50,7 @@ class FrozenDict(Dict[K, V], Frozen, Generic[K, V]):
     def pop(self, *args, **kwargs) -> V:
         raise TypeError(_DICT_IS_READONLY)
 
-    def popitem(self) -> Tuple[K, V]:
+    def popitem(self) -> tuple[K, V]:
         raise TypeError(_DICT_IS_READONLY)
 
     def update(self, *args, **kwargs) -> None:
@@ -68,14 +69,14 @@ class FrozenDict(Dict[K, V], Frozen, Generic[K, V]):
         raise TypeError(_DICT_IS_READONLY)
 
 
-class FrozenList(List[V], Frozen, Generic[V]):
+class FrozenList(list[V], Frozen, Generic[V]):
     """A frozen version of a standard ``list``."""
 
     @classmethod
     def freeze(cls, other: Sequence[V]) -> "FrozenList":
         return FrozenList(freeze_value(item) for item in other)
 
-    def defrost(self) -> List[V]:
+    def defrost(self) -> list[V]:
         return [defrost_value(item) for item in self]
 
     ###########################################################

--- a/xcube/util/fspath.py
+++ b/xcube/util/fspath.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import pathlib
-from typing import Type, Iterator
+from typing import Type
+from collections.abc import Iterator
 
 import fsspec
 from fsspec.implementations.local import LocalFileSystem
@@ -14,7 +15,7 @@ def is_local_fs(fs: fsspec.AbstractFileSystem) -> bool:
     return "file" in fs.protocol or isinstance(fs, LocalFileSystem)
 
 
-def get_fs_path_class(fs: fsspec.AbstractFileSystem) -> Type[pathlib.PurePath]:
+def get_fs_path_class(fs: fsspec.AbstractFileSystem) -> type[pathlib.PurePath]:
     """Get the appropriate ``pathlib.PurePath`` class for the filesystem *fs*."""
     if is_local_fs(fs):
         # Will return PurePosixPath or a PureWindowsPath object

--- a/xcube/util/geojson.py
+++ b/xcube/util/geojson.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Any, Optional, Dict, Sequence
+from typing import Any, Optional, Dict
+from collections.abc import Sequence
 
 from xcube.util.undefined import UNDEFINED
 
@@ -51,7 +52,7 @@ class GeoJSON:
         return False
 
     @classmethod
-    def get_geometry_collection_geometries(cls, obj: Any) -> Optional[Sequence[Dict]]:
+    def get_geometry_collection_geometries(cls, obj: Any) -> Optional[Sequence[dict]]:
         type_name = cls.get_type_name(obj)
         if type_name == cls.GEOMETRY_COLLECTION_TYPE:
             geometries = cls._get_sequence(obj, "geometries")
@@ -64,7 +65,7 @@ class GeoJSON:
         return None
 
     @classmethod
-    def get_feature_collection_features(cls, obj: Any) -> Optional[Sequence[Dict]]:
+    def get_feature_collection_features(cls, obj: Any) -> Optional[Sequence[dict]]:
         type_name = cls.get_type_name(obj)
         if type_name == cls.FEATURE_COLLECTION_TYPE:
             features = cls._get_sequence(obj, "features")
@@ -77,7 +78,7 @@ class GeoJSON:
         return None
 
     @classmethod
-    def get_feature_geometry(cls, obj: Any) -> Optional[Dict]:
+    def get_feature_geometry(cls, obj: Any) -> Optional[dict]:
         type_name = cls.get_type_name(obj)
         if type_name == cls.FEATURE_TYPE:
             if "geometry" not in obj:

--- a/xcube/util/ipython.py
+++ b/xcube/util/ipython.py
@@ -6,7 +6,7 @@ import warnings
 from typing import Type
 
 
-def register_json_formatter(cls: Type, to_dict_method_name: str = "to_dict"):
+def register_json_formatter(cls: type, to_dict_method_name: str = "to_dict"):
     """TODO
 
     Args:

--- a/xcube/util/jsonencoder.py
+++ b/xcube/util/jsonencoder.py
@@ -7,8 +7,8 @@ from typing import Any, Union, List, Dict
 
 import numpy as np
 
-JsonArray = List["JsonValue"]
-JsonObject = Dict[str, "JsonValue"]
+JsonArray = list["JsonValue"]
+JsonObject = dict[str, "JsonValue"]
 JsonValue = Union[None, bool, int, float, str, JsonArray, JsonObject]
 
 

--- a/xcube/util/jsonschema.py
+++ b/xcube/util/jsonschema.py
@@ -4,7 +4,8 @@
 
 import collections.abc
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Callable, Mapping, Sequence, Union, Tuple, Optional
+from typing import Dict, Any, Callable, Union, Tuple, Optional
+from collections.abc import Mapping, Sequence
 
 from xcube.util.assertions import assert_instance
 from xcube.util.assertions import assert_true
@@ -59,7 +60,7 @@ class JsonSchema(ABC):
         self.factory = factory
         self.serializer = serializer
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = dict()
         if self.type is not None:
             if self.nullable is True and self.type != "null":
@@ -157,7 +158,7 @@ class JsonComplexSchema(JsonSchema):
         self.any_of = any_of
         self.all_of = all_of
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         if self.one_of:
             d.update(oneOf=[schema.to_dict() for schema in self.one_of])
@@ -214,7 +215,7 @@ class JsonStringSchema(JsonSimpleSchema):
         self.min_length = min_length
         self.max_length = max_length
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         if self.format is not None:
             d.update(format=self.format)
@@ -264,7 +265,7 @@ class JsonDateSchema(JsonStringSchema, JsonDateAndTimeSchemaBase):
         self.min_date = min_date
         self.max_date = max_date
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         if self.min_date is not None:
             d.update(minDate=self.min_date)
@@ -312,7 +313,7 @@ class JsonDatetimeSchema(JsonStringSchema, JsonDateAndTimeSchemaBase):
         self.min_datetime = min_datetime
         self.max_datetime = max_datetime
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         if self.min_datetime is not None:
             d.update(minDatetime=self.min_datetime)
@@ -374,7 +375,7 @@ class JsonNumberSchema(JsonSimpleSchema):
         self.exclusive_maximum = exclusive_maximum
         self.multiple_of = multiple_of
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         if self.minimum is not None:
             d.update(minimum=self.minimum)
@@ -409,7 +410,7 @@ class JsonArraySchema(JsonSchema):
         self.max_items = max_items
         self.unique_items = unique_items
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         if self.items is not None:
             if isinstance(self.items, JsonSchema):
@@ -478,7 +479,7 @@ class JsonObjectSchema(JsonSchema):
         self.required = list(required) if required else []
         self.dependencies = dict(dependencies) if dependencies else None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = super().to_dict()
         if self.properties is not None:
             d.update(properties={k: v.to_dict() for k, v in self.properties.items()})
@@ -507,8 +508,8 @@ class JsonObjectSchema(JsonSchema):
 
     # TODO: move away. this is a special-purpose utility
     def process_kwargs_subset(
-        self, kwargs: Dict[str, Any], keywords: Sequence[str]
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        self, kwargs: dict[str, Any], keywords: Sequence[str]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Utility that helps to process keyword-arguments.
 
         Pops every keyword in *keywords* contained in this object schema's
@@ -649,7 +650,7 @@ class JsonObjectSchema(JsonSchema):
         return converted_mapping
 
     @classmethod
-    def inject_attrs(cls, obj: object, attrs: Dict[str, Any]):
+    def inject_attrs(cls, obj: object, attrs: dict[str, Any]):
         for k, v in (attrs or {}).items():
             setattr(obj, k, v)
 
@@ -674,15 +675,15 @@ class JsonObject(ABC):
         """Get JSON object schema."""
 
     @classmethod
-    def from_dict(cls, value: Dict[str, Any]) -> "JsonObject":
+    def from_dict(cls, value: dict[str, Any]) -> "JsonObject":
         """Create instance from JSON-serializable dictionary *value*."""
         return cls.get_schema().from_instance(value)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Create JSON-serializable dictionary representation."""
         return self.get_schema().to_instance(self)
 
-    def _inject_attrs(self, attrs: Dict[str, Any]):
+    def _inject_attrs(self, attrs: dict[str, Any]):
         assert_instance(attrs, dict, name="attrs")
         schema = self.get_schema()
         assert_true(

--- a/xcube/util/plugin.py
+++ b/xcube/util/plugin.py
@@ -27,7 +27,7 @@ _PLUGIN_REGISTRY_INIT = dict()
 
 # Mapping of xcube entry point names
 # to JSON-serializable plugin meta-information.
-_PLUGIN_REGISTRY: Dict[str, Dict[str, Any]] = _PLUGIN_REGISTRY_INIT
+_PLUGIN_REGISTRY: dict[str, dict[str, Any]] = _PLUGIN_REGISTRY_INIT
 
 
 def init_plugins() -> None:
@@ -37,7 +37,7 @@ def init_plugins() -> None:
         _PLUGIN_REGISTRY = load_plugins()
 
 
-def get_plugins() -> Dict[str, Dict]:
+def get_plugins() -> dict[str, dict]:
     """Get mapping of "xcube_plugins" entry point names
     to JSON-serializable plugin meta-information.
     """
@@ -81,7 +81,7 @@ def discover_plugin_modules(module_prefixes=None):
 
 def load_plugins(
     entry_points=None, ext_registry: Optional[ExtensionRegistry] = None
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     if ext_registry is None:
         from xcube.util.extension import get_extension_registry
 
@@ -108,10 +108,10 @@ def load_plugins(
 
 
 def _collect_plugins(
-    entry_points: List[Any],
+    entry_points: list[Any],
     ext_registry: ExtensionRegistry,
     verbose: bool,
-    plugins: Dict[str, Dict[str, Any]],
+    plugins: dict[str, dict[str, Any]],
 ):
     for entry_point in entry_points:
         # Note: Consider turning this into debug log,

--- a/xcube/util/progress.py
+++ b/xcube/util/progress.py
@@ -6,7 +6,8 @@ import threading
 import time
 import traceback
 from abc import ABC
-from typing import Sequence, Optional, Any, Tuple, Type, List
+from typing import Optional, Any, Tuple, Type, List
+from collections.abc import Sequence
 
 import dask.callbacks
 import dask.diagnostics
@@ -54,15 +55,15 @@ class ProgressState:
         return self._super_work * work / self._total_work
 
     @property
-    def exc_info(self) -> Optional[Tuple[Type, BaseException, Any]]:
+    def exc_info(self) -> Optional[tuple[type, BaseException, Any]]:
         return self._exc_info
 
     @exc_info.setter
-    def exc_info(self, exc_info: Tuple[Type, BaseException, Any]):
+    def exc_info(self, exc_info: tuple[type, BaseException, Any]):
         self._exc_info = exc_info
 
     @property
-    def exc_info_text(self) -> Optional[Tuple[str, str, List[str]]]:
+    def exc_info_text(self) -> Optional[tuple[str, str, list[str]]]:
         if not self.exc_info:
             return None
         exc_type, exc_value, exc_traceback = self.exc_info

--- a/xcube/util/projcache.py
+++ b/xcube/util/projcache.py
@@ -19,8 +19,8 @@ class ProjCache:
     INSTANCE: "ProjCache"
 
     def __init__(self):
-        self._crs_cache: Dict[str, pyproj.CRS] = dict()
-        self._transformer_cache: Dict[str, pyproj.Transformer] = dict()
+        self._crs_cache: dict[str, pyproj.CRS] = dict()
+        self._transformer_cache: dict[str, pyproj.Transformer] = dict()
 
     def get_crs(self, crs: CrsLike) -> pyproj.CRS:
         if isinstance(crs, pyproj.CRS):

--- a/xcube/util/temp.py
+++ b/xcube/util/temp.py
@@ -41,7 +41,7 @@ def new_temp_file(
     suffix: str = None,
     dir_path: str = None,
     text_mode: bool = False,
-) -> Tuple[int, str]:
+) -> tuple[int, str]:
     """Create new temporary file using ``tempfile.mkstemp()``.
     The file will be removed later when the process ends.
 

--- a/xcube/util/timeindex.py
+++ b/xcube/util/timeindex.py
@@ -13,7 +13,8 @@ this compatibility before attempting an indexing operation. See
 https://github.com/dcs4cop/xcube/issues/605 for more background information.
 """
 
-from typing import Dict, Any, Union, Hashable
+from typing import Dict, Any, Union
+from collections.abc import Hashable
 
 import numpy as np
 import pandas as pd
@@ -26,9 +27,9 @@ logger = logging.getLogger("xcube")
 
 def ensure_time_label_compatible(
     var: Union[xr.DataArray, xr.Dataset],
-    labels: Dict[Hashable, Any],
+    labels: dict[Hashable, Any],
     time_name: Hashable = "time",
-) -> Dict[Hashable, Any]:
+) -> dict[Hashable, Any]:
     """Ensure that *labels[time_name]* is compatible with *var*
 
     This function returns either the passed-in *labels* object, or a copy of

--- a/xcube/util/types.py
+++ b/xcube/util/types.py
@@ -8,8 +8,8 @@ from xcube.util.assertions import assert_true
 
 T = TypeVar("T")
 
-ItemType = Union[Type[T], Tuple[Type[T], ...]]
-Pair = Tuple[T, T]
+ItemType = Union[type[T], tuple[type[T], ...]]
+Pair = tuple[T, T]
 ScalarOrPair = Union[T, Pair]
 
 

--- a/xcube/util/versions.py
+++ b/xcube/util/versions.py
@@ -44,7 +44,7 @@ DEFAULT_DEPENDENCY_NAMES = [
 _XCUBE_VERSIONS = None
 
 
-def get_xcube_versions() -> Dict[str, str]:
+def get_xcube_versions() -> dict[str, str]:
     """Get a mapping from xcube package names to package versions.
 
     Returns:
@@ -62,8 +62,8 @@ def get_xcube_versions() -> Dict[str, str]:
 
 
 def get_versions(
-    dependency_names: List[str], plugin_names: List[str]
-) -> Dict[str, str]:
+    dependency_names: list[str], plugin_names: list[str]
+) -> dict[str, str]:
     """Get a mapping from package names to package versions.
     The input is divided into names of packages that are external dependencies
     and into names of xcube plugins.

--- a/xcube/webapi/auth/config.py
+++ b/xcube/webapi/auth/config.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import List, Optional, Any, Mapping
+from typing import List, Optional, Any
+from collections.abc import Mapping
 
 from xcube.constants import LOG
 from xcube.server.api import ApiError
@@ -42,7 +43,7 @@ class AuthConfig:
         self,
         authority: str,
         audience: str,
-        algorithms: List[str],
+        algorithms: list[str],
         is_required: bool = False,
     ):
         self._authority = authority
@@ -71,7 +72,7 @@ class AuthConfig:
         return self._audience
 
     @property
-    def algorithms(self) -> List[str]:
+    def algorithms(self) -> list[str]:
         return self._algorithms
 
     @property

--- a/xcube/webapi/auth/context.py
+++ b/xcube/webapi/auth/context.py
@@ -6,7 +6,8 @@ import json
 from functools import cached_property
 from itertools import filterfalse
 from string import Template
-from typing import Optional, Mapping, Dict, Any, Set, Union
+from typing import Optional, Dict, Any, Set, Union
+from collections.abc import Mapping
 
 import jwt
 import jwt.algorithms
@@ -37,7 +38,7 @@ class AuthContext(ApiContext):
         return self.auth_config is not None and self.auth_config.is_required
 
     @cached_property
-    def jwks(self) -> Dict[str, Any]:
+    def jwks(self) -> dict[str, Any]:
         response = requests.get(self.auth_config.well_known_jwks)
         return json.loads(response.content)
 
@@ -59,7 +60,7 @@ class AuthContext(ApiContext):
 
     def get_granted_scopes(
         self, request_headers: Mapping[str, str]
-    ) -> Optional[Set[str]]:
+    ) -> Optional[set[str]]:
         must_authenticate = self.must_authenticate
         id_token = self.get_id_token(request_headers, require_auth=must_authenticate)
         permissions = None
@@ -181,10 +182,10 @@ class AuthContext(ApiContext):
         templ_permissions = filter(predicate, permissions)
         id_mapping = self._get_template_dict(id_token)
         return plain_permissions.union(
-            set(
+            {
                 Template(permission).safe_substitute(id_mapping)
                 for permission in templ_permissions
-            )
+            }
         )
 
     @staticmethod
@@ -192,7 +193,7 @@ class AuthContext(ApiContext):
         return "$" in permission
 
     @staticmethod
-    def _get_template_dict(id_token: Mapping[str, Any]) -> Dict[str, str]:
+    def _get_template_dict(id_token: Mapping[str, Any]) -> dict[str, str]:
         d = {k: v for k, v in id_token.items() if isinstance(v, str)}
         if "username" not in d and "preferred_username" in d:
             d["username"] = d["preferred_username"]

--- a/xcube/webapi/common/context.py
+++ b/xcube/webapi/common/context.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import threading
-from typing import Any, Dict, List, Optional, Mapping, Iterator, Union, Tuple
+from typing import Any, Dict, List, Optional, Union, Tuple
+from collections.abc import Mapping, Iterator
 
 import fsspec
 
@@ -64,11 +65,11 @@ class ResourcesContext(ApiContext):
         return self._auth_ctx.must_authenticate
 
     @property
-    def access_control(self) -> Dict[str, Any]:
+    def access_control(self) -> dict[str, Any]:
         return self.config.get("AccessControl", {})
 
     @property
-    def required_scopes(self) -> List[str]:
+    def required_scopes(self) -> list[str]:
         return self.access_control.get("RequiredScopes", [])
 
     def get_service_url(self, base_url: Optional[str], *path: str):
@@ -146,7 +147,7 @@ class ResourcesContext(ApiContext):
             else:
                 yield token
 
-    def new_eval_env(self) -> Dict[str, Any]:
+    def new_eval_env(self) -> dict[str, Any]:
         return dict(
             ctx=self,
             base_dir=self.base_dir,
@@ -156,7 +157,7 @@ class ResourcesContext(ApiContext):
         )
 
     @classmethod
-    def _tokenize_value(cls, value: str) -> Iterator[Union[str, Tuple[str]]]:
+    def _tokenize_value(cls, value: str) -> Iterator[Union[str, tuple[str]]]:
         """Tokenize a string value. Tokens are either strings or 1-tuples
         that contain a string-expression to be evaluated. String-expressions
         are any strings between non-quoted "${" and "}".

--- a/xcube/webapi/common/xml.py
+++ b/xcube/webapi/common/xml.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import abc
-from typing import Optional, Dict, Union, Sequence, List
+from typing import Optional, Dict, Union, List
+from collections.abc import Sequence
 
 from xcube.util.assertions import assert_given, assert_false
 
@@ -47,7 +48,7 @@ class Element(Node):
     def __init__(
         self,
         tag: str,
-        attrs: Optional[Dict[str, str]] = None,
+        attrs: Optional[dict[str, str]] = None,
         text: Optional[Union[str, Sequence[str]]] = None,
         elements: Optional[Sequence["Element"]] = None,
     ):
@@ -69,7 +70,7 @@ class Element(Node):
         self._to_xml(indent, 0, lines)
         return "\n".join(lines)
 
-    def _to_xml(self, indent: int, level: int, lines: List[str]):
+    def _to_xml(self, indent: int, level: int, lines: list[str]):
         tab = indent * " "
         tabs = level * tab
         line = f"{tabs}<{self._tag}"

--- a/xcube/webapi/compute/context.py
+++ b/xcube/webapi/compute/context.py
@@ -30,13 +30,13 @@ LocalExecutor = concurrent.futures.ThreadPoolExecutor
 # TODO: we should create a module 'job' and define better job classes.
 #   Here we use dicts for time being.
 
-Job = Dict[str, Any]
-Jobs = Dict[int, Job]
+Job = dict[str, Any]
+Jobs = dict[int, Job]
 
-JobRequest = Dict[str, Any]
+JobRequest = dict[str, Any]
 
 JobFuture = concurrent.futures.Future
-JobFutures = Dict[int, JobFuture]
+JobFutures = dict[int, JobFuture]
 
 JOB_INIT = "init"
 JOB_SCHEDULED = "scheduled"
@@ -215,7 +215,7 @@ class ComputeContext(ResourcesContext):
 
         return job
 
-    def get_effective_parameters(self, op: Callable, parameters: Dict[str, Any]):
+    def get_effective_parameters(self, op: Callable, parameters: dict[str, Any]):
         """Replace dataset names with datasets in operation parameters.
 
         This method takes a parameter dictionary for the invocation or an
@@ -300,7 +300,7 @@ def set_job_status(job: Job, status: str, error: Optional[BaseException] = None)
         }
 
 
-def set_job_result(job: Job, result: Dict[str, Any]):
+def set_job_result(job: Job, result: dict[str, Any]):
     """Set the result of a compute job.
 
     Args:

--- a/xcube/webapi/compute/controllers.py
+++ b/xcube/webapi/compute/controllers.py
@@ -23,7 +23,7 @@ def get_compute_operation(ctx: ComputeContext, op_id: str):
     return encode_op(op_id, op)
 
 
-def encode_op(op_id: str, op: Callable) -> Dict[str, Any]:
+def encode_op(op_id: str, op: Callable) -> dict[str, Any]:
     op_info = OpInfo.get_op_info(op)
     op_json = {"operationId": op_id, "parametersSchema": op_info.params_schema}
     doc = inspect.getdoc(op)

--- a/xcube/webapi/compute/op/decorator.py
+++ b/xcube/webapi/compute/op/decorator.py
@@ -46,7 +46,7 @@ def operation(
 
 def op_param(
     name: str,
-    json_type: Optional[Union[str, List[str]]] = None,
+    json_type: Optional[Union[str, list[str]]] = None,
     py_type: Optional[PyType] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,

--- a/xcube/webapi/compute/op/info.py
+++ b/xcube/webapi/compute/op/info.py
@@ -33,7 +33,7 @@ class OpInfo:
     """Information about a compute operation"""
 
     def __init__(
-        self, params_schema: Dict[str, Any], param_py_types: Dict[str, PyType]
+        self, params_schema: dict[str, Any], param_py_types: dict[str, PyType]
     ):
         """Create information about a compute operation
 
@@ -163,7 +163,7 @@ class OpInfo:
             return all(map(OpInfo._is_valid_parameter_type, args))
 
     @property
-    def effective_param_py_types(self) -> Dict[str, PyType]:
+    def effective_param_py_types(self) -> dict[str, PyType]:
         """Return effective Python types for the operation’s parameters
 
         For any parameter which has a Python type annotation, that type will
@@ -192,13 +192,13 @@ class OpInfo:
         return py_types
 
     @property
-    def param_schemas(self) -> Dict[str, Any]:
+    def param_schemas(self) -> dict[str, Any]:
         """Returns:
         a mapping of parameter names to their JSON schemas
         """
         return self.params_schema.get("properties", {})
 
-    def set_param_schemas(self, schemas: Dict[str, Any]):
+    def set_param_schemas(self, schemas: dict[str, Any]):
         """Set JSON schemas for operation parameters
 
         Args:
@@ -206,7 +206,7 @@ class OpInfo:
         """
         self.params_schema["properties"] = schemas
 
-    def update_params_schema(self, schema: Dict[str, Any]):
+    def update_params_schema(self, schema: dict[str, Any]):
         """Update the JSON schema for the whole parameters dictionary
 
         Update the existing parameter dictionary schema with the supplied
@@ -220,7 +220,7 @@ class OpInfo:
         """
         self.params_schema.update(schema)
 
-    def update_param_schema(self, param_name: str, schema: Dict[str, Any]):
+    def update_param_schema(self, param_name: str, schema: dict[str, Any]):
         """Update the JSON Schema for a single parameter
 
         Args:

--- a/xcube/webapi/compute/op/registry.py
+++ b/xcube/webapi/compute/op/registry.py
@@ -11,10 +11,10 @@ from .info import OpInfo
 
 class OpRegistry:
     def __init__(self):
-        self._ops: Dict[str, Callable] = {}
+        self._ops: dict[str, Callable] = {}
 
     @property
-    def ops(self) -> Dict[str, Callable]:
+    def ops(self) -> dict[str, Callable]:
         return self._ops.copy()
 
     def get_op(self, op_id: str) -> Optional[Callable]:

--- a/xcube/webapi/compute/operations.py
+++ b/xcube/webapi/compute/operations.py
@@ -20,7 +20,7 @@ from xcube.webapi.compute.op.decorator import op_param
     # The rest of the schema is inferred from the function signature.
 )
 def spatial_subset(
-    dataset: xr.Dataset, bbox: Tuple[float, float, float, float]
+    dataset: xr.Dataset, bbox: tuple[float, float, float, float]
 ) -> xr.Dataset:
     """Create a spatial subset from given dataset."""
     x1, y1, x2, y2 = bbox

--- a/xcube/webapi/datasets/authutil.py
+++ b/xcube/webapi/datasets/authutil.py
@@ -12,8 +12,8 @@ READ_ALL_VARIABLES_SCOPE = "read:variable:*"
 
 
 def assert_scopes(
-    required_scopes: Set[str],
-    granted_scopes: Optional[Set[str]],
+    required_scopes: set[str],
+    granted_scopes: Optional[set[str]],
     is_substitute: bool = False,
 ):
     """Assert scopes.
@@ -35,8 +35,8 @@ def assert_scopes(
 
 
 def check_scopes(
-    required_scopes: Set[str],
-    granted_scopes: Optional[Set[str]],
+    required_scopes: set[str],
+    granted_scopes: Optional[set[str]],
     is_substitute: bool = False,
 ) -> bool:
     """Check scopes.
@@ -65,8 +65,8 @@ def check_scopes(
 
 
 def _get_missing_scope(
-    required_scopes: Set[str],
-    granted_scopes: Optional[Set[str]],
+    required_scopes: set[str],
+    granted_scopes: Optional[set[str]],
     is_substitute: bool = False,
 ) -> Optional[str]:
     """Return the first required scope that is

--- a/xcube/webapi/datasets/context.py
+++ b/xcube/webapi/datasets/context.py
@@ -16,11 +16,10 @@ from typing import (
     Optional,
     Tuple,
     Callable,
-    Collection,
     Set,
-    Mapping,
     Union,
 )
+from collections.abc import Collection, Mapping
 
 import numpy as np
 import pandas as pd
@@ -107,29 +106,29 @@ class DatasetsContext(ResourcesContext):
         return self._places_ctx
 
     @property
-    def dataset_cache(self) -> Dict[str, Tuple[MultiLevelDataset, DatasetConfig]]:
+    def dataset_cache(self) -> dict[str, tuple[MultiLevelDataset, DatasetConfig]]:
         return self._dataset_cache
 
     @cached_property
-    def access_control(self) -> Dict[str, Any]:
+    def access_control(self) -> dict[str, Any]:
         return self.config.get("AccessControl", {})
 
     @cached_property
-    def required_scopes(self) -> List[str]:
+    def required_scopes(self) -> list[str]:
         return self.access_control.get("RequiredScopes", [])
 
     @property
     def colormap_registry(self) -> ColormapRegistry:
         return self._colormap_registry
 
-    def get_required_dataset_scopes(self, dataset_config: DatasetConfig) -> Set[str]:
+    def get_required_dataset_scopes(self, dataset_config: DatasetConfig) -> set[str]:
         return self._get_required_scopes(
             dataset_config, "read:dataset", "Dataset", dataset_config["Identifier"]
         )
 
     def get_required_variable_scopes(
         self, dataset_config: DatasetConfig, var_name: str
-    ) -> Set[str]:
+    ) -> set[str]:
         return self._get_required_scopes(
             dataset_config, "read:variable", "Variable", var_name
         )
@@ -140,7 +139,7 @@ class DatasetsContext(ResourcesContext):
         base_scope: str,
         value_name: str,
         value: str,
-    ) -> Set[str]:
+    ) -> set[str]:
         required_global_scopes = set(self.required_scopes)
         required_dataset_scopes = set(
             dataset_config.get("AccessControl", {}).get("RequiredScopes", [])
@@ -176,7 +175,7 @@ class DatasetsContext(ResourcesContext):
         ds_id: Optional[str] = None,
         title: Optional[str] = None,
         style: Optional[str] = None,
-        color_mappings: Dict[str, Dict[str, Any]] = None,
+        color_mappings: dict[str, dict[str, Any]] = None,
     ) -> str:
         """Add a dataset to the configuration"""
         assert_instance(dataset, (xr.Dataset, MultiLevelDataset), "dataset")
@@ -275,7 +274,7 @@ class DatasetsContext(ResourcesContext):
     @classmethod
     def _maybe_assign_store_instance_ids(
         cls,
-        dataset_configs: List[Dict[str, Any]],
+        dataset_configs: list[dict[str, Any]],
         data_store_pool: DataStorePool,
         base_dir: str,
     ) -> None:
@@ -340,7 +339,7 @@ class DatasetsContext(ResourcesContext):
                         config["Path"] = new_path
 
     @classmethod
-    def _get_other_store_params_than_root(cls, dataset_config: DatasetConfig) -> Dict:
+    def _get_other_store_params_than_root(cls, dataset_config: DatasetConfig) -> dict:
         file_system = FS_TYPE_TO_PROTOCOL.get(dataset_config.get("FileSystem", "file"))
         if file_system != "s3":
             return {}
@@ -359,8 +358,8 @@ class DatasetsContext(ResourcesContext):
     @classmethod
     def get_dataset_configs_from_stores(
         cls, data_store_pool: DataStorePool
-    ) -> List[DatasetConfig]:
-        all_dataset_configs: List[DatasetConfig] = []
+    ) -> list[DatasetConfig]:
+        all_dataset_configs: list[DatasetConfig] = []
         for store_instance_id in data_store_pool.store_instance_ids:
             LOG.info(f"Scanning store {store_instance_id!r}")
             data_store_config = data_store_pool.get_store_config(store_instance_id)
@@ -378,7 +377,7 @@ class DatasetsContext(ResourcesContext):
             )
             for store_dataset_id in store_dataset_ids:
                 dataset_config_base = {}
-                store_dataset_configs: List[ServerConfig] = data_store_config.user_data
+                store_dataset_configs: list[ServerConfig] = data_store_config.user_data
                 if store_dataset_configs:
                     for store_dataset_config in store_dataset_configs:
                         dataset_id_pattern = store_dataset_config.get("Path", "*")
@@ -442,7 +441,7 @@ class DatasetsContext(ResourcesContext):
             raise ApiError.NotFound(f'Dataset "{ds_id}" not found')
         return dataset_config
 
-    def get_dataset_configs(self) -> List[DatasetConfig]:
+    def get_dataset_configs(self) -> list[DatasetConfig]:
         assert self._dataset_configs is not None
         return self._dataset_configs
 
@@ -453,7 +452,7 @@ class DatasetsContext(ResourcesContext):
     @classmethod
     def _process_dataset_configs(
         cls, config: ServerConfig, base_dir: str
-    ) -> Tuple[DataStorePool, List[Dict[str, Any]]]:
+    ) -> tuple[DataStorePool, list[dict[str, Any]]]:
         data_store_configs = config.get("DataStores", [])
         dataset_configs = config.get("Datasets", [])
 
@@ -478,8 +477,8 @@ class DatasetsContext(ResourcesContext):
         return data_store_pool, dataset_configs
 
     def get_rgb_color_mapping(
-        self, ds_id: str, norm_range: Tuple[float, float] = (0.0, 1.0)
-    ) -> Tuple[List[Optional[str]], List[Tuple[float, float]]]:
+        self, ds_id: str, norm_range: tuple[float, float] = (0.0, 1.0)
+    ) -> tuple[list[Optional[str]], list[tuple[float, float]]]:
         var_names = [None, None, None]
         norm_ranges = [norm_range, norm_range, norm_range]
         color_mappings = self.get_color_mappings(ds_id)
@@ -500,7 +499,7 @@ class DatasetsContext(ResourcesContext):
 
     def get_color_mapping(
         self, ds_id: str, var_name: str
-    ) -> Tuple[str, str, Tuple[float, float]]:
+    ) -> tuple[str, str, tuple[float, float]]:
         cmap_name = None
         cmap_norm = None
         cmap_vmin, cmap_vmax = None, None
@@ -523,7 +522,7 @@ class DatasetsContext(ResourcesContext):
         valid_range = get_var_valid_range(var)
         return get_var_cmap_params(var, cmap_name, cmap_norm, cmap_range, valid_range)
 
-    def _get_cm_styles(self) -> Tuple[Dict[str, Any], ColormapRegistry]:
+    def _get_cm_styles(self) -> tuple[dict[str, Any], ColormapRegistry]:
         custom_colormaps = {}
         cm_styles = {}
         for style in self.config.get("Styles", []):
@@ -553,26 +552,26 @@ class DatasetsContext(ResourcesContext):
 
         return cm_styles, ColormapRegistry(*custom_colormaps.values())
 
-    def get_color_mappings(self, ds_id: str) -> Optional[Dict[str, Dict[str, Any]]]:
+    def get_color_mappings(self, ds_id: str) -> Optional[dict[str, dict[str, Any]]]:
         dataset_config = self.get_dataset_config(ds_id)
         style_id = dataset_config.get("Style", "default")
         return self._cm_styles.get(style_id, {})
 
-    def _get_dataset_entry(self, ds_id: str) -> Tuple[MultiLevelDataset, ServerConfig]:
+    def _get_dataset_entry(self, ds_id: str) -> tuple[MultiLevelDataset, ServerConfig]:
         if ds_id not in self._dataset_cache:
             with self.rlock:
                 self._set_dataset_entry(self._create_dataset_entry(ds_id))
         return self._dataset_cache[ds_id]
 
     def _set_dataset_entry(
-        self, dataset_entry: Tuple[MultiLevelDataset, DatasetConfig]
+        self, dataset_entry: tuple[MultiLevelDataset, DatasetConfig]
     ):
         ml_dataset, dataset_config = dataset_entry
         self._dataset_cache[ml_dataset.ds_id] = ml_dataset, dataset_config
 
     def _create_dataset_entry(
         self, ds_id: str
-    ) -> Tuple[MultiLevelDataset, DatasetConfig]:
+    ) -> tuple[MultiLevelDataset, DatasetConfig]:
         dataset_config = self.get_dataset_config(ds_id)
         ml_dataset = self._open_ml_dataset(dataset_config)
         return ml_dataset, dataset_config
@@ -649,7 +648,7 @@ class DatasetsContext(ResourcesContext):
 
     def get_dataset_place_groups(
         self, ds_id: str, base_url: str, load_features=False
-    ) -> List[Dict]:
+    ) -> list[dict]:
         dataset_config = self.get_dataset_config(ds_id)
 
         place_group_id_prefix = f"DS-{ds_id}-"
@@ -679,7 +678,7 @@ class DatasetsContext(ResourcesContext):
 
     def get_dataset_place_group(
         self, ds_id: str, place_group_id: str, base_url: str, load_features=False
-    ) -> Dict:
+    ) -> dict:
         place_groups = self.get_dataset_place_groups(
             ds_id, base_url, load_features=False
         )
@@ -704,9 +703,9 @@ class DatasetsContext(ResourcesContext):
         ds_name: str,
         var_name: str,
         var: xr.DataArray,
-        dim_names: List[str],
-        query_params: Dict[str, str],
-    ) -> Dict[str, Any]:
+        dim_names: list[str],
+        query_params: dict[str, str],
+    ) -> dict[str, Any]:
         var_indexers = dict()
         for dim_name in dim_names:
             if dim_name not in var.coords:

--- a/xcube/webapi/datasets/controllers.py
+++ b/xcube/webapi/datasets/controllers.py
@@ -5,7 +5,8 @@ import fnmatch
 import functools
 import io
 import json
-from typing import Dict, Tuple, List, Set, Optional, Any, Callable, Mapping
+from typing import Dict, Tuple, List, Set, Optional, Any, Callable
+from collections.abc import Mapping
 
 import matplotlib.colorbar
 import matplotlib.colors
@@ -56,10 +57,10 @@ def find_dataset_places(
 def get_datasets(
     ctx: DatasetsContext,
     details: bool = False,
-    point: Optional[Tuple[float, float]] = None,
+    point: Optional[tuple[float, float]] = None,
     base_url: Optional[str] = None,
-    granted_scopes: Optional[Set[str]] = None,
-) -> Dict:
+    granted_scopes: Optional[set[str]] = None,
+) -> dict:
     can_authenticate = ctx.can_authenticate
     # If True, we can shorten scope checking
     if granted_scopes is None:
@@ -140,8 +141,8 @@ def get_dataset(
     ctx: DatasetsContext,
     ds_id: str,
     base_url: Optional[str] = None,
-    granted_scopes: Optional[Set[str]] = None,
-) -> Dict:
+    granted_scopes: Optional[set[str]] = None,
+) -> dict:
     can_authenticate = ctx.can_authenticate
     # If True, we can shorten scope checking
     if granted_scopes is None:
@@ -321,8 +322,8 @@ def get_dataset(
 
 
 def filter_variable_names(
-    var_names: List[str], var_name_patterns: List[str]
-) -> List[str]:
+    var_names: list[str], var_name_patterns: list[str]
+) -> list[str]:
     filtered_var_names = []
     filtered_var_names_set = set()
     for var_name_pattern in var_name_patterns:
@@ -338,7 +339,7 @@ def filter_variable_names(
 
 
 def get_bbox_geometry(
-    dataset_bounds: Tuple[float, float, float, float],
+    dataset_bounds: tuple[float, float, float, float],
     transformer: pyproj.Transformer,
     n: int = 6,
 ):
@@ -413,8 +414,8 @@ def get_time_chunk_size(
 def _allow_dataset(
     ctx: DatasetsContext,
     dataset_config: DatasetConfig,
-    granted_scopes: Optional[Set[str]],
-    function: Callable[[Set, Optional[Set], bool], Any],
+    granted_scopes: Optional[set[str]],
+    function: Callable[[set, Optional[set], bool], Any],
 ) -> Any:
     required_scopes = ctx.get_required_dataset_scopes(dataset_config)
     # noinspection PyArgumentList
@@ -427,7 +428,7 @@ def _allow_variable(
     ctx: DatasetsContext,
     dataset_config: DatasetConfig,
     var_name: str,
-    granted_scopes: Optional[Set[str]],
+    granted_scopes: Optional[set[str]],
 ) -> bool:
     required_scopes = ctx.get_required_variable_scopes(dataset_config, var_name)
     # noinspection PyArgumentList
@@ -442,7 +443,7 @@ def _is_substitute(dataset_config: DatasetConfig) -> bool:
 
 def get_dataset_place_groups(
     ctx: DatasetsContext, ds_id: str, base_url: str
-) -> List[GeoJsonFeatureCollection]:
+) -> list[GeoJsonFeatureCollection]:
     # Do not load or return features, just place group (metadata).
     place_groups = ctx.get_dataset_place_groups(ds_id, base_url, load_features=False)
     return _filter_place_groups(place_groups, del_features=True)
@@ -458,7 +459,7 @@ def get_dataset_place_group(
     return _filter_place_group(place_group, del_features=False)
 
 
-def get_dataset_coordinates(ctx: DatasetsContext, ds_id: str, dim_name: str) -> Dict:
+def get_dataset_coordinates(ctx: DatasetsContext, ds_id: str, dim_name: str) -> dict:
     ds, var = ctx.get_dataset_and_coord_variable(ds_id, dim_name)
     if np.issubdtype(var.dtype, np.floating):
         values = list(map(float, var.values))
@@ -518,7 +519,7 @@ def get_color_bars(ctx: DatasetsContext, mime_type: str) -> str:
     raise ApiError.BadRequest(f"Format {mime_type!r} not supported for colormaps")
 
 
-def _is_point_in_dataset_bbox(point: Tuple[float, float], dataset_dict: Dict):
+def _is_point_in_dataset_bbox(point: tuple[float, float], dataset_dict: dict):
     if "bbox" not in dataset_dict:
         return False
     x, y = point
@@ -532,7 +533,7 @@ def _is_point_in_dataset_bbox(point: Tuple[float, float], dataset_dict: Dict):
         return x_min <= x <= 180.0 or -180.0 <= x <= x_max
 
 
-def _filter_place_group(place_group: Dict, del_features: bool = False) -> Dict:
+def _filter_place_group(place_group: dict, del_features: bool = False) -> dict:
     place_group = dict(place_group)
     del place_group["sourcePaths"]
     del place_group["sourceEncoding"]
@@ -541,7 +542,7 @@ def _filter_place_group(place_group: Dict, del_features: bool = False) -> Dict:
     return place_group
 
 
-def _filter_place_groups(place_groups, del_features: bool = False) -> List[Dict]:
+def _filter_place_groups(place_groups, del_features: bool = False) -> list[dict]:
     if del_features:
 
         def __filter_place_group(place_group):

--- a/xcube/webapi/meta/controllers.py
+++ b/xcube/webapi/meta/controllers.py
@@ -10,7 +10,7 @@ from xcube.version import version
 from .context import MetaContext
 
 
-def get_service_info(ctx: MetaContext) -> Dict[str, Any]:
+def get_service_info(ctx: MetaContext) -> dict[str, Any]:
     api_infos = []
     for other_api in ctx.apis:
         api_info = {

--- a/xcube/webapi/ows/coverages/controllers.py
+++ b/xcube/webapi/ows/coverages/controllers.py
@@ -4,7 +4,8 @@
 import os
 import re
 import tempfile
-from typing import Mapping, Sequence, Optional, Any, Literal, NamedTuple, Union
+from typing import Optional, Any, Literal, NamedTuple, Union
+from collections.abc import Mapping, Sequence
 
 import numpy as np
 import pyproj

--- a/xcube/webapi/ows/coverages/request.py
+++ b/xcube/webapi/ows/coverages/request.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 import re
-from typing import Mapping, Sequence, Optional, Union
+from typing import Optional, Union
+from collections.abc import Mapping, Sequence
 import pyproj
 import rfc3339_validator
 

--- a/xcube/webapi/ows/coverages/routes.py
+++ b/xcube/webapi/ows/coverages/routes.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 import json
 import re
-from typing import Collection, Optional
+from typing import Optional
+from collections.abc import Collection
 import fnmatch
 from xcube.server.api import ApiHandler, ApiRequest, ApiError
 from .api import api

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -4,7 +4,8 @@
 
 
 import datetime
-from typing import Hashable, Any, Optional, Dict, List, Mapping, Union
+from typing import Any, Optional, Dict, List, Union
+from collections.abc import Hashable, Mapping
 import itertools
 
 import numpy as np
@@ -785,7 +786,7 @@ def _get_assets(ctx: DatasetsContext, base_url: str, dataset_id: str):
 
     tiles_query = ""
     if first_var_extra_dims:
-        tiles_query = "?" + "&".join(["%s=<%s>" % (d, d) for d in first_var_extra_dims])
+        tiles_query = "?" + "&".join([f"{d}=<{d}>" for d in first_var_extra_dims])
 
     # TODO: Prefer original storage location.
     #       The "s3" operation is default.
@@ -864,14 +865,14 @@ def _get_time_properties(dataset):
 
 def _get_xc_variables(
     variables: Mapping[Hashable, xr.DataArray]
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Create the value of the "xcube:coords" or
     "xcube:data_vars" property for the given *dataset*.
     """
     return [_get_xc_variable(var_name, var) for var_name, var in variables.items()]
 
 
-def _get_xc_variable(var_name: Hashable, var: xr.DataArray) -> Dict[str, Any]:
+def _get_xc_variable(var_name: Hashable, var: xr.DataArray) -> dict[str, Any]:
     """Create an entry of the value of the "xcube:coords" or
     "xcube:data_vars" property for the given *dataset*.
     """
@@ -888,7 +889,7 @@ def _get_xc_variable(var_name: Hashable, var: xr.DataArray) -> Dict[str, Any]:
 
 def get_datacube_dimensions(
     dataset: xr.Dataset, grid_mapping: GridMapping
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Create the value of the "datacube:dimensions" property
     for the given *dataset*.
 
@@ -921,7 +922,7 @@ def get_datacube_dimensions(
 
 def _get_dc_spatial_dimension(
     var: xr.DataArray, axis: str, grid_mapping: GridMapping
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Create a spatial dimension of the "datacube:dimensions" property
     for the given *var* and *axis*.
     """
@@ -938,7 +939,7 @@ def _get_dc_spatial_dimension(
     return asset
 
 
-def _get_dc_temporal_dimension(var: xr.DataArray) -> Dict[str, Any]:
+def _get_dc_temporal_dimension(var: xr.DataArray) -> dict[str, Any]:
     """Create a temporal dimension of the "datacube:dimensions" property
     for the given time *var*.
     """
@@ -949,7 +950,7 @@ def _get_dc_temporal_dimension(var: xr.DataArray) -> Dict[str, Any]:
 
 def _get_dc_additional_dimension(
     var: xr.DataArray, type_: str = "unknown"
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Create an additional dimension of the "datacube:dimensions" property
     for the given *var* and *type*.
     """
@@ -972,7 +973,7 @@ def _get_dc_dimension(
     type_: str,
     axis: Optional[str] = None,
     drop_unit: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Create a generic dimension of the "datacube:dimensions" property
     for the given *var*, *type*, and optional *axis*.
     """
@@ -998,7 +999,7 @@ def _get_dc_variables(dataset: xr.Dataset, dc_dimensions):
 def __get_dc_variables(
     variables: Mapping[Hashable, xr.DataArray],
     type: str,
-    dc_dimensions: Dict[str, Any],
+    dc_dimensions: dict[str, Any],
 ):
     """Create a partial value of the "datacube:variables" property
     for the given *variables* and *type*.
@@ -1010,7 +1011,7 @@ def __get_dc_variables(
     }
 
 
-def _get_dc_variable(var: xr.DataArray, type: str) -> Dict[str, Any]:
+def _get_dc_variable(var: xr.DataArray, type: str) -> dict[str, Any]:
     """Create a generic variable of the "datacube:variables" property
     for the given *var*, *type*, and optional *axis*.
     """
@@ -1034,7 +1035,7 @@ def _set_dc_unit(asset, var):
         asset.update(unit=unit)
 
 
-def _get_str_attr(attrs: Dict[str, Any], keys: List[str]) -> Optional[str]:
+def _get_str_attr(attrs: dict[str, Any], keys: list[str]) -> Optional[str]:
     for k in keys:
         v = attrs.get(k)
         if isinstance(v, str) and v:

--- a/xcube/webapi/ows/wmts/controllers.py
+++ b/xcube/webapi/ows/wmts/controllers.py
@@ -4,7 +4,8 @@
 
 import urllib.parse
 import warnings
-from typing import Dict, List, Tuple, Any, Mapping
+from typing import Dict, List, Tuple, Any
+from collections.abc import Mapping
 
 import numpy as np
 import pyproj
@@ -172,8 +173,8 @@ def get_dim_elements(
     ds_name: str,
     ds: xr.Dataset,
     var: xr.DataArray,
-    dim_element_cache: Dict[str, Element],
-) -> List[Element]:
+    dim_element_cache: dict[str, Element],
+) -> list[Element]:
     dim_elements = []
     for dim_name in var.dims[0:-2]:
         if dim_name not in ds.coords:
@@ -262,10 +263,10 @@ def get_var_layer_and_theme_element(
     ds_name: str,
     var_name: str,
     var: xr.DataArray,
-    var_geo_bbox: Tuple[float, float, float, float],
+    var_geo_bbox: tuple[float, float, float, float],
     var_tile_url_templ_pattern: str,
     tms_id: str,
-) -> Tuple[Element, Element]:
+) -> tuple[Element, Element]:
     var_id = f"{ds_name}.{var_name}"
     var_title = (
         ds_name + "/" + var.attrs.get("title", var.attrs.get("long_name", var_name))
@@ -379,7 +380,7 @@ def _get_tile_matrix_set_element(
     tms_title: str,
     crs_urn: str,
     wkss_urn: str,
-    bbox: Tuple[float, float, float, float],
+    bbox: tuple[float, float, float, float],
     meters_per_pixel: float,
     min_level: int,
     max_level: int,
@@ -668,7 +669,7 @@ def get_service_metadata_url_element(
 
 # TODO: move get_crs84_bbox() into GridMapping so we can adjust
 #   global dataset attributes with result
-def get_crs84_bbox(grid_mapping: GridMapping) -> Tuple[float, float, float, float]:
+def get_crs84_bbox(grid_mapping: GridMapping) -> tuple[float, float, float, float]:
     if grid_mapping.crs.is_geographic:
         return grid_mapping.xy_bbox
     t = pyproj.Transformer.from_crs(grid_mapping.crs, CRS_CRS84, always_xy=True)

--- a/xcube/webapi/places/context.py
+++ b/xcube/webapi/places/context.py
@@ -2,8 +2,9 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Any, Dict, List, Optional, Callable, Iterator
-from typing import Sequence
+from typing import Any, Dict, List, Optional, Callable
+from collections.abc import Iterator
+from collections.abc import Sequence
 
 import fiona
 import fsspec
@@ -16,8 +17,8 @@ from xcube.server.api import ApiError
 from xcube.server.api import Context
 from xcube.webapi.common.context import ResourcesContext
 
-PlaceGroup = Dict[str, Any]
-Feature = Dict[str, Any]
+PlaceGroup = dict[str, Any]
+Feature = dict[str, Any]
 
 ALL_PLACES = "all"
 
@@ -27,8 +28,8 @@ class PlacesContext(ResourcesContext):
 
     def __init__(self, server_ctx: Context):
         super().__init__(server_ctx)
-        self._additional_place_groups: Dict[str, List[PlaceGroup]] = dict()
-        self._place_group_cache: Dict[str, PlaceGroup] = dict()
+        self._additional_place_groups: dict[str, list[PlaceGroup]] = dict()
+        self._place_group_cache: dict[str, PlaceGroup] = dict()
 
     def on_dispose(self):
         if self._place_group_cache:
@@ -42,7 +43,7 @@ class PlacesContext(ResourcesContext):
 
     def get_cached_place_groups(
         self, predicate: Optional[Callable[[str, PlaceGroup], bool]] = None
-    ) -> List[PlaceGroup]:
+    ) -> list[PlaceGroup]:
         return [
             v
             for k, v in self._place_group_cache.items()
@@ -57,7 +58,7 @@ class PlacesContext(ResourcesContext):
 
     def get_global_place_groups(
         self, base_url: str, load_features=False
-    ) -> List[PlaceGroup]:
+    ) -> list[PlaceGroup]:
         return self.load_place_groups(
             self.config.get("PlaceGroups", []),
             base_url,
@@ -73,7 +74,7 @@ class PlacesContext(ResourcesContext):
             place_group_config, base_url, is_global=True, load_features=load_features
         )
 
-    def _get_place_group_config(self, place_group_id: str) -> Dict:
+    def _get_place_group_config(self, place_group_id: str) -> dict:
         place_group_configs = self.config.get("PlaceGroups", [])
         for place_group_config in place_group_configs:
             if place_group_config["Identifier"] == place_group_id:
@@ -82,12 +83,12 @@ class PlacesContext(ResourcesContext):
 
     def load_place_groups(
         self,
-        place_group_configs: List,
+        place_group_configs: list,
         base_url: str,
         is_global: bool = False,
         load_features: bool = False,
-        qualifiers: List[str] = list(),
-    ) -> List[PlaceGroup]:
+        qualifiers: list[str] = list(),
+    ) -> list[PlaceGroup]:
         place_groups = []
         for place_group_config in place_group_configs:
             place_group = self._load_place_group(
@@ -106,7 +107,7 @@ class PlacesContext(ResourcesContext):
                 place_groups.append(place_group)
         return place_groups
 
-    def add_place_group(self, place_group: PlaceGroup, qualifiers: List[str] = list()):
+    def add_place_group(self, place_group: PlaceGroup, qualifiers: list[str] = list()):
         for qualifier in qualifiers:
             if qualifier not in self._additional_place_groups:
                 self._additional_place_groups[qualifier] = []
@@ -114,7 +115,7 @@ class PlacesContext(ResourcesContext):
 
     def _load_place_group(
         self,
-        place_group_config: Dict[str, Any],
+        place_group_config: dict[str, Any],
         base_url: str,
         is_global: bool = False,
         load_features: bool = False,
@@ -212,7 +213,7 @@ class PlacesContext(ResourcesContext):
 
     def load_place_group_features(
         self, place_group: PlaceGroup
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         features = place_group.get("features")
         if features is not None:
             return features
@@ -255,7 +256,7 @@ class PlacesContext(ResourcesContext):
     @classmethod
     def _to_geo_interface(
         cls, feature_collection: Collection
-    ) -> Iterator[Dict[str, Any]]:
+    ) -> Iterator[dict[str, Any]]:
         source_crs = feature_collection.crs
         target_crs = fiona.crs.CRS.from_epsg(4326)
         if not source_crs == target_crs:

--- a/xcube/webapi/places/controllers.py
+++ b/xcube/webapi/places/controllers.py
@@ -16,10 +16,10 @@ from .context import PlacesContext
 from ...server.api import ApiError
 from ...util.assertions import assert_instance
 
-GeoJsonFeatureCollection = Dict
-GeoJsonFeature = Dict
+GeoJsonFeatureCollection = dict
+GeoJsonFeature = dict
 
-GeometryLike = Union[str, Dict, shapely.geometry.base.BaseGeometry]
+GeometryLike = Union[str, dict, shapely.geometry.base.BaseGeometry]
 
 
 def find_places(

--- a/xcube/webapi/s3/dsmapping.py
+++ b/xcube/webapi/s3/dsmapping.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import collections.abc
-from typing import Union, Iterator, Set, Dict
+from typing import Union, Set, Dict
+from collections.abc import Iterator
 
 import xarray as xr
 
@@ -48,7 +49,7 @@ class DatasetsMapping(collections.abc.Mapping):
     @staticmethod
     def _get_s3_names(
         datasets_ctx: DatasetsContext, is_multi_level: bool
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         """Generate user-friendly S3 names for dataset identifiers.
         If *is_multi_level* is True, S3 names will be forced to have
         ".levels" suffix, otherwise the ".zarr" suffix.
@@ -100,7 +101,7 @@ def _split_base_ext(identifier: str):
 
 
 def _replace_ext(
-    base_name: str, old_ext: str, trigger_ext: str, new_ext: str, all_ids: Set[str]
+    base_name: str, old_ext: str, trigger_ext: str, new_ext: str, all_ids: set[str]
 ) -> str:
     if old_ext == new_ext or (
         old_ext == trigger_ext and (base_name + new_ext) not in all_ids

--- a/xcube/webapi/s3/listbucket.py
+++ b/xcube/webapi/s3/listbucket.py
@@ -6,7 +6,8 @@ import collections.abc
 import datetime
 import hashlib
 import time
-from typing import Dict, Any, List, Mapping, Optional
+from typing import Dict, Any, List, Optional
+from collections.abc import Mapping
 
 from xcube.util.assertions import assert_instance
 
@@ -24,7 +25,7 @@ def list_s3_bucket_v2(
     continuation_token: Optional[str] = None,
     storage_class: Optional[str] = None,
     last_modified: Optional[str] = None,
-) -> Dict:
+) -> dict:
     """Implements AWS GET Bucket (List Objects) Version 2
     (https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html)
     for the local filesystem.
@@ -131,7 +132,7 @@ def list_s3_bucket_v2(
         )
         contents_list.append(item)
 
-    list_bucket_result: Dict[str, Any] = dict(
+    list_bucket_result: dict[str, Any] = dict(
         Name=name,
         Prefix=prefix,
         StartAfter=start_after,
@@ -160,7 +161,7 @@ def list_s3_bucket_v1(
     marker: str = None,
     storage_class: str = None,
     last_modified: str = None,
-) -> Dict:
+) -> dict:
     """Implements AWS GET Bucket (List Objects) Version 1
     (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html)
     for the local filesystem.
@@ -249,7 +250,7 @@ def list_s3_bucket_v1(
         )
         contents_list.append(item)
 
-    list_bucket_result: Dict[str, Any] = dict(
+    list_bucket_result: dict[str, Any] = dict(
         Name=name,
         Prefix=prefix,
         Marker=marker,
@@ -277,7 +278,7 @@ def list_bucket_result_to_xml(list_bucket_result):
 
 
 def dict_to_xml(
-    root_element_name: str, content_dict: Dict, root_element_attrs: Dict = None
+    root_element_name: str, content_dict: dict, root_element_attrs: dict = None
 ) -> str:
     lines = []
     _value_to_xml(
@@ -287,10 +288,10 @@ def dict_to_xml(
 
 
 def _value_to_xml(
-    lines: List[str],
+    lines: list[str],
     element_name: str,
     element_value: Any,
-    element_attrs: Dict = None,
+    element_attrs: dict = None,
     indent: int = 0,
 ):
     attrs = ""

--- a/xcube/webapi/s3/objectstorage.py
+++ b/xcube/webapi/s3/objectstorage.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 import collections.abc
-from typing import Union, Iterator, Tuple, Mapping
+from typing import Union, Tuple
+from collections.abc import Iterator, Mapping
 
 import xarray as xr
 import zarr.storage
@@ -70,7 +71,7 @@ class ObjectStorage(collections.abc.Mapping):
             )
         return value
 
-    def _parse_key(self, key: str) -> Tuple[zarr.storage.BaseStore, str]:
+    def _parse_key(self, key: str) -> tuple[zarr.storage.BaseStore, str]:
         """Parses a given *key* which is expected to have format
         "{dataset_id}/{level}.zarr/{*path}" for multi-level datasets and
         "{dataset_id}/{*path}" for other datasets.

--- a/xcube/webapi/tiles/controllers.py
+++ b/xcube/webapi/tiles/controllers.py
@@ -2,7 +2,8 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Optional, Mapping, Dict
+from typing import Optional, Dict
+from collections.abc import Mapping
 
 from xcube.constants import LOG
 from xcube.core.tile import DEFAULT_CRS_NAME
@@ -43,11 +44,11 @@ def _compute_ml_dataset_tile(
     x: str,
     y: str,
     z: str,
-    args: Dict[str, str],
+    args: dict[str, str],
     trace_perf: bool,
 ):
     try:
-        x, y, z = [int(c) for c in (x, y, z)]
+        x, y, z = (int(c) for c in (x, y, z))
     except ValueError:
         raise ApiError.BadRequest("x, y, z must be integers")
 

--- a/xcube/webapi/timeseries/controllers.py
+++ b/xcube/webapi/timeseries/controllers.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 
-from typing import Dict, List, Optional, Union, Sequence, Any, Set, Tuple
+from typing import Dict, List, Optional, Union, Any, Set, Tuple
+from collections.abc import Sequence
 
 import numpy as np
 import pandas as pd
@@ -19,10 +20,10 @@ from xcube.util.geojson import GeoJSON
 from xcube.util.perf import measure_time
 from .context import TimeSeriesContext
 
-TimeSeriesValue = Dict[str, Union[str, bool, int, float, None]]
-TimeSeries = List[TimeSeriesValue]
-TimeSeriesCollection = List[TimeSeries]
-GeoJsonObj = Dict[str, Any]
+TimeSeriesValue = dict[str, Union[str, bool, int, float, None]]
+TimeSeries = list[TimeSeriesValue]
+TimeSeriesCollection = list[TimeSeries]
+GeoJsonObj = dict[str, Any]
 GeoJsonFeature = GeoJsonObj
 GeoJsonGeometry = GeoJsonObj
 
@@ -123,8 +124,8 @@ def get_time_series(
 def _get_time_series_for_geometries(
     dataset: xr.Dataset,
     var_name: str,
-    geometries: List[shapely.geometry.base.BaseGeometry],
-    agg_methods: Set[str],
+    geometries: list[shapely.geometry.base.BaseGeometry],
+    agg_methods: set[str],
     grid_mapping: Optional[GridMapping] = None,
     start_date: Optional[np.datetime64] = None,
     end_date: Optional[np.datetime64] = None,
@@ -152,7 +153,7 @@ def _get_time_series_for_geometry(
     dataset: xr.Dataset,
     var_name: str,
     geometry: shapely.geometry.base.BaseGeometry,
-    agg_methods: Set[str],
+    agg_methods: set[str],
     grid_mapping: Optional[GridMapping] = None,
     start_date: Optional[np.datetime64] = None,
     end_date: Optional[np.datetime64] = None,
@@ -194,7 +195,7 @@ def _get_time_series_for_point(
     dataset: xr.Dataset,
     var_name: str,
     point: shapely.geometry.Point,
-    agg_methods: Set[str],
+    agg_methods: set[str],
     grid_mapping: Optional[GridMapping] = None,
     start_date: Optional[np.datetime64] = None,
     end_date: Optional[np.datetime64] = None,
@@ -246,7 +247,7 @@ def _get_time_series_for_point(
 
 
 def collect_timeseries_result(
-    time_series_ds: xr.Dataset, key_to_var_names: Dict[str, str], max_valids: int = None
+    time_series_ds: xr.Dataset, key_to_var_names: dict[str, str], max_valids: int = None
 ) -> TimeSeries:
     _check_max_valids(max_valids)
 
@@ -314,8 +315,8 @@ def collect_timeseries_result(
 
 
 def _to_shapely_geometries(
-    geo_json_geometries: List[GeoJsonGeometry],
-) -> List[shapely.geometry.base.BaseGeometry]:
+    geo_json_geometries: list[GeoJsonGeometry],
+) -> list[shapely.geometry.base.BaseGeometry]:
     geometries = []
     for geo_json_geometry in geo_json_geometries:
         try:
@@ -326,7 +327,7 @@ def _to_shapely_geometries(
     return geometries
 
 
-def _to_geo_json_geometries(geo_json: GeoJsonObj) -> Tuple[List[GeoJsonGeometry], bool]:
+def _to_geo_json_geometries(geo_json: GeoJsonObj) -> tuple[list[GeoJsonGeometry], bool]:
     is_collection = False
     if GeoJSON.is_feature(geo_json):
         geometry = _get_feature_geometry(geo_json)

--- a/xcube/webapi/viewer/context.py
+++ b/xcube/webapi/viewer/context.py
@@ -3,7 +3,8 @@
 # https://opensource.org/licenses/MIT.
 
 from functools import cached_property
-from typing import Mapping, Optional
+from typing import Optional
+from collections.abc import Mapping
 
 import fsspec
 

--- a/xcube/webapi/viewer/viewer.py
+++ b/xcube/webapi/viewer/viewer.py
@@ -7,7 +7,8 @@ import os
 import socket
 import threading
 from pathlib import Path
-from typing import Optional, Union, Mapping, Any, Tuple, Dict
+from typing import Optional, Union, Any, Tuple, Dict
+from collections.abc import Mapping
 
 import tornado.ioloop
 import xarray as xr
@@ -117,7 +118,7 @@ class Viewer:
         ds_id: Optional[str] = None,
         title: Optional[str] = None,
         style: Optional[str] = None,
-        color_mappings: Dict[str, Dict[str, Any]] = None,
+        color_mappings: dict[str, dict[str, Any]] = None,
     ):
         """Add a dataset to this viewer.
 
@@ -200,7 +201,7 @@ class Viewer:
         return self.is_server_running
 
 
-def _get_server_url_and_rev_prefix(port: int) -> Tuple[str, str]:
+def _get_server_url_and_rev_prefix(port: int) -> tuple[str, str]:
     lab_url = os.environ.get(_LAB_URL_ENV_VAR) or None
     has_proxy = lab_url is not None
 


### PR DESCRIPTION
This PR uses [pyupgrade](https://github.com/asottile/pyupgrade) to  automatically upgrade syntax for newer versions of the language by running

```bash
pyupgrade --py39 `find . -name "*.py"`
```

where `--py39` indicates that the code base is upgraded to the syntax of Python=3.9 and `find . -name "*.py"` applies it to all python files in the directory as upgrade can only handle individual python files.  
  
Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
