### PR TITLE
Web API: add "slash" parameter for routes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,9 @@
   a suitable matplotlib color map for variables that define the
   `flag_values` CF-attribute and optionally a `flag_colors` attribute. (#1011)
 
+* The `Api.route` decorator and `ApiRoute` constructor in
+  `xcube.server.api` now have a `slash` argument which lets a route support an
+  optional trailing slash.
 
 ### Fixes
 
@@ -85,6 +88,8 @@
 
 * Fixed broken table of contents links in dataset convention document.
 
+* Web API endpoints with an optional trailing slash are no longer listed
+  twice in the automatically generated OpenAPI documentation (#965)
 
 ### Incompatible API changes
 

--- a/test/server/test_api.py
+++ b/test/server/test_api.py
@@ -66,7 +66,7 @@ class ApiTest(unittest.TestCase):
     def test_route_decorator(self):
         api = Api("datasets")
 
-        @api.route("/datasets")
+        @api.route("/datasets", slash=True)
         class DatasetsHandler(ApiHandler):
             # noinspection PyMethodMayBeStatic
             def get(self):
@@ -80,7 +80,7 @@ class ApiTest(unittest.TestCase):
 
         self.assertEqual(
             (
-                ApiRoute("datasets", "/datasets", DatasetsHandler),
+                ApiRoute("datasets", "/datasets", DatasetsHandler, slash=True),
                 ApiRoute("datasets", "/datasets/{dataset_id}", DatasetHandler),
             ),
             api.routes,
@@ -173,6 +173,20 @@ class ApiRouteTest(unittest.TestCase):
             ")",
             f"{api_route!r}",
         )
+
+    def test_slash(self):
+        class DatasetHandler(ApiHandler):
+            # noinspection PyMethodMayBeStatic
+            def get(self):
+                return {}
+
+        self.assertFalse(
+            ApiRoute("datasets", "/datasets", DatasetHandler).slash
+        )
+        self.assertTrue(
+            ApiRoute("datasets", "/datasets", DatasetHandler, slash=True).slash
+        )
+
 
 
 class ApiContextTest(unittest.TestCase):

--- a/test/webapi/ows/coverages/test_routes.py
+++ b/test/webapi/ows/coverages/test_routes.py
@@ -5,18 +5,19 @@
 from ...helpers import RoutesTestCase
 
 from xcube.webapi.ows.coverages.routes import PATH_PREFIX
+_COVERAGE_PREFIX = PATH_PREFIX + "/collections/demo/coverage"
 
 
 class CoveragesRoutesTest(RoutesTestCase):
     def test_fetch_coverage_json(self):
         response = self.fetch(
-            PATH_PREFIX + "/collections/demo/coverage?f=application/json"
+            _COVERAGE_PREFIX + "?f=application/json"
         )
         self.assertResponseOK(response)
 
     def test_fetch_coverage_html(self):
         response = self.fetch(
-            PATH_PREFIX + "/collections/demo/coverage",
+            _COVERAGE_PREFIX + "",
             headers=dict(
                 Accept="text/nonexistent,application/json;q=0.9,text/html;q=1.0"
             ),
@@ -26,7 +27,7 @@ class CoveragesRoutesTest(RoutesTestCase):
 
     def test_fetch_coverage_netcdf(self):
         response = self.fetch(
-            PATH_PREFIX + "/collections/demo/coverage?f=application/netcdf"
+            _COVERAGE_PREFIX + "?f=application/netcdf"
         )
         self.assertResponseOK(response)
         self.assertEqual(
@@ -36,23 +37,23 @@ class CoveragesRoutesTest(RoutesTestCase):
 
     def test_fetch_coverage_wrong_media_type(self):
         response = self.fetch(
-            PATH_PREFIX + "/collections/demo/coverage",
+            _COVERAGE_PREFIX,
             headers=dict(Accept="text/nonexistent"),
         )
         self.assertEqual(response.status, 415)
 
     def test_fetch_domainset(self):
-        response = self.fetch(PATH_PREFIX + "/collections/demo/coverage/domainset")
+        response = self.fetch(_COVERAGE_PREFIX + "/domainset")
         self.assertResponseOK(response)
 
     def test_fetch_rangetype(self):
-        response = self.fetch(PATH_PREFIX + "/collections/demo/coverage/rangetype")
+        response = self.fetch(_COVERAGE_PREFIX + "/rangetype")
         self.assertResponseOK(response)
 
     def test_fetch_metadata(self):
-        response = self.fetch(PATH_PREFIX + "/collections/demo/coverage/metadata")
+        response = self.fetch(_COVERAGE_PREFIX + "/metadata")
         self.assertResponseOK(response)
 
     def test_fetch_rangeset(self):
-        response = self.fetch(PATH_PREFIX + "/collections/demo/coverage/rangeset")
+        response = self.fetch(_COVERAGE_PREFIX + "/rangeset")
         self.assertEqual(response.status, 405)

--- a/test/webapi/ows/stac/test_controllers.py
+++ b/test/webapi/ows/stac/test_controllers.py
@@ -75,7 +75,7 @@ EXPECTED_CONFORMANCE = {
 
 EXPECTED_ENDPOINTS = functools.reduce(
     lambda endpoint_list, ep: endpoint_list
-    + [{"methods": ep[0], "path": ep[1] + suffix} for suffix in ("/", "")],
+    + [{"methods": ep[0], "path": ep[1]}],
     [
         (["get"], "/collections/{collectionId}/coverage"),
         (["get"], "/collections/{collectionId}/coverage/domainset"),

--- a/xcube/server/api.py
+++ b/xcube/server/api.py
@@ -771,6 +771,7 @@ class ApiRoute:
                 and self.path == other.path
                 and self.handler_cls == other.handler_cls
                 and self.handler_kwargs == other.handler_kwargs
+                and self.slash == other.slash
             )
         return False
 
@@ -779,6 +780,7 @@ class ApiRoute:
             hash(self.api_name)
             + 2 * hash(self.path)
             + 4 * hash(self.handler_cls)
+            + 8 * hash(self.slash)
             + 16
             * hash(
                 tuple(sorted(tuple(self.handler_kwargs.items()), key=lambda p: p[0]))

--- a/xcube/server/api.py
+++ b/xcube/server/api.py
@@ -216,13 +216,15 @@ class Api(Generic[ServerContextT]):
 
         return decorator_func
 
-    def route(self, path: str, **handler_kwargs):
+    def route(self, path: str, slash: bool = False, **handler_kwargs):
         """Decorator that adds a route to this API.
 
         The decorator target must be a class derived from ApiHandler.
 
         Args:
             path: The route path.
+            slash: If true, a second route will also be created at the
+                same path with a slash suffixed
             **handler_kwargs: Optional keyword arguments passed to
                 ApiHandler constructor.
 
@@ -232,7 +234,9 @@ class Api(Generic[ServerContextT]):
         """
 
         def decorator_func(handler_cls: type[ApiHandler]):
-            self._routes.append(ApiRoute(self.name, path, handler_cls, handler_kwargs))
+            self._routes.append(ApiRoute(
+                self.name, path, handler_cls, handler_kwargs, slash
+            ))
             return handler_cls
 
         return decorator_func
@@ -732,6 +736,8 @@ class ApiRoute:
             ``ApiHandler``.
         handler_kwargs: Optional keyword arguments passed to the
             *handler_cls* when it is instantiated.
+        slash: If true, a second route will also be created at the
+            same path with a slash suffixed
     """
 
     def __init__(
@@ -740,6 +746,7 @@ class ApiRoute:
         path: str,
         handler_cls: type[ApiHandler],
         handler_kwargs: Optional[dict[str, Any]] = None,
+        slash: bool = False
     ):
         assert_instance(api_name, str, name="api_name")
         assert_instance(path, str, name="path")
@@ -755,6 +762,7 @@ class ApiRoute:
         self.path = path
         self.handler_cls = handler_cls
         self.handler_kwargs = dict(handler_kwargs or {})
+        self.slash = slash
 
     def __eq__(self, other) -> bool:
         if isinstance(other, ApiRoute):

--- a/xcube/server/webservers/tornado.py
+++ b/xcube/server/webservers/tornado.py
@@ -122,30 +122,20 @@ class TornadoFramework(Framework):
 
     def add_routes(self, api_routes: Sequence[ApiRoute], url_prefix: str):
         handlers = []
+
         for api_route in api_routes:
-            handlers.append(
-                (
-                    url_prefix + self.path_to_pattern(api_route.path),
-                    TornadoRequestHandler,
-                    {"api_route": api_route},
-                )
-            )
-
-            if api_route.slash:
-                handlers.append(
-                    (
-                        url_prefix + self.path_to_pattern(api_route.path) + "/",
-                        TornadoRequestHandler,
-                        {"api_route": api_route},
-                    )
-                )
-
+            handlers.append((
+                url_prefix + self.path_to_pattern(api_route.path)
+                + ("/?" if api_route.slash else ""),
+                TornadoRequestHandler,
+                {"api_route": api_route},
+            ))
             LOG.log(
                 LOG_LEVEL_DETAIL,
-                f"Added route"
-                f" {api_route.path!r}"
+                f"Added route {api_route.path!r}"
                 f" from API {api_route.api_name!r}",
             )
+
         if handlers:
             self.application.add_handlers(".*$", handlers)
 

--- a/xcube/server/webservers/tornado.py
+++ b/xcube/server/webservers/tornado.py
@@ -131,6 +131,15 @@ class TornadoFramework(Framework):
                 )
             )
 
+            if api_route.slash:
+                handlers.append(
+                    (
+                        url_prefix + self.path_to_pattern(api_route.path) + "/",
+                        TornadoRequestHandler,
+                        {"api_route": api_route},
+                    )
+                )
+
             LOG.log(
                 LOG_LEVEL_DETAIL,
                 f"Added route"

--- a/xcube/webapi/ows/coverages/routes.py
+++ b/xcube/webapi/ows/coverages/routes.py
@@ -18,12 +18,10 @@ from .controllers import (
 )
 
 
-PATH_PREFIX = "/ogc"
-
+_PATH_PREFIX = "/ogc/collections/{collectionId}/"
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/collections/{collectionId}/coverage")
-@api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/")
+@api.route(_PATH_PREFIX + "coverage", slash=True)
 class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
     """
     Return coverage data
@@ -85,8 +83,7 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/domainset")
-@api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/domainset/")
+@api.route(_PATH_PREFIX + "coverage/domainset", slash=True)
 class CoveragesDomainsetHandler(ApiHandler[CoveragesContext]):
     """Describe the domain set of a coverage
 
@@ -105,8 +102,7 @@ class CoveragesDomainsetHandler(ApiHandler[CoveragesContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/rangetype")
-@api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/rangetype/")
+@api.route(_PATH_PREFIX + "coverage/rangetype", slash=True)
 class CoveragesRangetypeHandler(ApiHandler[CoveragesContext]):
     """Describe the range type of a coverage
 
@@ -125,8 +121,7 @@ class CoveragesRangetypeHandler(ApiHandler[CoveragesContext]):
         return self.response.finish(range_type)
 
 
-@api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/metadata")
-@api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/metadata/")
+@api.route(_PATH_PREFIX + "coverage/metadata", slash=True)
 class CoveragesMetadataHandler(ApiHandler[CoveragesContext]):
     """Return coverage metadata
 
@@ -144,8 +139,7 @@ class CoveragesMetadataHandler(ApiHandler[CoveragesContext]):
         )
 
 
-@api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/rangeset")
-@api.route(PATH_PREFIX + "/collections/{collectionId}/coverage/rangeset/")
+@api.route(_PATH_PREFIX + "coverage/rangeset", slash=True)
 class CoveragesRangesetHandler(ApiHandler[CoveragesContext]):
     """Handle rangeset endpoint with a "not allowed" response
 

--- a/xcube/webapi/ows/coverages/routes.py
+++ b/xcube/webapi/ows/coverages/routes.py
@@ -18,10 +18,11 @@ from .controllers import (
 )
 
 
-_PATH_PREFIX = "/ogc/collections/{collectionId}/"
+PATH_PREFIX = "/ogc"
+_COVERAGE_PREFIX = PATH_PREFIX + "/collections/{collectionId}/coverage"
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(_PATH_PREFIX + "coverage", slash=True)
+@api.route(_COVERAGE_PREFIX, slash=True)
 class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
     """
     Return coverage data
@@ -83,7 +84,7 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(_PATH_PREFIX + "coverage/domainset", slash=True)
+@api.route(_COVERAGE_PREFIX + "/domainset", slash=True)
 class CoveragesDomainsetHandler(ApiHandler[CoveragesContext]):
     """Describe the domain set of a coverage
 
@@ -102,7 +103,7 @@ class CoveragesDomainsetHandler(ApiHandler[CoveragesContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(_PATH_PREFIX + "coverage/rangetype", slash=True)
+@api.route(_COVERAGE_PREFIX + "/rangetype", slash=True)
 class CoveragesRangetypeHandler(ApiHandler[CoveragesContext]):
     """Describe the range type of a coverage
 
@@ -121,7 +122,7 @@ class CoveragesRangetypeHandler(ApiHandler[CoveragesContext]):
         return self.response.finish(range_type)
 
 
-@api.route(_PATH_PREFIX + "coverage/metadata", slash=True)
+@api.route(_COVERAGE_PREFIX + "/metadata", slash=True)
 class CoveragesMetadataHandler(ApiHandler[CoveragesContext]):
     """Return coverage metadata
 
@@ -139,7 +140,7 @@ class CoveragesMetadataHandler(ApiHandler[CoveragesContext]):
         )
 
 
-@api.route(_PATH_PREFIX + "coverage/rangeset", slash=True)
+@api.route(_COVERAGE_PREFIX + "/rangeset", slash=True)
 class CoveragesRangesetHandler(ApiHandler[CoveragesContext]):
     """Handle rangeset endpoint with a "not allowed" response
 

--- a/xcube/webapi/ows/stac/routes.py
+++ b/xcube/webapi/ows/stac/routes.py
@@ -25,8 +25,7 @@ from .config import (
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX)
-@api.route(PATH_PREFIX + "/")
+@api.route(PATH_PREFIX, slash=True)
 class CatalogRootHandler(ApiHandler[StacContext]):
     @api.operation(
         operation_id="getCatalogRoot", summary="Get the STAC catalog's root."
@@ -37,8 +36,7 @@ class CatalogRootHandler(ApiHandler[StacContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/conformance")
-@api.route(PATH_PREFIX + "/conformance/")
+@api.route(PATH_PREFIX + "/conformance", slash=True)
 class CatalogConformanceHandler(ApiHandler[StacContext]):
     @api.operation(
         operation_id="getCatalogConformance",
@@ -50,8 +48,7 @@ class CatalogConformanceHandler(ApiHandler[StacContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/collections")
-@api.route(PATH_PREFIX + "/collections/")
+@api.route(PATH_PREFIX + "/collections", slash=True)
 class CatalogCollectionsHandler(ApiHandler[StacContext]):
     @api.operation(
         operation_id="getCatalogCollections",
@@ -63,8 +60,7 @@ class CatalogCollectionsHandler(ApiHandler[StacContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/collections/{collectionId}")
-@api.route(PATH_PREFIX + "/collections/{collectionId}/")
+@api.route(PATH_PREFIX + "/collections/{collectionId}", slash=True)
 class CatalogCollectionHandler(ApiHandler[StacContext]):
     # noinspection PyPep8Naming
     @api.operation(
@@ -76,8 +72,7 @@ class CatalogCollectionHandler(ApiHandler[StacContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/collections/{collectionId}/items")
-@api.route(PATH_PREFIX + "/collections/{collectionId}/items/")
+@api.route(PATH_PREFIX + "/collections/{collectionId}/items", slash=True)
 class CatalogCollectionItemsHandler(ApiHandler[StacContext]):
     # noinspection PyPep8Naming
     @api.operation(
@@ -105,8 +100,7 @@ class CatalogCollectionItemsHandler(ApiHandler[StacContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/collections/{collectionId}/items/{featureId}")
-@api.route(PATH_PREFIX + "/collections/{collectionId}/items/{featureId}/")
+@api.route(PATH_PREFIX + "/collections/{collectionId}/items/{featureId}", slash=True)
 class CatalogCollectionItemHandler(ApiHandler[StacContext]):
     # noinspection PyPep8Naming
     @api.operation(
@@ -124,8 +118,7 @@ class CatalogCollectionItemHandler(ApiHandler[StacContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/search")
-@api.route(PATH_PREFIX + "/search/")
+@api.route(PATH_PREFIX + "/search", slash=True)
 class CatalogSearchHandler(ApiHandler[StacContext]):
     @api.operation(
         operation_id="searchCatalogByKeywords",
@@ -147,8 +140,7 @@ class CatalogSearchHandler(ApiHandler[StacContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/collections/{collectionId}/queryables")
-@api.route(PATH_PREFIX + "/collections/{collectionId}/queryables/")
+@api.route(PATH_PREFIX + "/collections/{collectionId}/queryables", slash=True)
 class QueryablesHandler(ApiHandler[StacContext]):
     # noinspection PyPep8Naming
     @api.operation(
@@ -165,8 +157,7 @@ class QueryablesHandler(ApiHandler[StacContext]):
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "/collections/{collectionId}/schema")
-@api.route(PATH_PREFIX + "/collections/{collectionId}/schema/")
+@api.route(PATH_PREFIX + "/collections/{collectionId}/schema", slash=True)
 class SchemaHandler(ApiHandler[StacContext]):
     # noinspection PyPep8Naming
     @api.operation(


### PR DESCRIPTION
Add an optional `slash` parameter to the `server.api.Api.route` decorator, a corresponding constructor parameter and field to `ApiRoute`, and code to handle this field to `TornadoFramework.add_routes.` Passing `slash=True` causes the framework to handle the specified route both with and without an additional trailing `/` character.

Update STAC and Coverages implementations to use this feature, which gets rid of the duplicate entries in their generated OpenAPI documentation

Fixes #965.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* ~[ ] New/modified features documented in `docs/source/*`~ n/a
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
