### PR TITLE
Default return value of open geotiffs from mldataset to dataset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,9 +58,9 @@
 * Corrected extent object of a STAC collection issued by xcube server, following the
   [collection STAC specifications](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#extent-object)
   (#1053)
-* When opening a GeoTIFF file, the default return value is changed from
-  `MultiLevelDataset` to `xr.Dataset`, if no `data_type` is assigned
-  in the `open_params`. (#1054) 
+* When opening a GeoTIFF file using a file system data store, the default return value 
+  is changed from `MultiLevelDataset` to `xr.Dataset`, if no `data_type` is assigned
+  in the `open_params` of the `store.open_data()` method. (#1054) 
 
 ### Other changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,9 @@
 * Corrected extent object of a STAC collection issued by xcube server, following the
   [collection STAC specifications](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#extent-object)
   (#1053)
+* When opening a GeoTIFF file, the default return value is changed from
+  `MultiLevelDataset` to `xr.Dataset`, if no `data_type` is assigned
+  in the `open_params`. (#1054) 
 
 ### Other changes
 

--- a/environment.yml
+++ b/environment.yml
@@ -40,7 +40,7 @@ dependencies:
   - shapely >=1.6
   - tornado >=6.0
   - urllib3 >=1.26
-  - xarray >=2022.6
+  - xarray >=2022.6, <=2024.6
   - zarr >=2.11
   # Testing
   - flake8 >=3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
   "shapely>=1.6",
   "tornado>=6.0",
   "urllib3>=1.26",
-  "xarray>=2022.6",
+  "xarray>=2022.6,<=2024.6",
   "zarr>=2.11"
 ]
 classifiers = [

--- a/rtd-environment.yml
+++ b/rtd-environment.yml
@@ -43,7 +43,7 @@ dependencies:
   - tornado >=6.0
   - urllib3 >=1.26
   - werkzeug <2.2  # >=2.2 slows down S3 tests (deps: moto->flask->werkzeug)
-  - xarray >=2022.6
+  - xarray >=2022.6, <= 2024.6
   - zarr >=2.11
   # Required by Coiled
   # These are very likely transitive deps anyway

--- a/test/core/store/test_store.py
+++ b/test/core/store/test_store.py
@@ -45,6 +45,19 @@ class ListDataStoreTest(unittest.TestCase):
         )
 
 
+class TestBaseFsDataStore(unittest.TestCase):
+
+    def test_get_data_opener_ids(self):
+        store = new_data_store("file")
+        self.assertEqual(
+            ("dataset:geotiff:file",), store.get_data_opener_ids(data_id="test.geotiff")
+        )
+        self.assertEqual(
+            ("mldataset:geotiff:file",),
+            store.get_data_opener_ids(data_id="test.geotiff", data_type="mldataset"),
+        )
+
+
 def test_fsspec_instantiation_error():
     error_string = "deliberate instantiation error for testing"
     register_implementation(

--- a/xcube/core/store/fs/store.py
+++ b/xcube/core/store/fs/store.py
@@ -80,7 +80,7 @@ _FORMAT_TO_DATA_TYPE_ALIASES = {
     "zarr": (DATASET_TYPE.alias,),
     "netcdf": (DATASET_TYPE.alias,),
     "levels": (MULTI_LEVEL_DATASET_TYPE.alias, DATASET_TYPE.alias),
-    "geotiff": (MULTI_LEVEL_DATASET_TYPE.alias, DATASET_TYPE.alias),
+    "geotiff": (DATASET_TYPE.alias, MULTI_LEVEL_DATASET_TYPE.alias),
     "geojson": (GEO_DATA_FRAME_TYPE.alias,),
     "shapefile": (GEO_DATA_FRAME_TYPE.alias,),
 }


### PR DESCRIPTION
When opening a GeoTIFF file, the default return value is changed from `MultiLevelDataset` to `xr.Dataset`, if no `data_type` is assigned in the `open_params`.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
