### PR TITLE
Migrate docker image build from `setup.py` to `pyproject.toml`

### DIFF
--- a/.github/workflows/xcube_build_docker.yaml
+++ b/.github/workflows/xcube_build_docker.yaml
@@ -1,7 +1,9 @@
 name: xcube docker build
 
 on:
-  workflow_dispatch:
+  push:
+  release:
+    types: [published]
 
 env:
   APP_NAME: xcube
@@ -23,7 +25,7 @@ jobs:
 
       # checkout the repo with the release tag from previous step
       - name: git-checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ steps.latest_release.outputs.release_tag }}
 

--- a/.github/workflows/xcube_build_docker.yaml
+++ b/.github/workflows/xcube_build_docker.yaml
@@ -23,7 +23,7 @@ jobs:
 
       # checkout the repo with the release tag from previous step
       - name: git-checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           ref: ${{ steps.latest_release.outputs.release_tag }}
 

--- a/.github/workflows/xcube_build_docker.yaml
+++ b/.github/workflows/xcube_build_docker.yaml
@@ -23,7 +23,7 @@ jobs:
 
       # checkout the repo with the release tag from previous step
       - name: git-checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.latest_release.outputs.release_tag }}
 

--- a/.github/workflows/xcube_build_docker.yaml
+++ b/.github/workflows/xcube_build_docker.yaml
@@ -1,9 +1,7 @@
 name: xcube docker build
 
 on:
-  push:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 env:
   APP_NAME: xcube

--- a/.github/workflows/xcube_build_docker.yaml
+++ b/.github/workflows/xcube_build_docker.yaml
@@ -23,7 +23,7 @@ jobs:
 
       # checkout the repo with the release tag from previous step
       - name: git-checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ steps.latest_release.outputs.release_tag }}
 
@@ -36,7 +36,7 @@ jobs:
 
       # Build and push docker release to quay.io
       - name: push-docker-image-with-release-tag
-        uses: mr-smithers-excellent/docker-build-push@v5
+        uses: mr-smithers-excellent/docker-build-push@v6
         with:
           image: ${{ env.ORG_NAME }}/${{ env.APP_NAME }}
           tags: ${{ steps.latest_release.outputs.release_tag }}

--- a/.github/workflows/xcube_workflow.yaml
+++ b/.github/workflows/xcube_workflow.yaml
@@ -51,7 +51,7 @@ jobs:
     name: build-docker-image
     # Only run if unittests succeed
     needs: unittest
-    if: ${{ github.event_name == 'release' }}
+    #if: ${{ github.event_name == 'release' }}
     steps:
       - name: git-checkout
         uses: actions/checkout@v4

--- a/.github/workflows/xcube_workflow.yaml
+++ b/.github/workflows/xcube_workflow.yaml
@@ -51,7 +51,7 @@ jobs:
     name: build-docker-image
     # Only run if unittests succeed
     needs: unittest
-    #if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'release' }}
     steps:
       - name: git-checkout
         uses: actions/checkout@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Changes in 1.6.1.dev1 (in development)
