### PR TITLE
Dynamical xcube package name; xcube used for local install, xcube-core used for PyPI

### DIFF
--- a/.github/workflows/xcube_publish_pypi.yml
+++ b/.github/workflows/xcube_publish_pypi.yml
@@ -8,9 +8,7 @@
 
 name: publish to PyPI
 
-on:
-  release:
-    types: [published]
+on: push
 
 jobs:
   deploy:
@@ -29,8 +27,10 @@ jobs:
         pip install build
     - name: Build package
       run: |
+        LINE_NB=$(grep -n 'name = "xcube" # PYPI RENAME THIS LINE' pyproject.toml | cut -f1 -d:)
+        sed -i ""$LINE_NB"s/.*/name = 'xcube-core'/" pyproject.toml 
         python -m build
-    - name: Publish to TestPyPI
+    - name: Publish to PyPI
       run: |
         pip install twine
-        python -m twine upload --username __token__ --password ${{ secrets.PYPI_API_TOKEN }} dist/*
+        python -m twine upload --repository testpypi --username __token__ --password ${{ secrets.PYPI_API_TOKEN }} dist/*

--- a/.github/workflows/xcube_publish_pypi.yml
+++ b/.github/workflows/xcube_publish_pypi.yml
@@ -8,7 +8,9 @@
 
 name: publish to PyPI
 
-on: push
+on:
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -33,4 +35,4 @@ jobs:
     - name: Publish to PyPI
       run: |
         pip install twine
-        python -m twine upload --repository testpypi --username __token__ --password ${{ secrets.PYPI_API_TOKEN }} dist/*
+        python -m twine upload --username __token__ --password ${{ secrets.PYPI_API_TOKEN }} dist/*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,7 +135,7 @@
   [fsspec.implementations.http.HTTPFileSystem)](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.http.HTTPFileSystem),
   so that the upcoming xcube STAC data store will be able to access files from URLs.
 
-* Change package name from "xcube-core" to "xcube" in the `pyproject.toml` file. The workflow
+* Changed package name from "xcube-core" to "xcube" in the `pyproject.toml` file. The workflow
   `.github/workflows/xcube_publish_pypi.yml` changes the line in the `pyproject.toml`, where
   the package name is defined to `name = "xcube-core"`. This allows to release xcube under
   the package name xcube-core on PyPI. #1010

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,11 +135,10 @@
   [fsspec.implementations.http.HTTPFileSystem)](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.http.HTTPFileSystem),
   so that the upcoming xcube STAC data store will be able to access files from URLs.
 
-* Changed package name from "xcube-core" to "xcube" in the `pyproject.toml` file. The workflow
-  `.github/workflows/xcube_publish_pypi.yml` changes the line in the `pyproject.toml`, where
+* The workflow `.github/workflows/xcube_publish_pypi.yml` changes the line in the `pyproject.toml`, where
   the package name is defined to `name = "xcube-core"`. This allows to release xcube under
-  the package name xcube-core on PyPI. #1010
-
+  the package name "xcube-core" on PyPI where the name "xcube" is already taken. #1010 
+  
 ## Changes in 1.5.1
 
 * Embedded [xcube-viewer 1.1.1](https://github.com/xcube-dev/xcube-viewer/releases/tag/v1.1.1).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,6 +135,11 @@
   [fsspec.implementations.http.HTTPFileSystem)](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.http.HTTPFileSystem),
   so that the upcoming xcube STAC data store will be able to access files from URLs.
 
+* Change package name from "xcube-core" to "xcube" in the `pyproject.toml` file. The workflow
+  `.github/workflows/xcube_publish_pypi.yml` changes the line in the `pyproject.toml`, where
+  the package name is defined to `name = "xcube-core"`. This allows to release xcube under
+  the package name xcube-core on PyPI. #1010
+
 ## Changes in 1.5.1
 
 * Embedded [xcube-viewer 1.1.1](https://github.com/xcube-dev/xcube-viewer/releases/tag/v1.1.1).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 61.2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "xcube" # PYPI RENAME THIS LINE (do not remove this comment, see #) 
+name = "xcube" # PYPI RENAME THIS LINE (do not remove this comment, see #1010) 
 dynamic = ["version", "readme"]
 authors = [
   {name = "xcube Development Team"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 61.2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "xcube-core"
+name = "xcube" # PYPI RENAME THIS LINE (do not remove this comment, see #) 
 dynamic = ["version", "readme"]
 authors = [
   {name = "xcube Development Team"}


### PR DESCRIPTION
This PR changes the package name from `xcube-core` to `xcube` in the `pyproject.toml`. For the automated workflow to release on PyPI, the line where the package name is defined is changed to `name = "xcube-core"`. 

The workflow has been tested with TestPyPI (see [TestPyPI xcube-core 1.6.0.dev3](https://test.pypi.org/project/xcube-core/1.6.0.dev3/))

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
