### PR TITLE
Add data store parameters and data ID to the assets in the STAC published by xcube server 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,9 @@
 * The `xcube.core.store.DataDescriptor` class now supports specifying time ranges
   using both `datetime.date` and `datetime.datetime` objects. Previously,
   only `datetime.date` objects were supported.
+* The xcube server STAC publication has been adjusted so that the data store
+  parameters and data ID, which are needed to open the data, 
+  are now included with the asset (#1020).
 
 ## Changes in 1.6.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,11 +26,11 @@
 * The `xcube.core.store.DataDescriptor` class now supports specifying time ranges
   using both `datetime.date` and `datetime.datetime` objects. Previously,
   only `datetime.date` objects were supported.
-* The xcube server STAC publication has been adjusted so that the data store
-  parameters and data ID, which are needed to open the data, 
-  are now included with the asset; furthermore, a second assert called
-  `analytic_multires` will be published referring to the multi-resolution data format
-  levels (#1020).
+* The xcube server STAC API has been adjusted so that the data store
+  parameters and data ID, which are needed to open the data referred to by a STAC item, 
+  are now included with the item's `analytic` asset. 
+  Furthermore, a second assert called `analytic_multires` will be published
+  referring to the multi-resolution data format levels (#1020).
 
 ## Changes in 1.6.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,9 @@
   only `datetime.date` objects were supported.
 * The xcube server STAC publication has been adjusted so that the data store
   parameters and data ID, which are needed to open the data, 
-  are now included with the asset (#1020).
+  are now included with the asset; furthermore, a second assert called
+  `analytic_multires` will be published referring to the multi-resolution data format
+  levels (#1020).
 
 ## Changes in 1.6.0
 

--- a/test/webapi/ows/stac/demo-collection.json
+++ b/test/webapi/ows/stac/demo-collection.json
@@ -7,8 +7,8 @@
       ],
       "type": "application/zarr",
       "href": "http://localhost:8080/s3/datasets/demo.zarr",
-      "xcube:store_kwargs": {
-        "data_store_id": "s3",
+      "xcube:data_store_id": "s3",
+      "xcube:data_store_params": {
         "root": "datasets",
         "storage_options": {
           "anon": true,
@@ -17,7 +17,7 @@
           }
         }
       },
-      "xcube:open_kwargs": {
+      "xcube:open_data_params": {
         "data_id": "demo.zarr"
       },
       "xcube:analytic": {
@@ -70,8 +70,8 @@
       ],
       "type": "application/zarr",
       "href": "http://localhost:8080/s3/pyramids/demo.levels",
-      "xcube:store_kwargs": {
-        "data_store_id": "s3",
+      "xcube:data_store_id": "s3",
+      "xcube:data_store_params": {
         "root": "pyramids",
         "storage_options": {
           "anon": true,
@@ -80,7 +80,7 @@
           }
         }
       },
-      "xcube:open_kwargs": {
+      "xcube:open_data_params": {
         "data_id": "demo.levels"
       },
       "xcube:analytic_multires": {

--- a/test/webapi/ows/stac/demo-collection.json
+++ b/test/webapi/ows/stac/demo-collection.json
@@ -7,6 +7,19 @@
       ],
       "type": "application/zarr",
       "href": "http://localhost:8080/s3/datasets/demo.zarr",
+      "xcube:store_kwargs": {
+        "data_store_id": "s3",
+        "root": "datasets",
+        "storage_options": {
+          "anon": true,
+          "client_kwargs": {
+            "endpoint_url": "http://localhost:8080/s3"
+          }
+        }
+      },
+      "xcube:open_kwargs": {
+        "data_id": "demo.zarr"
+      },
       "xcube:analytic": {
         "c2rcc_flags": {
           "title": "c2rcc_flags data access",

--- a/test/webapi/ows/stac/demo-collection.json
+++ b/test/webapi/ows/stac/demo-collection.json
@@ -63,6 +63,69 @@
         }
       }
     },
+    "analytic_multires": {
+      "title": "demo multi-resolution data access",
+      "roles": [
+        "data"
+      ],
+      "type": "application/zarr",
+      "href": "http://localhost:8080/s3/pyramids/demo.levels",
+      "xcube:store_kwargs": {
+        "data_store_id": "s3",
+        "root": "pyramids",
+        "storage_options": {
+          "anon": true,
+          "client_kwargs": {
+            "endpoint_url": "http://localhost:8080/s3"
+          }
+        }
+      },
+      "xcube:open_kwargs": {
+        "data_id": "demo.levels"
+      },
+      "xcube:analytic_multires": {
+        "c2rcc_flags": {
+          "title": "c2rcc_flags data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo.levels/0.zarr/c2rcc_flags"
+        },
+        "conc_chl": {
+          "title": "conc_chl data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo.levels/0.zarr/conc_chl"
+        },
+        "conc_tsm": {
+          "title": "conc_tsm data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo.levels/0.zarr/conc_tsm"
+        },
+        "kd489": {
+          "title": "kd489 data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo.levels/0.zarr/kd489"
+        },
+        "quality_flags": {
+          "title": "quality_flags data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo.levels/0.zarr/quality_flags"
+        }
+      }
+    },
     "visual": {
       "title": "demo visualisation",
       "roles": [

--- a/test/webapi/ows/stac/stac-datacubes-item.json
+++ b/test/webapi/ows/stac/stac-datacubes-item.json
@@ -970,8 +970,8 @@
       ],
       "type": "application/zarr",
       "href": "http://localhost:8080/s3/datasets/demo-1w.zarr",
-      "xcube:store_kwargs": {
-        "data_store_id": "s3",
+      "xcube:data_store_id": "s3",
+      "xcube:data_store_params": {
         "root": "datasets",
         "storage_options": {
           "anon": true,
@@ -980,7 +980,7 @@
           }
         }
       },
-      "xcube:open_kwargs": {
+      "xcube:open_data_params": {
         "data_id": "demo-1w.zarr"
       },
       "xcube:analytic": {
@@ -1073,8 +1073,8 @@
       ],
       "type": "application/zarr",
       "href": "http://localhost:8080/s3/pyramids/demo-1w.levels",
-      "xcube:store_kwargs": {
-        "data_store_id": "s3",
+      "xcube:data_store_id": "s3",
+      "xcube:data_store_params": {
         "root": "pyramids",
         "storage_options": {
           "anon": true,
@@ -1083,7 +1083,7 @@
           }
         }
       },
-      "xcube:open_kwargs": {
+      "xcube:open_data_params": {
         "data_id": "demo-1w.levels"
       },
       "xcube:analytic_multires": {

--- a/test/webapi/ows/stac/stac-datacubes-item.json
+++ b/test/webapi/ows/stac/stac-datacubes-item.json
@@ -1066,6 +1066,109 @@
         }
       }
     },
+    "analytic_multires": {
+      "title": "demo-1w multi-resolution data access",
+      "roles": [
+        "data"
+      ],
+      "type": "application/zarr",
+      "href": "http://localhost:8080/s3/pyramids/demo-1w.levels",
+      "xcube:store_kwargs": {
+        "data_store_id": "s3",
+        "root": "pyramids",
+        "storage_options": {
+          "anon": true,
+          "client_kwargs": {
+            "endpoint_url": "http://localhost:8080/s3"
+          }
+        }
+      },
+      "xcube:open_kwargs": {
+        "data_id": "demo-1w.levels"
+      },
+      "xcube:analytic_multires": {
+        "c2rcc_flags": {
+          "title": "c2rcc_flags data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/c2rcc_flags"
+        },
+        "conc_chl": {
+          "title": "conc_chl data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/conc_chl"
+        },
+        "conc_tsm": {
+          "title": "conc_tsm data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/conc_tsm"
+        },
+        "kd489": {
+          "title": "kd489 data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/kd489"
+        },
+        "quality_flags": {
+          "title": "quality_flags data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/quality_flags"
+        },
+        "c2rcc_flags_stdev": {
+          "title": "c2rcc_flags_stdev data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/c2rcc_flags_stdev"
+        },
+        "conc_chl_stdev": {
+          "title": "conc_chl_stdev data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/conc_chl_stdev"
+        },
+        "conc_tsm_stdev": {
+          "title": "conc_tsm_stdev data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/conc_tsm_stdev"
+        },
+        "kd489_stdev": {
+          "title": "kd489_stdev data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/kd489_stdev"
+        },
+        "quality_flags_stdev": {
+          "title": "quality_flags_stdev data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/quality_flags_stdev"
+        }
+      }
+    },
     "visual": {
       "title": "demo-1w visualisation",
       "roles": [

--- a/test/webapi/ows/stac/stac-datacubes-item.json
+++ b/test/webapi/ows/stac/stac-datacubes-item.json
@@ -970,6 +970,19 @@
       ],
       "type": "application/zarr",
       "href": "http://localhost:8080/s3/datasets/demo-1w.zarr",
+      "xcube:store_kwargs": {
+        "data_store_id": "s3",
+        "root": "datasets",
+        "storage_options": {
+          "anon": true,
+          "client_kwargs": {
+            "endpoint_url": "http://localhost:8080/s3"
+          }
+        }
+      },
+      "xcube:open_kwargs": {
+        "data_id": "demo-1w.zarr"
+      },
       "xcube:analytic": {
         "c2rcc_flags": {
           "title": "c2rcc_flags data access",

--- a/test/webapi/ows/stac/stac-single-item.json
+++ b/test/webapi/ows/stac/stac-single-item.json
@@ -970,8 +970,8 @@
       ],
       "type": "application/zarr",
       "href": "http://localhost:8080/s3/datasets/demo-1w.zarr",
-      "xcube:store_kwargs": {
-        "data_store_id": "s3",
+      "xcube:data_store_id": "s3",
+      "xcube:data_store_params": {
         "root": "datasets",
         "storage_options": {
           "anon": true,
@@ -980,7 +980,7 @@
           }
         }
       },
-      "xcube:open_kwargs": {
+      "xcube:open_data_params": {
         "data_id": "demo-1w.zarr"
       },
       "xcube:analytic": {
@@ -1073,8 +1073,8 @@
       ],
       "type": "application/zarr",
       "href": "http://localhost:8080/s3/pyramids/demo-1w.levels",
-      "xcube:store_kwargs": {
-        "data_store_id": "s3",
+      "xcube:data_store_id": "s3",
+      "xcube:data_store_params": {
         "root": "pyramids",
         "storage_options": {
           "anon": true,
@@ -1083,7 +1083,7 @@
           }
         }
       },
-      "xcube:open_kwargs": {
+      "xcube:open_data_params": {
         "data_id": "demo-1w.levels"
       },
       "xcube:analytic_multires": {

--- a/test/webapi/ows/stac/stac-single-item.json
+++ b/test/webapi/ows/stac/stac-single-item.json
@@ -1066,6 +1066,109 @@
         }
       }
     },
+    "analytic_multires": {
+      "title": "demo-1w multi-resolution data access",
+      "roles": [
+        "data"
+      ],
+      "type": "application/zarr",
+      "href": "http://localhost:8080/s3/pyramids/demo-1w.levels",
+      "xcube:store_kwargs": {
+        "data_store_id": "s3",
+        "root": "pyramids",
+        "storage_options": {
+          "anon": true,
+          "client_kwargs": {
+            "endpoint_url": "http://localhost:8080/s3"
+          }
+        }
+      },
+      "xcube:open_kwargs": {
+        "data_id": "demo-1w.levels"
+      },
+      "xcube:analytic_multires": {
+        "c2rcc_flags": {
+          "title": "c2rcc_flags data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/c2rcc_flags"
+        },
+        "conc_chl": {
+          "title": "conc_chl data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/conc_chl"
+        },
+        "conc_tsm": {
+          "title": "conc_tsm data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/conc_tsm"
+        },
+        "kd489": {
+          "title": "kd489 data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/kd489"
+        },
+        "quality_flags": {
+          "title": "quality_flags data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/quality_flags"
+        },
+        "c2rcc_flags_stdev": {
+          "title": "c2rcc_flags_stdev data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/c2rcc_flags_stdev"
+        },
+        "conc_chl_stdev": {
+          "title": "conc_chl_stdev data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/conc_chl_stdev"
+        },
+        "conc_tsm_stdev": {
+          "title": "conc_tsm_stdev data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/conc_tsm_stdev"
+        },
+        "kd489_stdev": {
+          "title": "kd489_stdev data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/kd489_stdev"
+        },
+        "quality_flags_stdev": {
+          "title": "quality_flags_stdev data access",
+          "roles": [
+            "data"
+          ],
+          "type": "application/zarr",
+          "href": "http://localhost:8080/s3/pyramids/demo-1w.levels/0.zarr/quality_flags_stdev"
+        }
+      }
+    },
     "visual": {
       "title": "demo-1w visualisation",
       "roles": [

--- a/test/webapi/ows/stac/stac-single-item.json
+++ b/test/webapi/ows/stac/stac-single-item.json
@@ -970,6 +970,19 @@
       ],
       "type": "application/zarr",
       "href": "http://localhost:8080/s3/datasets/demo-1w.zarr",
+      "xcube:store_kwargs": {
+        "data_store_id": "s3",
+        "root": "datasets",
+        "storage_options": {
+          "anon": true,
+          "client_kwargs": {
+            "endpoint_url": "http://localhost:8080/s3"
+          }
+        }
+      },
+      "xcube:open_kwargs": {
+        "data_id": "demo-1w.zarr"
+      },
       "xcube:analytic": {
         "c2rcc_flags": {
           "title": "c2rcc_flags data access",

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -797,15 +797,15 @@ def _get_assets(ctx: DatasetsContext, base_url: str, dataset_id: str):
             "roles": ["data"],
             "type": "application/zarr",
             "href": f"{base_url}/s3/datasets/{dataset_id}.zarr",
-            "xcube:store_kwargs": {
-                "data_store_id": "s3",
+            "xcube:data_store_id": "s3",
+            "xcube:data_store_params": {
                 "root": "datasets",
                 "storage_options": {
                     "anon": True,
                     "client_kwargs": {"endpoint_url": "http://localhost:8080/s3"},
                 },
             },
-            "xcube:open_kwargs": {"data_id": f"{dataset_id}.zarr"},
+            "xcube:open_data_params": {"data_id": f"{dataset_id}.zarr"},
             "xcube:analytic": {
                 v["name"]: {
                     "title": f"{v['name']} data access",
@@ -821,15 +821,15 @@ def _get_assets(ctx: DatasetsContext, base_url: str, dataset_id: str):
             "roles": ["data"],
             "type": "application/zarr",
             "href": f"{base_url}/s3/pyramids/{dataset_id}.levels",
-            "xcube:store_kwargs": {
-                "data_store_id": "s3",
+            "xcube:data_store_id": "s3",
+            "xcube:data_store_params": {
                 "root": "pyramids",
                 "storage_options": {
                     "anon": True,
                     "client_kwargs": {"endpoint_url": "http://localhost:8080/s3"},
                 },
             },
-            "xcube:open_kwargs": {"data_id": f"{dataset_id}.levels"},
+            "xcube:open_data_params": {"data_id": f"{dataset_id}.levels"},
             "xcube:analytic_multires": {
                 v["name"]: {
                     "title": f"{v['name']} data access",

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -806,9 +806,7 @@ def _get_assets(ctx: DatasetsContext, base_url: str, dataset_id: str):
                     "client_kwargs": {"endpoint_url": "http://localhost:8080/s3"},
                 },
             },
-            "xcube:open_kwargs": {
-                "data_id": f"{dataset_id}.zarr",
-            },
+            "xcube:open_kwargs": {"data_id": f"{dataset_id}.zarr"},
             "xcube:analytic": {
                 v["name"]: {
                     "title": f"{v['name']} data access",

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -790,14 +790,13 @@ def _get_assets(ctx: DatasetsContext, base_url: str, dataset_id: str):
 
     # TODO: Prefer original storage location.
     #       The "s3" operation is default.
-    default_storage_url = f"{base_url}/s3/datasets"
 
     return {
         "analytic": {
             "title": f"{dataset_id} data access",
             "roles": ["data"],
             "type": "application/zarr",
-            "href": f"{default_storage_url}/{dataset_id}.zarr",
+            "href": f"{base_url}/s3/datasets/{dataset_id}.zarr",
             "xcube:store_kwargs": {
                 "data_store_id": "s3",
                 "root": "datasets",
@@ -812,7 +811,31 @@ def _get_assets(ctx: DatasetsContext, base_url: str, dataset_id: str):
                     "title": f"{v['name']} data access",
                     "roles": ["data"],
                     "type": "application/zarr",
-                    "href": f"{default_storage_url}/" f"{dataset_id}.zarr/{v['name']}",
+                    "href": f"{base_url}/s3/datasets/{dataset_id}.zarr/{v['name']}",
+                }
+                for v in xcube_data_vars
+            },
+        },
+        "analytic_multires": {
+            "title": f"{dataset_id} multi-resolution data access",
+            "roles": ["data"],
+            "type": "application/zarr",
+            "href": f"{base_url}/s3/pyramids/{dataset_id}.levels",
+            "xcube:store_kwargs": {
+                "data_store_id": "s3",
+                "root": "pyramids",
+                "storage_options": {
+                    "anon": True,
+                    "client_kwargs": {"endpoint_url": "http://localhost:8080/s3"},
+                },
+            },
+            "xcube:open_kwargs": {"data_id": f"{dataset_id}.levels"},
+            "xcube:analytic_multires": {
+                v["name"]: {
+                    "title": f"{v['name']} data access",
+                    "roles": ["data"],
+                    "type": "application/zarr",
+                    "href": f"{base_url}/s3/pyramids/{dataset_id}.levels/0.zarr/{v['name']}",
                 }
                 for v in xcube_data_vars
             },

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -4,7 +4,7 @@
 
 
 import datetime
-from typing import Any, Optional, Dict, List, Union
+from typing import Any, Optional, Union
 from collections.abc import Hashable, Mapping
 import itertools
 
@@ -18,7 +18,7 @@ from xcube.core.gridmapping import CRS_CRS84, GridMapping
 from xcube.server.api import ApiError
 from xcube.server.api import ServerConfig
 from xcube.util.jsonencoder import to_json_value
-from xcube.util.jsonschema import JsonObjectSchema, JsonSchema
+from xcube.util.jsonschema import JsonObjectSchema
 from .config import DEFAULT_CATALOG_DESCRIPTION, DEFAULT_FEATURE_ID
 from .config import DEFAULT_CATALOG_ID
 from .config import DEFAULT_CATALOG_TITLE
@@ -798,6 +798,17 @@ def _get_assets(ctx: DatasetsContext, base_url: str, dataset_id: str):
             "roles": ["data"],
             "type": "application/zarr",
             "href": f"{default_storage_url}/{dataset_id}.zarr",
+            "xcube:store_kwargs": {
+                "data_store_id": "s3",
+                "root": "datasets",
+                "storage_options": {
+                    "anon": True,
+                    "client_kwargs": {"endpoint_url": "http://localhost:8080/s3"},
+                },
+            },
+            "xcube:open_kwargs": {
+                "data_id": f"{dataset_id}.zarr",
+            },
             "xcube:analytic": {
                 v["name"]: {
                     "title": f"{v['name']} data access",


### PR DESCRIPTION
Closes #1020 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
