### PR TITLE
labels added, custom cmaps added also if they are not in styles

### DIFF
--- a/docs/source/cli/xcube_serve.rst
+++ b/docs/source/cli/xcube_serve.rst
@@ -650,20 +650,12 @@ Both, reversed and alpha blending is possible as well and can be configured by n
             ColorBar: plasma_r_alpha
             ValueRange: [0., 24.]
 
-Colormaps may be user-defined within the configuration file. One example is shown below.
-
-
-.. code-block:: yaml
-
-    Styles:
-      - Identifier: default
-        ColorMappings:
-          conc_chl:
-            CustomColorBar: my_cmap
-
-The colormap `my_cmap` can then be configured in section
-`customcolormaps`_.
-
+Colormaps may be user-defined within the configuration file, which can be configured
+in section `customcolormaps`_. The colormap can be selected by setting
+`ColorBar: my_cmap`, where `my_cmap` is the identifier of the custom defined color map.
+If the `ValueRange` is given, it overwrites the value range defined in
+`CustomColorMaps` if the color map type is continuous or stepwise, and it is ignored
+if the color map type is categorical, where a warning is raised.
 
 .. _customcolormaps:
 
@@ -738,6 +730,10 @@ For example *CustomColorMaps* can look like this:
           - [ 0, [0, 1, 0., 0.5], low_risk]
           - [ 1, orange, medium_risk]
           - [ 2, [1, 0, 0], high_risk]
+
+All colormaps defined in the `CustomColorMaps` section will be available in the xcube
+Viewer, even if they haven't been selected in the Styles section for a specific data
+variable.
 
 .. _example:
 

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -161,9 +161,10 @@ Styles:
   - Identifier: default
     ColorMappings:
       conc_chl:
-        CustomColorBar: my_cmap
+        ColorBar: my_cmap
+        ValueRange: [0., 20.] # this value range overwrites the range defined in CustomColorMaps
       chl_category:
-        CustomColorBar: cmap_bloom_risk
+        ColorBar: cmap_bloom_risk
       conc_tsm:
         ColorFile: cc_tsm.cpd
       kd489:
@@ -220,9 +221,24 @@ CustomColorMaps:
   - Identifier: cmap_bloom_risk
     Type: categorical
     Colors:
-      - [ 0, [0, 1, 0., 0.5], low_risk]
-      - [ 1, orange, medium_risk]
-      - [ 2, [1, 0, 0], high_risk]
+      - [ 0, [0, 1, 0., 0.5]]
+      - [ 1, orange]
+      - [ 2, [1, 0, 0]]
+  - Identifier: s2_l2_scl
+    Type: categorical
+    Colors:
+      - [ 0, red,     no data]
+      - [ 1, yellow,  defective]
+      - [ 2, black,   dark area pixels]
+      - [ 3, gray,    cloud shadows]
+      - [ 4, green,   vegetation]
+      - [ 5, tan,     bare soils]
+      - [ 6, blue,    water]
+      - [ 7, "#aaaabb", clouds low prob ]
+      - [ 8, "#bbbbcc", clouds medium prob]
+      - [ 9, "#ccccdd", clouds high prob]
+      - [10, "#ddddee", cirrus]
+      - [11, "#ffffff", snow or ice]
 
 ServiceProvider:
   ProviderName: Brockmann Consult GmbH

--- a/test/util/test_cmaps.py
+++ b/test/util/test_cmaps.py
@@ -402,8 +402,11 @@ class ColormapConfigTest(TestCase):
             {
                 "name": "my_cmap",
                 "type": "continuous",
-                "colors": [[0.0, "red"], [12.0, "#0000FF"], [24.0, [0, 1, 0, 0.3]]],
-                "labels": ["low", "medium", "high"],
+                "colors": [
+                    [0.0, "red", "low"],
+                    [12.0, "#0000FF", "medium"],
+                    [24.0, [0, 1, 0, 0.3], "high"],
+                ],
             },
             config_parse,
         )
