### PR TITLE
Cleanup in module `xcube.core.varexpr`

### DIFF
--- a/test/core/varexpr/test_context.py
+++ b/test/core/varexpr/test_context.py
@@ -52,37 +52,33 @@ BOMB = """
 
 
 class VarExprContextTest(unittest.TestCase):
-    def test_locals(self):
+    def test_names(self):
         ctx = VarExprContext(dataset)
-        # noinspection PyShadowingBuiltins
-        locals = ctx.locals()
-        self.assertIsInstance(locals.get("A"), ExprVar)
-        self.assertIsInstance(locals.get("B"), ExprVar)
-        self.assertIsInstance(locals.get("C"), ExprVar)
+        names = ctx.names()
 
-    def test_globals(self):
-        # noinspection PyShadowingBuiltins
-        globals = VarExprContext.globals()
+        self.assertIsInstance(names.get("A"), ExprVar)
+        self.assertIsInstance(names.get("B"), ExprVar)
+        self.assertIsInstance(names.get("C"), ExprVar)
 
-        self.assertIsInstance(globals.get("nan"), float)
-        self.assertIsInstance(globals.get("inf"), float)
-        self.assertIsInstance(globals.get("e"), float)
-        self.assertIsInstance(globals.get("pi"), float)
+        self.assertIsInstance(names.get("nan"), float)
+        self.assertIsInstance(names.get("inf"), float)
+        self.assertIsInstance(names.get("e"), float)
+        self.assertIsInstance(names.get("pi"), float)
 
-        self.assertTrue(callable(globals.get("where")))
-        self.assertTrue(callable(globals.get("hypot")))
-        self.assertTrue(callable(globals.get("sin")))
-        self.assertTrue(callable(globals.get("cos")))
-        self.assertTrue(callable(globals.get("tan")))
-        self.assertTrue(callable(globals.get("sqrt")))
-        self.assertTrue(callable(globals.get("fmin")))
-        self.assertTrue(callable(globals.get("fmax")))
-        self.assertTrue(callable(globals.get("minimum")))
-        self.assertTrue(callable(globals.get("maximum")))
+        self.assertTrue(callable(names.get("where")))
+        self.assertTrue(callable(names.get("hypot")))
+        self.assertTrue(callable(names.get("sin")))
+        self.assertTrue(callable(names.get("cos")))
+        self.assertTrue(callable(names.get("tan")))
+        self.assertTrue(callable(names.get("sqrt")))
+        self.assertTrue(callable(names.get("fmin")))
+        self.assertTrue(callable(names.get("fmax")))
+        self.assertTrue(callable(names.get("minimum")))
+        self.assertTrue(callable(names.get("maximum")))
 
-        self.assertNotIn("min", globals)
-        self.assertNotIn("max", globals)
-        self.assertNotIn("open", globals)
+        self.assertNotIn("min", names)
+        self.assertNotIn("max", names)
+        self.assertNotIn("open", names)
 
     def test_capabilities(self):
         c_list = VarExprContext.get_constants()
@@ -241,7 +237,7 @@ class VarExprContextTest(unittest.TestCase):
         # This is intentional disintegration
         ev = ExprVar(xr.DataArray(var_a_data, dims=("y", "x")))
         ev.__dict__["_ExprVar__da"] = True
-        ctx._locals["my_ev"] = ev
+        ctx._names["my_ev"] = ev
         with pytest.raises(
             RuntimeError,
             match="internal error: 'DataArray' object expected, but got type 'bool'",

--- a/xcube/core/varexpr/names.py
+++ b/xcube/core/varexpr/names.py
@@ -36,11 +36,10 @@ def get_xarray_funcs() -> dict[str, Callable]:
 
 
 # noinspection PyProtectedMember
-GLOBALS = {
+_GLOBAL_NAMES = {
     **get_constants(),
     **{k: ExprVar._wrap_fn(fn) for k, fn in get_numpy_ufuncs().items()},
     **{k: ExprVar._wrap_fn(fn) for k, fn in get_xarray_funcs().items()},
-    "__builtins__": {},
 }
 
 # noinspection PyProtectedMember

--- a/xcube/core/varexpr/varexpr.py
+++ b/xcube/core/varexpr/varexpr.py
@@ -12,7 +12,6 @@ from xcube.core.varexpr.error import VarExprError
 Names = Mapping[str, Any]
 UnaryFunction = Callable[[Any], Any]
 BinaryFunction = Callable[[Any, Any], Any]
-ComparisonFunction = Callable[[Any, Any], bool]
 
 _UNARY_OPS: Mapping[str, UnaryFunction] = {
     "UAdd": lambda x: +x,
@@ -20,6 +19,7 @@ _UNARY_OPS: Mapping[str, UnaryFunction] = {
     "Invert": lambda x: ~x,
     "Not": lambda x: not x,
 }
+
 _BINARY_OPS: Mapping[str, BinaryFunction] = {
     "Add": lambda x, y: x + y,
     "Sub": lambda x, y: x - y,
@@ -35,7 +35,7 @@ _BINARY_OPS: Mapping[str, BinaryFunction] = {
     "BitOr": lambda x, y: x | y,
 }
 
-_COMPARISON_OPS: Mapping[str, ComparisonFunction] = {
+_COMPARISON_OPS: Mapping[str, BinaryFunction] = {
     "Eq": lambda x, y: x == y,
     "NotEq": lambda x, y: x != y,
     "Lt": lambda x, y: x < y,


### PR DESCRIPTION
Cleanup in module `xcube.core.varexpr`

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `CHANGES.md`~
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
