### PR TITLE
Updates in `xcube` needed for `xcube-stac` plugin to deal with data access via urls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,10 @@
 
 * Decreased number of warnings in the xcube workflow step unittest-xcube.
 
+* Added new data store `"https"` that uses
+  [fsspec.implementations.http.HTTPFileSystem)](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.http.HTTPFileSystem),
+  so that the upcoming xcube STAC data store will be able to access files from URLs.
+
 ## Changes in 1.5.1
 
 * Embedded [xcube-viewer 1.1.1](https://github.com/xcube-dev/xcube-viewer/releases/tag/v1.1.1).

--- a/xcube/core/store/fs/impl/fs.py
+++ b/xcube/core/store/fs/impl/fs.py
@@ -195,3 +195,9 @@ class FtpFsAccessor(FsAccessor):
             ),
             additional_properties=True,
         )
+
+
+class HttpsFsAccessor(FsAccessor):
+    @classmethod
+    def get_protocol(cls) -> str:
+        return "https"

--- a/xcube/core/store/fs/registry.py
+++ b/xcube/core/store/fs/registry.py
@@ -2,7 +2,7 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-from typing import Type, Dict, Optional, Any
+from typing import Optional, Any
 from collections.abc import Sequence
 
 import fsspec
@@ -15,6 +15,7 @@ from .impl.dataset import DatasetZarrFsDataAccessor
 from .impl.fs import AzureFsAccessor
 from .impl.fs import FileFsAccessor
 from .impl.fs import FtpFsAccessor
+from .impl.fs import HttpsFsAccessor
 from .impl.fs import MemoryFsAccessor
 from .impl.fs import S3FsAccessor
 from .impl.geodataframe import GeoDataFrameGeoJsonFsDataAccessor
@@ -47,6 +48,7 @@ for cls in (
     AzureFsAccessor,
     FileFsAccessor,
     FtpFsAccessor,
+    HttpsFsAccessor,
     MemoryFsAccessor,
     S3FsAccessor,
 ):

--- a/xcube/core/store/fs/store.py
+++ b/xcube/core/store/fs/store.py
@@ -321,7 +321,7 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
         open_params_schema = self._get_open_data_params_schema(opener, data_id)
         assert_valid_params(open_params, name="open_params", schema=open_params_schema)
         fs_path = self._convert_data_id_into_fs_path(data_id)
-        return opener.open_data(fs_path, fs=self.fs, root=self.root, **open_params)
+        return opener.open_data(fs_path, fs=self.fs, **open_params)
 
     def get_data_writer_ids(self, data_type: str = None) -> tuple[str, ...]:
         data_type = DataType.normalize(data_type)

--- a/xcube/plugin.py
+++ b/xcube/plugin.py
@@ -39,7 +39,8 @@ def _register_input_processors(ext_registry: extension.ExtensionRegistry):
 
 
 def _register_dataset_ios(ext_registry: extension.ExtensionRegistry):
-    """Register xcube's standard dataset I/O components used by various CLI and API functions."""
+    """Register xcube's standard dataset I/O components
+    used by various CLI and API functions."""
     ext_registry.add_extension(
         loader=extension.import_component("xcube.core.dsio:ZarrDatasetIO", call=True),
         point=EXTENSION_POINT_DATASET_IOS,
@@ -77,12 +78,13 @@ def _register_dataset_ios(ext_registry: extension.ExtensionRegistry):
 
 
 _FS_STORAGE_ITEMS = (
-    ("file", "local filesystem"),
-    ("s3", "AWS S3 compatible object storage"),
     ("abfs", "Azure blob compatible object storage"),
-    ("memory", "in-memory filesystem"),
+    ("file", "local filesystem"),
     ("ftp", "FTP filesystem"),
+    ("https", "HTTPS filesystem"),
+    ("memory", "in-memory filesystem"),
     ("reference", "reference filesystem"),
+    ("s3", "AWS S3 compatible object storage")
 )
 
 _FS_DATA_ACCESSOR_ITEMS = (
@@ -128,7 +130,7 @@ def _register_data_stores(ext_registry: extension.ExtensionRegistry):
         point=EXTENSION_POINT_DATA_STORES,
         loader=ref_ds_cls_loader,
         name="reference",
-        description=f"Data store that uses Kerchunk references",
+        description="Data store that uses Kerchunk references",
     )
 
 


### PR DESCRIPTION
This PR adds a `https` data store which will be created dynamically similar to a filesystem-based data store. It uses [fsspec.implementations.http.HTTPFileSystem)](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.http.HTTPFileSystem). 

Furthermore, an error occurred when trying to open a .tif file and storing it in an `xr.Dataset` with the `file` data store and therefore, also with new `https` data store. (See comment below.) 

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