@@ -431,8 +434,11 @@ class ColormapConfigTest(TestCase):
             {
                 "name": "my_cmap",
                 "type": "categorical",
-                "colors": [[0.0, "red"], [1.0, "#0000FF"], [2.0, [0, 1, 0]]],
-                "labels": ["low", "", "high"],
+                "colors": [
+                    [0.0, "red", "low"],
+                    [1.0, "#0000FF"],
+                    [2.0, [0, 1, 0], "high"],
+                ],
             },
             config_parse,
         )

--- a/test/util/test_cmaps.py
+++ b/test/util/test_cmaps.py
@@ -403,6 +403,7 @@ class ColormapConfigTest(TestCase):
                 "name": "my_cmap",
                 "type": "continuous",
                 "colors": [[0.0, "red"], [12.0, "#0000FF"], [24.0, [0, 1, 0, 0.3]]],
+                "labels": ["low", "medium", "high"],
             },
             config_parse,
         )
@@ -413,7 +414,7 @@ class ColormapConfigTest(TestCase):
             Type="categorical",
             Colors=[
                 [0, "red", "low"],
-                [1, "#0000FF", "medium"],
+                [1, "#0000FF"],
                 [2, [0, 1, 0], "high"],
             ],
         )
@@ -431,6 +432,7 @@ class ColormapConfigTest(TestCase):
                 "name": "my_cmap",
                 "type": "categorical",
                 "colors": [[0.0, "red"], [1.0, "#0000FF"], [2.0, [0, 1, 0]]],
+                "labels": ["low", "", "high"],
             },
             config_parse,
         )

--- a/test/webapi/datasets/test_context.py
+++ b/test/webapi/datasets/test_context.py
@@ -153,23 +153,32 @@ class DatasetsContextTest(unittest.TestCase):
         self.assertNotIn("demo2", ctx.dataset_cache)
 
     def test_get_color_mappings(self):
-        ctx = get_datasets_ctx()
+        with self.assertLogs("xcube", level="WARNING") as cm:
+            ctx = get_datasets_ctx()
+        self.assertEqual(
+            cm.output,
+            [
+                "WARNING:xcube:Custom color map 'cmap_bloom_risk' is categorical. "
+                "ValueRange is ignored."
+            ],
+        )
         color_mapping = ctx.get_color_mappings("demo-1w")
         self.assertEqual(
             {
-                "conc_chl": {"ColorBar": "my_cmap", "ValueRange": (0.0, 24.0)},
-                "conc_tsm": {"ColorBar": "cmap_cat", "ValueRange": (0.0, 3.0)},
+                "conc_chl": {"ColorBar": "my_cmap", "ValueRange": [0.0, 20.0]},
+                "conc_tsm": {"ColorBar": "cmap_bloom_risk", "ValueRange": [0.0, 3.0]},
                 "kd489": {"ColorBar": "jet", "ValueRange": [0.0, 6.0]},
             },
             color_mapping,
         )
+        self.assertIn("s2_l2_scl", ctx.colormap_registry.colormaps)
 
     def test_get_color_mapping(self):
         ctx = get_datasets_ctx()
         cm = ctx.get_color_mapping("demo", "conc_chl")
-        self.assertEqual(("my_cmap", "lin", (0.0, 24.0)), cm)
+        self.assertEqual(("my_cmap", "lin", (0.0, 20.0)), cm)
         cm = ctx.get_color_mapping("demo", "conc_tsm")
-        self.assertEqual(("cmap_cat", "lin", (0.0, 3.0)), cm)
+        self.assertEqual(("cmap_bloom_risk", "lin", (0.0, 3.0)), cm)
         cm = ctx.get_color_mapping("demo", "kd489")
         self.assertEqual(("jet", "lin", (0.0, 6.0)), cm)
         with self.assertRaises(ApiError.NotFound):

--- a/test/webapi/res/config.yml
+++ b/test/webapi/res/config.yml
@@ -49,9 +49,11 @@ Styles:
   - Identifier: default
     ColorMappings:
       conc_chl:
-        CustomColorBar: my_cmap
+        ColorBar: my_cmap
+        ValueRange: [0., 20.]
       conc_tsm:
