### PR TITLE
Force xcube Server to open multi-level datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,9 +35,10 @@
 * The `open_data` method of xcube's default `xcube.core.store.DataStore` implementations
   now supports a keyword argument `data_type`, which determines the
   data type of the return value. Note that `opener_id` includes the `data_type`
-  at its first position and will override the `date_type` argument.
+  at its first position and will override the `data_type` argument.
   To preserve backward compatibility, the keyword argument `data_type`
-  has not yet been added to the `open_data()` method arguments. (#1030)
+  has not yet been literally specified as `open_data()` method argument,
+  but may be passed as part of `**open_params`. (#1030)
 * The `xcube.core.store.DataDescriptor` class now supports specifying time ranges
   using both `datetime.date` and `datetime.datetime` objects. Previously,
   only `datetime.date` objects were supported.
@@ -60,7 +61,9 @@
   (#1053)
 * When opening a GeoTIFF file using a file system data store, the default return value 
   is changed from `MultiLevelDataset` to `xr.Dataset`, if no `data_type` is assigned
-  in the `open_params` of the `store.open_data()` method. (#1054) 
+  in the `open_params` of the `store.open_data()` method. (#1054)
+  xcube server has been adapted to always open `MultiLevelDataset`s from
+  a specified data store, if that data type is supported.
 
 ### Other changes
 

--- a/test/core/store/fs/test_plugin.py
+++ b/test/core/store/fs/test_plugin.py
@@ -11,6 +11,7 @@ from xcube.core.store import find_data_opener_extensions
 from xcube.core.store import find_data_store_extensions
 from xcube.core.store import find_data_writer_extensions
 from xcube.util.jsonschema import JsonObjectSchema
+from xcube.util.jsonschema import JsonStringSchema
 
 expected_fs_data_accessor_ids: set = {
     "dataset:netcdf:file",
@@ -60,6 +61,7 @@ class FsDataStoreAndAccessorsPluginTest(unittest.TestCase):
             params_schema = data_store.get_data_store_params_schema()
             self.assertParamsSchemaIncludesFsParams(params_schema)
             params_schema = data_store.get_open_data_params_schema()
+            self.assertParamsSchemaIncludesDataTypeParam(params_schema)
             self.assertParamsSchemaExcludesFsParams(params_schema)
             params_schema = data_store.get_delete_data_params_schema()
             self.assertParamsSchemaExcludesFsParams(params_schema)
@@ -69,9 +71,7 @@ class FsDataStoreAndAccessorsPluginTest(unittest.TestCase):
     def test_find_data_opener_extensions(self):
         extensions = find_data_opener_extensions()
         self.assertTrue(len(extensions) >= len(expected_fs_data_accessor_ids))
-        self.assertEqual(
-            {"xcube.core.store.opener"}, {ext.point for ext in extensions}
-        )
+        self.assertEqual({"xcube.core.store.opener"}, {ext.point for ext in extensions})
         self.assertTrue(
             expected_fs_data_accessor_ids.issubset({ext.name for ext in extensions})
         )
@@ -88,9 +88,7 @@ class FsDataStoreAndAccessorsPluginTest(unittest.TestCase):
     def test_find_data_writer_extensions(self):
         extensions = find_data_writer_extensions()
         self.assertTrue(len(extensions) >= len(expected_fs_data_accessor_ids))
-        self.assertEqual(
-            {"xcube.core.store.writer"}, {ext.point for ext in extensions}
-        )
+        self.assertEqual({"xcube.core.store.writer"}, {ext.point for ext in extensions})
         self.assertTrue(
             expected_fs_data_accessor_ids.issubset({ext.name for ext in extensions})
         )
@@ -105,6 +103,13 @@ class FsDataStoreAndAccessorsPluginTest(unittest.TestCase):
             self.assertParamsSchemaIncludesFsParams(params_schema)
             params_schema = data_writer.get_delete_data_params_schema()
             self.assertParamsSchemaIncludesFsParams(params_schema)
+
+    def assertParamsSchemaIncludesDataTypeParam(self, params_schema):
+        # print(params_schema.to_dict())
+        self.assertIsInstance(params_schema, JsonObjectSchema)
+        self.assertIsInstance(params_schema.properties, dict)
+        self.assertIn("data_type", params_schema.properties)
+        self.assertIsInstance(params_schema.properties["data_type"], JsonStringSchema)
 
     def assertParamsSchemaIncludesFsParams(self, params_schema):
         # print(params_schema.to_dict())

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -415,8 +415,7 @@ class FsDataStoresTestMixin(ABC):
         )
 
         with pytest.raises(
-            DataStoreError,
-            match=f'Data resource "{data_id}"' f" does not exist in store",
+            DataStoreError, match=f'Data resource "{data_id}" does not exist in store'
         ):
             data_store.get_data_types_for_data(data_id)
         self.assertEqual(False, data_store.has_data(data_id))


### PR DESCRIPTION
- Changed xcube Server impl. to force opening multi-level datasets.
- Added schema for "data_type" parameter fro all filesystem data stores

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
