### PR TITLE
A few fixes/updates to AppVeyor/micromamba config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,14 +21,15 @@ for:
     only:
       - image: macos
   install:
-    - curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+    - curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
     - mv bin/micromamba ./micromamba
 -
   matrix:
     only:
       - image: Ubuntu2204
   install:
-    - wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
+    - curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+    - mv bin/micromamba ./micromamba
 
 build_script:
   # Diagnostics
@@ -40,14 +41,14 @@ build_script:
   - ls
 
   # Set up micromamba
-  - ./micromamba shell init -s bash ~/micromamba
+  - ./micromamba shell init -s bash --root-prefix ~/micromamba
   - source ~/.bashrc
   - source ~/.profile
   - hash -r
   - mkdir -p ~/micromamba/pkgs/
   - export MAMBA_ROOT_PREFIX=~/micromamba
   - export MAMBA_EXE=$(pwd)/micromamba
-  - . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
+  - . $MAMBA_ROOT_PREFIX/etc/profile.d/micromamba.sh
 
   # Create environment from build folder environment.yml and install xcube
   - micromamba create --name xc --file $APPVEYOR_BUILD_FOLDER/environment.yml


### PR DESCRIPTION
Closes #1050 .

- Use current official/canonical URLs to fetch micromamba binaries (old ones still work at present, but might break in future).

- Fetch with curl, not wget, on Ubuntu. No change in functionality, but this makes it consistent with the Mac config so easier to understand and maintain.

- Add missing `--root-prefix` parameter to the `micromamba shell` invocation. Previously we used the synonymous `-p` parameter for this, but this will be retired in the upcoming micromamba 2.0 release (see https://mamba.readthedocs.io/en/latest/developer_zone/changes-2.0.html#micromamba ).

- Execute micromamba.sh, not mamba.sh, as the profile set-up script (since the latter is not found).

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~ n/a
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~ n/a
* ~[ ] New/modified features documented in `docs/source/*`~ n/a
* ~[ ] Changes documented in `CHANGES.md`~ n/a
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
