### PR TITLE
The `xcube.core.store.DataDescriptor` class now supports specifying time ranges using both `datetime.date` and `datetime.datetime` objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,9 @@
   at its first position and will override the `date_type` argument.
   To preserve backward compatibility, the keyword argument `data_type`
   has not yet been added to the `open_data()` method arguments. (#1030)
+* The `xcube.core.store.DataDescriptor` class now supports specifying time ranges
+  using both `datetime.date` and `datetime.datetime` objects. Previously,
+  only `datetime.date` objects were supported.
 
 ## Changes in 1.6.0
 

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -159,7 +159,7 @@ class DataDescriptorTest(unittest.TestCase):
                 "data_type": "dataset",
                 "bbox": [10.0, 20.0, 30.0, 40.0],
                 "spatial_res": 20.0,
-                "time_range": ["2017-06-05", "2017-06-27"],
+                "time_range": ("2017-06-05", "2017-06-27"),
                 "time_period": "daily",
                 "open_params_schema": {
                     "type": "object",
@@ -193,7 +193,7 @@ class DataDescriptorTest(unittest.TestCase):
                 "data_type": "dataset",
                 "bbox": [10.0, 20.0, 30.0, 40.0],
                 "spatial_res": 20.0,
-                "time_range": ["2017-06-05T12:22:45Z", "2017-06-27T18:22:45Z"],
+                "time_range": ("2017-06-05T12:22:45Z", "2017-06-27T18:22:45Z"),
                 "time_period": "daily",
                 "open_params_schema": {
                     "type": "object",
@@ -344,7 +344,7 @@ class DatasetDescriptorTest(unittest.TestCase):
                 crs="EPSG:9346",
                 bbox=[10.0, 20.0, 30.0, 40.0],
                 spatial_res=20.0,
-                time_range=["2017-06-05", "2017-06-27"],
+                time_range=("2017-06-05", "2017-06-27"),
                 time_period="daily",
                 coords=dict(
                     rtdt=dict(

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -159,7 +159,7 @@ class DataDescriptorTest(unittest.TestCase):
                 "data_type": "dataset",
                 "bbox": [10.0, 20.0, 30.0, 40.0],
                 "spatial_res": 20.0,
-                "time_range": ("2017-06-05", "2017-06-27"),
+                "time_range": ["2017-06-05", "2017-06-27"],
                 "time_period": "daily",
                 "open_params_schema": {
                     "type": "object",
@@ -193,7 +193,7 @@ class DataDescriptorTest(unittest.TestCase):
                 "data_type": "dataset",
                 "bbox": [10.0, 20.0, 30.0, 40.0],
                 "spatial_res": 20.0,
-                "time_range": ("2017-06-05T12:22:45Z", "2017-06-27T18:22:45Z"),
+                "time_range": ["2017-06-05T12:22:45Z", "2017-06-27T18:22:45Z"],
                 "time_period": "daily",
                 "open_params_schema": {
                     "type": "object",

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -159,7 +159,41 @@ class DataDescriptorTest(unittest.TestCase):
                 "data_type": "dataset",
                 "bbox": [10.0, 20.0, 30.0, 40.0],
                 "spatial_res": 20.0,
-                "time_range": ["2017-06-05", "2017-06-27"],
+                "time_range": ("2017-06-05", "2017-06-27"),
+                "time_period": "daily",
+                "open_params_schema": {
+                    "type": "object",
+                    "properties": {"consolidated": {"type": "boolean"}},
+                    "additionalProperties": False,
+                },
+            },
+            descriptor_dict,
+        )
+
+    def test_datetime_to_dict(self):
+        descriptor = DatasetDescriptor(
+            data_id="xyz",
+            crs="EPSG:9346",
+            bbox=(10.0, 20.0, 30.0, 40.0),
+            spatial_res=20.0,
+            time_range=("2017-06-05T12:22:45Z", "2017-06-27T18:22:45Z"),
+            time_period="daily",
+            open_params_schema=JsonObjectSchema(
+                properties=dict(
+                    consolidated=JsonBooleanSchema(),
+                ),
+                additional_properties=False,
+            ),
+        )
+        descriptor_dict = descriptor.to_dict()
+        self.assertEqual(
+            {
+                "data_id": "xyz",
+                "crs": "EPSG:9346",
+                "data_type": "dataset",
+                "bbox": [10.0, 20.0, 30.0, 40.0],
+                "spatial_res": 20.0,
+                "time_range": ("2017-06-05T12:22:45Z", "2017-06-27T18:22:45Z"),
                 "time_period": "daily",
                 "open_params_schema": {
                     "type": "object",

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -109,7 +109,7 @@ class DataDescriptor(JsonObject):
             or WKT string
         bbox: A bounding box of the data
         time_range: Start and end time delimiting this data's temporal
-            extent
+            extent;
         time_period: The data's periodicity if it is evenly temporally
             resolved.
         open_params_schema: A JSON schema describing the parameters that

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -23,6 +23,8 @@ from xcube.util.assertions import assert_not_none
 from xcube.util.ipython import register_json_formatter
 from xcube.util.jsonschema import JsonArraySchema
 from xcube.util.jsonschema import JsonDateSchema
+from xcube.util.jsonschema import JsonDatetimeSchema
+from xcube.util.jsonschema import JsonComplexSchema
 from xcube.util.jsonschema import JsonIntegerSchema
 from xcube.util.jsonschema import JsonNumberSchema
 from xcube.util.jsonschema import JsonObject
@@ -155,7 +157,12 @@ class DataDescriptor(JsonObject):
                         JsonNumberSchema(),
                     ]
                 ),
-                time_range=JsonDateSchema.new_range(nullable=True),
+                time_range=JsonComplexSchema(
+                    any_of=[
+                        JsonDateSchema.new_range(nullable=True),
+                        JsonDatetimeSchema.new_range(nullable=True),
+                    ]
+                ),
                 time_period=JsonStringSchema(min_length=1),
                 open_params_schema=JsonObjectSchema(additional_properties=True),
             ),


### PR DESCRIPTION
closes #1031 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
