### PR TITLE
Updates for NumPy 2.0.0 compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,8 @@
 * Web API endpoints with an optional trailing slash are no longer listed
   twice in the automatically generated OpenAPI documentation (#965)
 
+* Several minor updates to make xcube compatible with NumPy 2.0.0 (#1024)
+
 ### Incompatible API changes
 
 * The `get_cmap()` method of `util.cmaps.ColormapProvider` now returns a 

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -373,7 +373,7 @@ class VariableDescriptorTest(unittest.TestCase):
             "rj",
             ["dfjhrt", "sg"],
             chunks=(3, 2),
-            attrs={"ssd": 4, "zjgrhgu": "dgfrf", "fill_value": np.NaN},
+            attrs={"ssd": 4, "zjgrhgu": "dgfrf", "fill_value": np.nan},
         )
         expected = {
             "name": "xf",

--- a/xcube/core/maskset.py
+++ b/xcube/core/maskset.py
@@ -133,7 +133,9 @@ class MaskSet:
     def __str__(self):
         return "{}({})".format(
             self._flag_var.name,
-            ", ".join([f"{n}={v}" for n, v in self._flags.items()]),
+            ", ".join([f"{n}=({v[0]}, {v[1]})" for n, v in self._flags.items()]),
+            # We explicitly unpack the tuple to get the __str__ of the elements,
+            # rather than the __repr__. See https://peps.python.org/pep-3140/
         )
 
     def __dir__(self) -> Iterable[str]:

--- a/xcube/core/reproject.py
+++ b/xcube/core/reproject.py
@@ -394,8 +394,8 @@ def _ensure_valid_region(
         x1, y1, x2, y2 = region
     else:
         # Determine region from full-res lon/lat 2D variables
-        x1, x2 = x_var.min(), x_var.max()
-        y1, y2 = y_var.min(), y_var.max()
+        x1, x2 = x_var.min().item(), x_var.max().item()
+        y1, y2 = y_var.min().item(), y_var.max().item()
         extra_space = extra * max(x2 - x1, y2 - y1)
         # Add extra space in units of the source coordinates
         x1, x2 = x1 - extra_space, x2 + extra_space


### PR DESCRIPTION
- Update `test_variable_descriptor_to_dict` to use `np.nan`, not `np.NaN`.
- Update MaskSet.__str__ for NumPy 2.0.0
- reproject._ensure_valid_region: return plain tuple

Closes #1024.

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~ n/a
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~ n/a
* ~[ ] New/modified features documented in `docs/source/*`~ n/a
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
