### PR TITLE
Adjustments to `resample_in_time()` so that xcube now supports `xarray=2024.7`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+out.yml
 *.cover
 .hypothesis/
 .pytest_cache/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,8 @@
   in the `open_params` of the `store.open_data()` method. (#1054)
   xcube server has been adapted to always open `MultiLevelDataset`s from
   a specified data store, if that data type is supported.
+* Adjustments to `resample_in_time()` in `xcube/core/resampling/temporal.py`
+  so that xcube now supports `xarray=2024.7`.
 
 ### Other changes
 

--- a/environment.yml
+++ b/environment.yml
@@ -40,7 +40,7 @@ dependencies:
   - shapely >=1.6
   - tornado >=6.0
   - urllib3 >=1.26
-  - xarray >=2022.6, <=2024.6
+  - xarray >=2022.6
   - zarr >=2.11
   # Testing
   - flake8 >=3.7

--- a/xcube/core/resampling/temporal.py
+++ b/xcube/core/resampling/temporal.py
@@ -80,7 +80,7 @@ def resample_in_time(
         dataset = select_variables_subset(dataset, var_names)
 
     resampler = dataset.resample(
-        skipna=True, closed="left", label="left", time=frequency, loffset=offset
+        skipna=True, closed="left", label="left", time=frequency, offset=offset
     )
 
     if isinstance(method, str):


### PR DESCRIPTION
Adjustments to `resample_in_time()` in `xcube/core/resampling/temporal.py` so that xcube now supports `xarray=2024.7`.

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
