### PR TITLE
Bug fix of xcube server config colormaps schema 

### DIFF
--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -168,7 +168,6 @@ Styles:
       conc_tsm:
         ColorFile: cc_tsm.cpd
       kd489:
-        ColorBar: jet
         ValueRange: [0., 6.]
       rgb:
         Red:

--- a/xcube/webapi/datasets/config.py
+++ b/xcube/webapi/datasets/config.py
@@ -120,7 +120,7 @@ DATA_STORE_SCHEMA = JsonObjectSchema(
 
 COLOR_MAPPING_EXPLICIT_SCHEMA = JsonObjectSchema(
     properties=dict(ColorBar=STRING_SCHEMA, ValueRange=VALUE_RANGE_SCHEMA),
-    required=["ColorBar"],
+    required=[],
     additional_properties=False,
 )
 
@@ -133,7 +133,6 @@ COLOR_MAPPING_BY_PATH_SCHEMA = JsonObjectSchema(
     ],
     additional_properties=False,
 )
-
 
 COLOR_MAPPING_SCHEMA = JsonComplexSchema(
     one_of=[


### PR DESCRIPTION
This PR resolves a bug in the xcube server configuration related to the colormaps schema. In PR #1057, the `ColorBar` field within the `Styles` section of the config was incorrectly set as a required field. To ensure backward compatibility, this PR removes the `ColorBar` field from the list of required fields.

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `CHANGES.md`~
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
