### PR TITLE
Suppress no ext config error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Changes in 1.8.2 (in development)
+
+* No longer logging a `TypeError` if xcube server's 
+  `GET viewer/ext/contributions` is called without any 
+  viewer extensions configured. (#1116)
+
 ## Changes in 1.8.1
 
 ### Fixes

--- a/test/webapi/viewer/test_routes.py
+++ b/test/webapi/viewer/test_routes.py
@@ -137,6 +137,51 @@ class ViewerExtRoutesTest(RoutesTestCase):
         self.assertEqual({"result": expected_callback_result}, result)
 
 
+class ViewerExtRoutesWithDefaultConfigTest(RoutesTestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.maxDiff = None
+
+    def test_viewer_ext_contributions(self):
+        response = self.fetch("/viewer/ext/contributions")
+        self.assertResourceNotFoundResponse(response)
+
+    def test_viewer_ext_layout(self):
+        response = self.fetch(
+            "/viewer/ext/layout/panels/0",
+            method="POST",
+            body={
+                "inputValues": [
+                    "",  # dataset_id
+                ]
+            },
+        )
+        self.assertResourceNotFoundResponse(response)
+
+    def test_viewer_ext_callback(self):
+        response = self.fetch(
+            "/viewer/ext/callback",
+            method="POST",
+            body={
+                "callbackRequests": [
+                    {
+                        "contribPoint": "panels",
+                        "contribIndex": 0,
+                        "callbackIndex": 0,
+                        "inputValues": [
+                            "",  # dataset_id
+                            True,  # opaque
+                            1,  # color
+                            "",  # info_text
+                        ],
+                    }
+                ]
+            },
+        )
+        self.assertResourceNotFoundResponse(response)
+
+
 expected_callback_result = [
     {
         "contribIndex": 0,

--- a/xcube/version.py
+++ b/xcube/version.py
@@ -2,4 +2,4 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-version = "1.8.1"
+version = "1.8.2.dev0"

--- a/xcube/webapi/viewer/routes.py
+++ b/xcube/webapi/viewer/routes.py
@@ -163,17 +163,31 @@ class ViewerStateHandler(ApiHandler[ViewerContext]):
 
 class ViewerExtHandler(ApiHandler[ViewerContext]):
     def do_get_contributions(self):
-        self._write_response(get_contributions(self.ctx.ext_ctx))
+        if self.ctx.ext_ctx is None:
+            self._write_no_ext_status()
+        else:
+            self._write_response(get_contributions(self.ctx.ext_ctx))
 
     def do_get_layout(self, contrib_point: str, contrib_index: str):
-        self._write_response(
-            get_layout(
-                self.ctx.ext_ctx, contrib_point, int(contrib_index), self.request.json
+        if self.ctx.ext_ctx is None:
+            self._write_no_ext_status()
+        else:
+            self._write_response(
+                get_layout(
+                    self.ctx.ext_ctx,
+                    contrib_point,
+                    int(contrib_index),
+                    self.request.json,
+                )
             )
-        )
 
     def do_get_callback_results(self):
-        self._write_response(get_callback_results(self.ctx.ext_ctx, self.request.json))
+        if self.ctx.ext_ctx is None:
+            self._write_no_ext_status()
+        else:
+            self._write_response(
+                get_callback_results(self.ctx.ext_ctx, self.request.json)
+            )
 
     def _write_response(self, response: ExtResponse):
         self.response.set_header("Content-Type", "text/json")
@@ -186,6 +200,10 @@ class ViewerExtHandler(ApiHandler[ViewerContext]):
             self.response.write(
                 {"error": {"status": response.status, "message": response.reason}}
             )
+
+    def _write_no_ext_status(self):
+        self.response.set_status(404, "No extensions configured")
+        self.response.finish()
 
 
 @api.route("/viewer/ext/contributions")


### PR DESCRIPTION
 No longer logging a `TypeError` if xcube server's `GET viewer/ext/contributions` is called without any viewer extensions configured.

Closes #1116 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
