### PR TITLE
xarray dependency adjusted in pyproject.toml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
   - tabulate >=0.9
   - tornado >=6.0
   - urllib3 >=1.26
-  - xarray >=2022.6
+  - xarray >=2024.7
   - zarr >=2.11
   # Chartlets
   - altair

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
   "tabulate>=0.9",
   "tornado>=6.0",
   "urllib3>=1.26",
-  "xarray>=2022.6,<=2024.6",
+  "xarray>=2022.6",
   "zarr>=2.11"
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
   "tabulate>=0.9",
   "tornado>=6.0",
   "urllib3>=1.26",
-  "xarray>=2022.6",
+  "xarray>=2024.7",
   "zarr>=2.11"
 ]
 classifiers = [


### PR DESCRIPTION
Fixes https://github.com/xcube-dev/xcube/issues/1094

In #1068 xcube has been adjusted so that it is complient to `xarray >=2024.6`. However, I forgot to adjust `pyproject.toml`.

Note that `xarray.core.resample.DataArrayResample.quantile` now allows dask arrays. Therefore, the test in `resample_in_time` was adjusted. This is related to the new feature in xarray 2024.7 (https://docs.xarray.dev/en/stable/whats-new.html#id40) and the PR https://github.com/pydata/xarray/pull/9109.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `CHANGES.md`~
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
