### PR TITLE
Renamed internal color mapping types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,11 @@
   color bar management in xcube viewer,
   see https://github.com/xcube-dev/xcube-viewer/issues/390. (#1043)  
 
+### Other changes
+
+* Renamed internal color mapping types from `"node"`, `"bound"`, `"key"` 
+  into `"continuous"`, `"stepwise"`, `"categorical"`.
+
 ## Changes in 1.6.0
 
 ### Enhancements

--- a/test/util/test_cmaps.py
+++ b/test/util/test_cmaps.py
@@ -106,13 +106,13 @@ class ColormapRegistryTest(TestCase):
             '[1, "#00000000"], '
             '[2, "#ff0000aa"], '
             '[5, "#ffffffff"]'
-            '], "type": "key"}'
+            '], "type": "categorical"}'
         )
         self.assertIsInstance(cmap, matplotlib.colors.ListedColormap)
         self.assertIsInstance(cmap(np.linspace(0, 1, 10)), np.ndarray)
         self.assertIsInstance(colormap, Colormap)
         self.assertEqual("ucb783473", colormap.cm_name)
-        self.assertEqual("key", colormap.cm_type)
+        self.assertEqual("categorical", colormap.cm_type)
         self.assertEqual(CUSTOM_CATEGORY.name, colormap.cat_name)
         self.assertEqual([1, 2, 3, 5, 6], colormap.values)
 
@@ -124,13 +124,13 @@ class ColormapRegistryTest(TestCase):
             '[0.0, "#00000000"], '
             '[0.6, "#ff0000aa"], '
             '[1.0, "#ffffffff"]'
-            '], "type": "bound"}'
+            '], "type": "stepwise"}'
         )
         self.assertIsInstance(cmap, matplotlib.colors.LinearSegmentedColormap)
         self.assertIsInstance(cmap(np.linspace(0, 1, 10)), np.ndarray)
         self.assertIsInstance(colormap, Colormap)
         self.assertEqual("ucb783474", colormap.cm_name)
-        self.assertEqual("bound", colormap.cm_type)
+        self.assertEqual("stepwise", colormap.cm_type)
         self.assertEqual(CUSTOM_CATEGORY.name, colormap.cat_name)
         self.assertEqual((0.0, 0.6, 1.0), colormap.values)
 
@@ -148,7 +148,7 @@ class ColormapRegistryTest(TestCase):
         self.assertIsInstance(cmap(np.linspace(0, 1, 10)), np.ndarray)
         self.assertIsInstance(colormap, Colormap)
         self.assertEqual("ucb783475", colormap.cm_name)
-        self.assertEqual("node", colormap.cm_type)
+        self.assertEqual("continuous", colormap.cm_type)
         self.assertEqual(CUSTOM_CATEGORY.name, colormap.cat_name)
         self.assertEqual((0.0, 0.5, 1.0), colormap.values)
 
@@ -160,7 +160,7 @@ class ColormapRegistryTest(TestCase):
         self.assertIsInstance(cmap, matplotlib.colors.LinearSegmentedColormap)
         self.assertIsInstance(colormap, Colormap)
         self.assertEqual("Reds", colormap.cm_name)
-        self.assertEqual("node", colormap.cm_type)
+        self.assertEqual("continuous", colormap.cm_type)
         self.assertEqual("Sequential", colormap.cat_name)
         self.assertIsNone(colormap.values)
 
@@ -306,7 +306,7 @@ class ColormapTest(TestCase):
     def test_names(self):
         self.assertEqual("Diverging", self.colormap.cat_name)
         self.assertEqual("coolwarm", self.colormap.cm_name)
-        self.assertEqual("node", self.colormap.cm_type)
+        self.assertEqual("continuous", self.colormap.cm_type)
 
     def test_cmap(self):
         cmap = self.colormap.cmap

--- a/xcube/core/tile.py
+++ b/xcube/core/tile.py
@@ -502,7 +502,7 @@ def compute_rgba_tile(
 
         with measure_time("Encoding tile as RGBA image"):
             var_tile, value_range = var_tiles[0], value_ranges[0]
-            if colormap.cm_type == "key":
+            if colormap.cm_type == "categorical":
                 assert isinstance(colormap.values, list)
                 norm = matplotlib.colors.BoundaryNorm(
                     colormap.values, ncolors=cmap.N, clip=False


### PR DESCRIPTION
For https://github.com/xcube-dev/xcube-viewer/pull/394.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
