### PR TITLE
Allow for grouping datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
   is an arbitrary band-math expression, 
   see https://github.com/xcube-dev/xcube-viewer/issues/371.
 
+* xcube server now allows for assigning a `GroupTitle` and a list of `Tags`
+  to a configured dataset. This feature has been added in order to support
+  grouping and filtering of datasets in UIs, see
+  
+
 ### Fixes
 
 * Migrated the `.github/workflows/xcube_build_docker.yaml` and the corresponding 

--- a/docs/source/cli/xcube_serve.rst
+++ b/docs/source/cli/xcube_serve.rst
@@ -114,7 +114,7 @@ The parts of the demo configuration file are explained in detail further down.
 
 Some hints before, which are not addressed in the server demo configuration file.
 To increase imaging performance, xcube datasets can be converted to multi-resolution pyramids using the
-:doc:`xcube_level` tool. In the configuration, the format must be set to ``'levels'``.
+:doc:`xcube_level` tool. In the configuration, the path should use the ``.levels`` extension.
 Leveled xcube datasets are configured this way:
 
 .. code-block:: yaml

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -35,6 +35,7 @@ Datasets:
   #
   - Identifier: local
     Title: Local OLCI L2C cube for region SNS
+    GroupTitle: Zarr
     BoundingBox: [0.0, 50, 5.0, 52.5]
     FileSystem: file
     Path: cube-1-250-250.levels
@@ -63,6 +64,7 @@ Datasets:
   # Will not appear at all, because it is a "hidden" resource
   - Identifier: local_ts
     Title: "'local' optimized for time-series"
+    GroupTitle: Zarr
     BoundingBox: [0.0, 50, 5.0, 52.5]
     FileSystem: file
     Path: cube-5-100-200.zarr
@@ -91,6 +93,7 @@ Datasets:
   # Will only appear for unauthorized clients
   - Identifier: local_1w
     Title: OLCI weekly L3 cube for region SNS computed from local L2C cube
+    GroupTitle: Zarr
     BoundingBox: [0.0, 50, 5.0, 52.5]
     FileSystem: memory
     Path: resample_in_time.py
@@ -127,12 +130,14 @@ Datasets:
 
   - Identifier: cog_local
     Title: COG example
+    GroupTitle: GeoTIFF
     FileSystem: file
     Path: sample-cog.tif
     Style: tif_style
 
   - Identifier: geotiff_local
     Title: GeoTIFF example
+    GroupTitle: GeoTIFF
     FileSystem: file
     Path: sample-geotiff.tif
     Style: tif_style

--- a/test/webapi/datasets/test_controllers.py
+++ b/test/webapi/datasets/test_controllers.py
@@ -58,6 +58,8 @@ class DatasetsControllerTest(DatasetsControllerTestBase):
             self.assertIsInstance(dataset, dict)
             self.assertIsInstance(dataset.get("id"), str)
             self.assertIsInstance(dataset.get("title"), str)
+            self.assertIsInstance(dataset.get("groupTitle"), str)
+            self.assertIsInstance(dataset.get("tags"), (tuple, list))
             self.assertIsInstance(dataset.get("attributions"), (tuple, list))
             self.assertIsInstance(dataset.get("variables"), (tuple, list))
             self.assertIsInstance(dataset.get("dimensions"), (tuple, list))

--- a/test/webapi/res/config.yml
+++ b/test/webapi/res/config.yml
@@ -4,6 +4,8 @@ DatasetAttribution:
 Datasets:
   - Identifier: demo
     Title: xcube-server Demonstration L2C Cube
+    GroupTitle: Demo
+    Tags: ["demo", "zarr"]
     Path: ../../../examples/serve/demo/cube-1-250-250.zarr
     Variables:
       - "conc_chl"
@@ -17,6 +19,8 @@ Datasets:
 
   - Identifier: demo-1w
     Title: xcube-server Demonstration L3 Cube
+    GroupTitle: Demo
+    Tags: ["demo", "zarr", "computed"]
     FileSystem: memory
     Path: script.py
     Variables:

--- a/xcube/webapi/datasets/config.py
+++ b/xcube/webapi/datasets/config.py
@@ -59,6 +59,8 @@ ACCESS_CONTROL_SCHEMA = JsonObjectSchema(
 
 COMMON_DATASET_PROPERTIES = dict(
     Title=STRING_SCHEMA,
+    GroupTitle=STRING_SCHEMA,
+    Tags=JsonArraySchema(items=STRING_SCHEMA),
     Variables=VARIABLES_SCHEMA,
     TimeSeriesDataset=IDENTIFIER_SCHEMA,
     BoundingBox=GEO_BOUNDING_BOX_SCHEMA,


### PR DESCRIPTION
Server config now allows for specifying a dataset's `GroupTitle` and `Tags`.

Closes #1038

See https://github.com/xcube-dev/xcube-viewer/pull/386

![image](https://github.com/user-attachments/assets/dc80fd4c-3d0f-4014-bcdd-b22e1b52f190)


Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [x] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
