### PR TITLE
 Fixed server `/timeseries` endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,5 @@
 ## Changes in 1.6.0 (in development)
 
-### Other changes
-
-*  Refactored xcube workflow to build docker images only on release and deleted the 
-  update xcube tag job.
-
 ### Enhancements
 
 * xcube server's tile API can now handle user-defined colormaps from xcube 
@@ -71,12 +66,17 @@
   - Removed endpoint `/datasets/{datasetId}/vars/{varName}/tiles2/{z}/{y}/{x}`
     from xcube server.
 
+### Fixes
+
+* Fixed an issue with xcube server `/timeseries` endpoint that returned
+  status 500 if a given dataset used a CRS other geographic and the 
+  geometry was not a point. (#995) 
+
+* Fixed broken table of contents links in dataset convention document.
 
 ### Other changes
 
 * Make tests compatible with PyTest 8.2.0. (#973)
-
-* Fix broken table of contents links in dataset convention document.
 
 * Addressed all warnings from xarray indicating that `Dataset.dims` will
   be replaced by `Dataset.sizes`. (#981)
@@ -90,8 +90,15 @@
 * Added project URLs and classifiers to `setup.py`, which will be shown in the
   left sidebar on the [PyPI xcube-core](https://pypi.org/project/xcube-core/) webpage.
 
+* Refactored xcube workflow to build docker images only on release and deleted the 
+  update xcube tag job.
+
 * Used [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade
   language syntax for Python versions >= 3.9.  
+
+* The functions `mask_dataset_by_geometry()` and `clip_dataset_by_geometry()`
+  of module `xcube.core.geom` have a new keyword argument 
+  `update_attrs: bool = True` as part of the fix for #99.
 
 ## Changes in 1.5.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,7 +98,7 @@
 
 * The functions `mask_dataset_by_geometry()` and `clip_dataset_by_geometry()`
   of module `xcube.core.geom` have a new keyword argument 
-  `update_attrs: bool = True` as part of the fix for #99.
+  `update_attrs: bool = True` as part of the fix for #995.
 
 ## Changes in 1.5.1
 

--- a/xcube/core/timeseries.py
+++ b/xcube/core/timeseries.py
@@ -114,6 +114,7 @@ def get_time_series(
         ).transform
         geometry = shapely.ops.transform(project, geometry)
 
+    # Warning: select_variables_subset will remove also "crs" or "spatial_ref"
     dataset = select_variables_subset(cube, var_names)
     if len(dataset.data_vars) == 0:
         return None
@@ -136,7 +137,10 @@ def get_time_series(
 
     if geometry is not None:
         dataset = mask_dataset_by_geometry(
-            dataset, geometry, save_geometry_mask="__mask__"
+            dataset,
+            geometry,
+            update_attrs=False,
+            save_geometry_mask="__mask__",
         )
         if dataset is None:
             return None


### PR DESCRIPTION
* Fixed an issue with xcube server `/timeseries` endpoint that returned status 500 if a given dataset used a CRS other geographic and the geometry was not a point. 
* The functions `mask_dataset_by_geometry()` and `clip_dataset_by_geometry()` of module `xcube.core.geom` have a new keyword argument `update_attrs: bool = True` as part of the fix for #995. 

Closes #995  

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
