### PR TITLE
Fix typos in TestThreadedProgressObservers tests

### DIFF
--- a/test/core/gen2/test_progress.py
+++ b/test/core/gen2/test_progress.py
@@ -112,7 +112,7 @@ class TestThreadedProgressObservers(unittest.TestCase):
 
         observer.on_begin([state_stack])
         self.assertTrue(_mock.called)
-        _mock.stop()
+        _mock_patch.stop()
 
         _mock = _mock_patch.start()
         state_stack1 = ProgressState("Test", 100, 100)
@@ -134,7 +134,7 @@ class TestThreadedProgressObservers(unittest.TestCase):
 
         observer.on_end([state_stack])
         self.assertTrue(_mock.called)
-        _mock.stop()
+        _mock_patch.stop()
 
         _mock = _mock_patch.start()
         state_stack1 = ProgressState("Test", 100, 100)


### PR DESCRIPTION
test_threaded_progress_on_begin and test_threaded_progress_on_end were calling stop() on _patch rather than _mock_patch(), producing an error on the subsequent _mock_patch.start() (since it was already started, and hadn't been stopped). Corrected in this commit.

Fixes #1104

[Description of PR]

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
