### PR TITLE
Updated xcube server's dataset configuration extraction methodology

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,13 @@
 * Improved the way color mapping works in xcube server to support simplified
   color bar management in xcube viewer,
   see https://github.com/xcube-dev/xcube-viewer/issues/390. (#1043)  
+* The xcube server's dataset configuration extraction methodology has been updated.
+  When the data resource ID is provided in the Path field, xcube will attempt to
+  access the dataset using the given ID. If wildcard patterns are used, the server
+  will crawl through the data store to find matching data IDs. This process may
+  result in a long setup time if the data store contains numerous data IDs.
+  A UserWarning will be issued for the "stac" data store.
+
 
 ## Changes in 1.6.0
 

--- a/xcube/webapi/datasets/context.py
+++ b/xcube/webapi/datasets/context.py
@@ -393,7 +393,6 @@ class DatasetsContext(ResourcesContext):
                             data_store.get_data_ids(data_type=MULTI_LEVEL_DATASET_TYPE),
                         )
                         for store_dataset_id in store_dataset_ids:
-                            print(store_dataset_id)
                             if fnmatch.fnmatch(store_dataset_id, dataset_id_pattern):
                                 all_dataset_configs.append(
                                     _get_selected_dataset_config(

--- a/xcube/webapi/datasets/context.py
+++ b/xcube/webapi/datasets/context.py
@@ -396,7 +396,7 @@ class DatasetsContext(ResourcesContext):
                             print(store_dataset_id)
                             if fnmatch.fnmatch(store_dataset_id, dataset_id_pattern):
                                 all_dataset_configs.append(
-                                    _get_dataset_config(
+                                    _get_selected_dataset_config(
                                         store_dataset_id,
                                         store_instance_id,
                                         store_dataset_config,
@@ -404,7 +404,7 @@ class DatasetsContext(ResourcesContext):
                                 )
                     else:
                         all_dataset_configs.append(
-                            _get_dataset_config(
+                            _get_selected_dataset_config(
                                 store_dataset_config["Path"],
                                 store_instance_id,
                                 store_dataset_config,
@@ -866,7 +866,7 @@ def _get_common_prefixes(p):
         )
 
 
-def _get_dataset_config(
+def _get_selected_dataset_config(
     store_dataset_id: str, store_instance_id: str, dataset_config_base: dict
 ) -> dict:
     LOG.debug(f"Selected dataset {store_dataset_id!r}")


### PR DESCRIPTION
The xcube server's dataset configuration extraction methodology has been updated. When the data resource ID is provided in the Path field, xcube will attempt to  access the dataset using the given ID. If wildcard patterns are used, the server will crawl through the data store to find matching data IDs. This process may result in a long setup time if the data store contains numerous data IDs. A UserWarning will be issued for the "stac" data store.

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
