### PR TITLE
Initial commit for making time optional in xcube server

### DIFF
--- a/xcube/webapi/statistics/controllers.py
+++ b/xcube/webapi/statistics/controllers.py
@@ -47,10 +47,12 @@ def _compute_statistics(
     dataset = ml_dataset.get_dataset(0)
     grid_mapping = ml_dataset.grid_mapping
 
-    try:
-        time = np.array(time_label, dtype=dataset.time.dtype)
-    except (TypeError, ValueError) as e:
-        raise ApiError.BadRequest("Invalid 'time'") from e
+    time = None
+    if time_label:
+        try:
+            time = np.array(time_label, dtype=dataset.time.dtype)
+        except (TypeError, ValueError) as e:
+            raise ApiError.BadRequest("Invalid 'time'") from e
 
     if isinstance(geometry, tuple):
         compact_mode = True
@@ -64,7 +66,10 @@ def _compute_statistics(
 
     nan_result = NAN_RESULT_COMPACT if compact_mode else NAN_RESULT
 
-    dataset = dataset.sel(time=time, method="nearest")
+    if time_label:
+        dataset = dataset.sel(time=time, method="nearest")
+    else:
+        dataset = dataset.sel(method="nearest")
 
     x_name, y_name = grid_mapping.xy_dim_names
     if isinstance(geometry, shapely.geometry.Point):

--- a/xcube/webapi/statistics/routes.py
+++ b/xcube/webapi/statistics/routes.py
@@ -30,7 +30,7 @@ QUERY_PARAM_TIME = {
     "name": "time",
     "in": "query",
     "description": 'Timestamp using format "YYYY-MM-DD hh:mm:ss"',
-    "required": True,
+    "required": False,
     "schema": {"type": "string", "format": "datetime"},
 }
 
@@ -54,7 +54,7 @@ class StatisticsHandler(ApiHandler[StatisticsContext]):
     async def get(self, datasetId: str, varName: str):
         lon = self.request.get_query_arg("lon", type=float, default=UNDEFINED)
         lat = self.request.get_query_arg("lat", type=float, default=UNDEFINED)
-        time = self.request.get_query_arg("time", type=str, default=UNDEFINED)
+        time = self.request.get_query_arg("time", type=str, default=None)
         trace_perf = self.request.get_query_arg(
             "debug", default=self.ctx.datasets_ctx.trace_perf
         )
@@ -89,7 +89,7 @@ class StatisticsHandler(ApiHandler[StatisticsContext]):
         ],
     )
     async def post(self, datasetId: str, varName: str):
-        time = self.request.get_query_arg("time", type=str, default=UNDEFINED)
+        time = self.request.get_query_arg("time", type=str, default=None)
         trace_perf = self.request.get_query_arg(
             "debug", default=self.ctx.datasets_ctx.trace_perf
         )


### PR DESCRIPTION
This PR makes the time dimension optional for calculating the stats of datasets that do not contain any time dimension. Please have a look at the issue for more details.

[Issue Link](https://github.com/xcube-dev/xcube/issues/1066)

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
