### PR TITLE
Initial POC implementation of OpenTelemetry

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -42,6 +42,11 @@ dependencies:
   - urllib3 >=1.26
   - xarray >=2022.6, <=2024.6
   - zarr >=2.11
+  # Observability
+  - opentelemetry-api
+  - opentelemetry-sdk
+  - opentelemetry-instrumentation-tornado
+  - opentelemetry-exporter-otlp-proto-grpc
   # Testing
   - flake8 >=3.7
   - kerchunk

--- a/xcube/cli/serve.py
+++ b/xcube/cli/serve.py
@@ -18,6 +18,7 @@ from xcube.constants import (
     DEFAULT_SERVER_PORT,
     DEFAULT_SERVER_ADDRESS,
 )
+from xcube.webapi.common.telemetry import tracer
 
 assets_to_show = ["apis", "endpoints", "openapi", "config", "configschema"]
 
@@ -134,6 +135,7 @@ assets_to_show_choices.extend([a + ".json" for a in assets_to_show])
 @cli_option_quiet
 @cli_option_verbosity
 @click.argument("paths", metavar="[PATHS...]", nargs=-1)
+@tracer.start_as_current_span("serve")
 def serve(
     framework_name: str,
     port: int,

--- a/xcube/server/webservers/tornado.py
+++ b/xcube/server/webservers/tornado.py
@@ -15,6 +15,7 @@ import tornado.escape
 import tornado.httputil
 import tornado.ioloop
 import tornado.web
+from opentelemetry.instrumentation.tornado import TornadoInstrumentor
 
 from xcube.constants import LOG
 from xcube.constants import LOG_LEVEL_DETAIL
@@ -39,6 +40,7 @@ from xcube.util.jsonschema import JsonStringSchema
 from xcube.version import version
 
 SERVER_CTX_ATTR_NAME = "__xcube_server_ctx"
+TornadoInstrumentor().instrument()
 
 
 class TornadoFramework(Framework):
@@ -124,16 +126,18 @@ class TornadoFramework(Framework):
         handlers = []
 
         for api_route in api_routes:
-            handlers.append((
-                url_prefix + self.path_to_pattern(api_route.path)
-                + ("/?" if api_route.slash else ""),
-                TornadoRequestHandler,
-                {"api_route": api_route},
-            ))
+            handlers.append(
+                (
+                    url_prefix
+                    + self.path_to_pattern(api_route.path)
+                    + ("/?" if api_route.slash else ""),
+                    TornadoRequestHandler,
+                    {"api_route": api_route},
+                )
+            )
             LOG.log(
                 LOG_LEVEL_DETAIL,
-                f"Added route {api_route.path!r}"
-                f" from API {api_route.api_name!r}",
+                f"Added route {api_route.path!r}" f" from API {api_route.api_name!r}",
             )
 
         if handlers:

--- a/xcube/webapi/common/telemetry.py
+++ b/xcube/webapi/common/telemetry.py
@@ -1,0 +1,29 @@
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+otel_config = {
+    "exporter_otlp_endpoint": "http://localhost:4317",
+    "exporter_otlp_insecure": True,
+}
+
+otlp_trace_exporter = OTLPSpanExporter(
+    endpoint=otel_config["exporter_otlp_endpoint"],
+    insecure=otel_config["exporter_otlp_insecure"],
+)
+
+# Observability Initialization
+provider = TracerProvider()
+processor = BatchSpanProcessor(otlp_trace_exporter)
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer("xcube.observability")
+
+
+def set_attributes(*attrs):
+    span = trace.get_current_span()
+    combined = {}
+    for attr in attrs:
+        combined.update(attr)
+    span.set_attributes(combined)

--- a/xcube/webapi/datasets/controllers.py
+++ b/xcube/webapi/datasets/controllers.py
@@ -30,6 +30,7 @@ from .authutil import assert_scopes
 from .authutil import check_scopes
 from .context import DatasetConfig
 from .context import DatasetsContext
+from ..common.telemetry import tracer
 from ..places.controllers import GeoJsonFeatureCollection
 from ..places.controllers import find_places
 
@@ -494,6 +495,7 @@ def get_dataset_coordinates(ctx: DatasetsContext, ds_id: str, dim_name: str) -> 
 
 
 # noinspection PyUnusedLocal
+@tracer.start_as_current_span("get_color_bars.test")
 def get_color_bars(ctx: DatasetsContext, mime_type: str) -> str:
     cmaps = ctx.colormap_registry.to_json()
     if mime_type == "application/json":

--- a/xcube/webapi/datasets/routes.py
+++ b/xcube/webapi/datasets/routes.py
@@ -15,6 +15,7 @@ from .controllers import get_dataset_coordinates
 from .controllers import get_dataset_place_group
 from .controllers import get_datasets
 from .controllers import get_legend
+from ..common.telemetry import tracer
 from ..places import PATH_PARAM_PLACE_GROUP_ID
 
 PATH_PARAM_DATASET_ID = {
@@ -264,6 +265,7 @@ class StylesColorBarsHandler(ApiHandler):
         summary="Get available color bars.",
         tags=["styles"],
     )
+    @tracer.start_as_current_span("colorbars.test")
     def get(self):
         response = get_color_bars(self.ctx, "application/json")
         self.response.finish(response)


### PR DESCRIPTION
This is a test PR that implements the initial POC implementation of OpenTelemetry to get observability insights into the xcube server.

**Opentelemetry** (OT) is used to extract the traces. In production, it is recommended to use a Collector (a concept from OT) but for this POC, we can directly send the data to the backend (Jaeger in this case).
**Jaeger** is a docker container (for development purposes) that collects these traces and displays them in an UI

Reference links:
[OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/)
[Jaeger](https://www.jaegertracing.io/)
[Youtube-OT Basics](https://www.youtube.com/watch?v=iVQmhMLEkS0&t=0s)

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