-        CustomColorBar: cmap_cat
+        ColorBar: cmap_bloom_risk
+        ValueRange: [0., 1.]
       kd489:
         ColorBar: jet
         ValueRange: [0., 6.]
@@ -72,12 +74,28 @@ CustomColorMaps:
       - Value: 24
         Color: [0, 1, 0, 0.3]
         Label: high
-  - Identifier: cmap_cat
+  - Identifier: cmap_bloom_risk
     Type: categorical
     Colors:
       - [ 0, [0, 1, 0., 0.5]]
       - [ 1, orange]
       - [ 2, [1, 0, 0]]
+  - Identifier: s2_l2_scl
+    Type: categorical
+    Colors:
+      - [ 0, red,     no data]
+      - [ 1, yellow,  defective]
+      - [ 2, black,   dark area pixels]
+      - [ 3, gray,    cloud shadows]
+      - [ 4, green,   vegetation]
+      - [ 5, tan,     bare soils]
+      - [ 6, blue,    water]
+      - [ 7, "#aaaabb", clouds low prob ]
+      - [ 8, "#bbbbcc", clouds medium prob]
+      - [ 9, "#ccccdd", clouds high prob]
+      - [10, "#ddddee", cirrus]
+      - [11, "#ffffff", snow or ice]
+      - [11, "#ffffff", snow or ice]
 
 Viewer:
   Configuration:

--- a/xcube/util/cmaps.py
+++ b/xcube/util/cmaps.py
@@ -640,18 +640,25 @@ def create_colormap_from_config(cmap_config: dict) -> Colormap:
         if isinstance(color, list):
             colors.append(color[:2])
             if len(color) == 3:
-                labels.append(labels)
+                labels.append(color[2])
+            else:
+                labels.append("")
         else:
             colors.append([color["Value"], color["Color"]])
             if "Label" in color:
                 labels.append(color["Label"])
+            else:
+                labels.append("")
 
     for i, [_, color] in enumerate(colors):
         if isinstance(color, list):
             if any([val > 1 for val in color]):
                 colors[i][1] = list(np.array(color) / 255)
     config_parse = dict(
-        name=cmap_config["Identifier"], type=cmap_config["Type"], colors=colors
+        name=cmap_config["Identifier"],
+        type=cmap_config["Type"],
+        colors=colors,
+        labels=labels,
     )
     _, cmap = registry.get_cmap(json.dumps(config_parse))
     return cmap, config_parse

--- a/xcube/webapi/datasets/config.py
+++ b/xcube/webapi/datasets/config.py
@@ -120,7 +120,7 @@ DATA_STORE_SCHEMA = JsonObjectSchema(
 
 COLOR_MAPPING_EXPLICIT_SCHEMA = JsonObjectSchema(
     properties=dict(ColorBar=STRING_SCHEMA, ValueRange=VALUE_RANGE_SCHEMA),
-    required=[],
+    required=["ColorBar"],
     additional_properties=False,
 )
 
@@ -134,21 +134,11 @@ COLOR_MAPPING_BY_PATH_SCHEMA = JsonObjectSchema(
     additional_properties=False,
 )
 
-COLOR_MAPPING_BY_CUSTOM_CONFIG = JsonObjectSchema(
-    properties=dict(
-        CustomColorBar=STRING_SCHEMA,
-    ),
-    required=[
-        "CustomColorBar",
-    ],
-    additional_properties=False,
-)
 
 COLOR_MAPPING_SCHEMA = JsonComplexSchema(
     one_of=[
         COLOR_MAPPING_EXPLICIT_SCHEMA,
         COLOR_MAPPING_BY_PATH_SCHEMA,
-        COLOR_MAPPING_BY_CUSTOM_CONFIG,
     ]
 )
 


### PR DESCRIPTION
Closes #1046 second part; see [discussion comment and comments below](https://github.com/xcube-dev/xcube/issues/1046#issuecomment-2273583595)

`CHANGES.md` will not be updated, as it is already updated in #1055.  

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [x] New/modified features documented in `docs/source/*`
* [ ] ~Changes documented in `CHANGES.md`~
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