+
+* Migrated the `.github/workflows/xcube_build_docker.yaml` and the corresponding 
+  `Dockerfile` from `setup.py` to `pyproject.toml`. Additionally, updated the relevant 
+  documentation in `doc/source` to reflect this change from `setup.py` to
+  `pyproject.toml.` (related to #992) 
+
 ## Changes in 1.6.0
 
 ### Enhancements

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN micromamba install -y -n base -f /tmp/environment.yml \
 
 # Copy files for xcube source install
 COPY --chown=$MAMBA_USER:$MAMBA_USER ./xcube /tmp/xcube
-COPY --chown=$MAMBA_USER:$MAMBA_USER ./setup.py /tmp/setup.py
+COPY --chown=$MAMBA_USER:$MAMBA_USER ./pyproject.toml /tmp/pyproject.toml
 COPY --chown=$MAMBA_USER:$MAMBA_USER ./README.md /tmp/README.md
 
 # Switch into /tmp to install xcube.
@@ -58,7 +58,7 @@ WORKDIR /tmp
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 # Install xcube from source.
-RUN python setup.py install
+RUN pip install --no-deps .
 
 # Install our known xcube plugins.
 COPY --chown=$MAMBA_USER:$MAMBA_USER docker/install-xcube-plugin.sh ./

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -459,6 +459,13 @@ in the package's `plugin` module (hence `{package}.plugin.init_plugin()`).
 Alternatively, the package can have any name, but then it must register 
 a [setuptools entry point] in the slot "xcube_plugins". In this case the 
 function `init_plugin()` can also be placed anywhere in your code.
+
+If you use `pyproject.toml`:
+```
+[project.entry-points.xcube_plugins]
+{your_name} = "{your_name}.plugin:init_plugin"
+```
+
 If you use `setup.cfg`:
 
 ```
@@ -467,7 +474,7 @@ xcube_plugins =
     {your_name} = {your_package}.plugin:init_plugin
 ```
 
-If you are (still) using `setup.py`:
+If you use `setup.py`:
 
 ```python
 from setuptools import setup

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -78,11 +78,8 @@ pip install --no-deps --editable .
 
 The second command installs xcube in ‘editable mode’, meaning that it will
 be run directly from the repository, and changes to the code in the repository
-will take immediate effect without reinstallation. (As an alternative to
-pip, the command `python setup.py develop` can be used, but this is
-[no longer recommended](https://docs.python.org/3/install/#introduction).
-Among other things, `pip` has the advantage of allowing easy deinstallation of
-installed packages.)
+will take immediate effect without reinstallation. Note that `pip` offers the
+advantage of easily uninstalling the respective package.
 
 To update the install to the latest repository version and update the
 environment to reflect to any changes in `environment.yml`:

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -1,5 +1,5 @@
 .. _xcube.core.gen.iproc.DefaultInputProcessor: https://github.com/dcs4cop/xcube/blob/main/xcube/core/gen/iproc.py
-.. _setup.py: https://github.com/dcs4cop/xcube/blob/main/setup.py
+.. _pyproject.toml: https://github.com/dcs4cop/xcube/blob/main/pyproject.toml
 .. _`Creating and discovering plugins`: https://packaging.python.org/guides/creating-and-discovering-plugins/
 .. _`Python Packing User Guide`: https://packaging.python.org/
 .. _`Dynamic Discovery of Services and Plugins`: https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins
@@ -30,7 +30,7 @@ Installing Plugins
 Plugins are installed by simply installing the plugin's package into xcube's Python environment.
 
 In order to be detected by xcube, an plugin package's name must either start with ``xcube_``
-or the plugin package's ``setup.py`` file must specify an entry point in the group
+or the plugin package's ``setup.py`` or ``pyproject.toml`` file must specify an entry point in the group
 ``xcube_plugins``. Details are provided below in section `plugin_development`_.
 
 
@@ -92,7 +92,7 @@ defines a non-empty entry point group ``xcube_plugins`` is an xcube plugin. An e
 ``xcube_plugins`` group has the format ``<name> = <fully-qualified-module-path>:<init-func-name>``,
 and therefore specifies where plugin *initializer function* named ``<init-func-name>`` is found.
 As an example, refer to the xcube standard plugin definitions in xcube's
-`setup.py`_ file.
+`pyproject.toml`_ file.
 
 For more information on Setuptools entry points refer to section `Creating and discovering plugins`_ in the
 `Python Packing User Guide`_ and `Dynamic Discovery of Services and Plugins`_ in the `Setuptools documentation`_.

--- a/xcube/core/byoa/config.py
+++ b/xcube/core/byoa/config.py
@@ -273,7 +273,7 @@ class CodeConfig(JsonObject):
         a local directory. This directory may be used without
         package installation (i.e. added to Python's sys.path) or
         used after installation (i.e. by executing
-        ``python setup.py install``).
+        ``pip install .``).
         """
         return _for_local(self)
 


### PR DESCRIPTION
This PR is related to #992 and migrated the `.github/workflows/xcube_build_docker.yaml` and the corresponding `Dockerfile` from `setup.py` to `pyproject.toml`. Additionally, I updated the relevant documentation in `doc/source` to reflect this change from `setup.py` to `pyproject.toml.`

I successfully build the docker image (see https://github.com/xcube-dev/xcube/actions/runs/9659329963). The workflow is changed back, so that the docker image is only built on release. 

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
