### PR TITLE
Add markdown component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
   3. Default values for the `Description` setting are derived from metadata of 
      datasets and variable CF attributes.
 
+* Added support the xcube Viewer's `Markdown` component so it can be used in 
+  server-side viewer extensions. See new package `xcube.webapi.viewer.components`
+  exporting class `Markdown` which has a single `text` property that takes 
+  the markdown text.
+
 ### Other changes
 
 * Reformatted code base according to the default settings used by 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
   3. Default values for the `Description` setting are derived from metadata of 
      datasets and variable CF attributes.
 
-* Added support the xcube Viewer's `Markdown` component so it can be used in 
+* Added support for the xcube Viewer's `Markdown` component so it can be used in 
   server-side viewer extensions. See new package `xcube.webapi.viewer.components`
   exporting class `Markdown` which has a single `text` property that takes 
   the markdown text.

--- a/test/webapi/viewer/test_components.py
+++ b/test/webapi/viewer/test_components.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2018-2025 by xcube team and contributors
+# Permissions are hereby granted under the terms of the MIT License:
+# https://opensource.org/licenses/MIT.
+
+
+import unittest
+
+from xcube.webapi.viewer.components import Markdown
+
+
+class ViewerComponentsTest(unittest.TestCase):
+    # noinspection PyMethodMayBeStatic
+    def test_markdown(self):
+        markdown = Markdown(text="_Hello_ **world**!")
+        self.assertEqual(
+            {"type": "Markdown", "text": "_Hello_ **world**!"},
+            markdown.to_dict(),
+        )

--- a/xcube/webapi/viewer/components/__init__.py
+++ b/xcube/webapi/viewer/components/__init__.py
@@ -2,3 +2,8 @@
 #  Permissions are hereby granted under the terms of the MIT License:
 #  https://opensource.org/licenses/MIT.
 
+from .markdown import Markdown
+
+__all__ = [
+    "Markdown",
+]

--- a/xcube/webapi/viewer/components/__init__.py
+++ b/xcube/webapi/viewer/components/__init__.py
@@ -1,0 +1,4 @@
+#  Copyright (c) 2018-2025 by xcube team and contributors
+#  Permissions are hereby granted under the terms of the MIT License:
+#  https://opensource.org/licenses/MIT.
+

--- a/xcube/webapi/viewer/components/markdown.py
+++ b/xcube/webapi/viewer/components/markdown.py
@@ -1,0 +1,15 @@
+#  Copyright (c) 2018-2025 by xcube team and contributors
+#  Permissions are hereby granted under the terms of the MIT License:
+#  https://opensource.org/licenses/MIT.
+
+from dataclasses import dataclass
+
+from chartlets import Component
+
+
+@dataclass(frozen=True)
+class Markdown(Component):
+    """A div-element in which the given markdown text is rendered."""
+
+    text: str | None = None
+    """The markdown text."""

--- a/xcube/webapi/viewer/context.py
+++ b/xcube/webapi/viewer/context.py
@@ -101,4 +101,4 @@ def prepend_sys_path(path: Path | str | None):
     finally:
         if prev_sys_path:
             sys.path = prev_sys_path
-            LOG.info(f"Restored sys.path")
+            LOG.info("Restored sys.path")


### PR DESCRIPTION
Added support the xcube Viewer's `Markdown` component so it can be used in server-side viewer extensions. See new package `xcube.webapi.viewer.components` exporting class `Markdown` which has a single `text` property that takes the markdown text.

See related https://github.com/xcube-dev/xcube-viewer/pull/473

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
