### PR TITLE
Fixes for Python 3.13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
   [ruff](https://docs.astral.sh/ruff/). Updated development 
   dependencies accordingly.
 * Updated copyright notices.
+* Ensured xcube can be installed and tested in Python 3.13 environments.
 
 ## Changes in 1.8.2
 

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -9,7 +9,7 @@ import unittest
 import warnings
 from abc import ABC, abstractmethod
 from test.s3test import MOTO_SERVER_ENDPOINT_URL, S3Test
-from typing import Any, Callable, Dict, Optional, Set, Type, Union
+from typing import Any, Callable, Optional, Union
 
 import fsspec
 import numpy as np
@@ -452,7 +452,7 @@ class FsDataStoresTestMixin(ABC):
                 )
             # if "s3" data store is tested, warnings from other
             # libraries like botocore occur
-            if data_store.protocol is not "s3":
+            if data_store.protocol != "s3":
                 self.assertEqual(1, len(w))
             self.assertEqual(w[0].category, UserWarning)
             self.assertEqual(warning_msg, w[0].message.args[0])

--- a/xcube/webapi/viewer/routes.py
+++ b/xcube/webapi/viewer/routes.py
@@ -48,10 +48,9 @@ def get_local_viewer_path() -> Union[None, str, pathlib.Path]:
     if local_viewer_path:
         return local_viewer_path
     try:
-        with importlib.resources.files(_viewer_module) as path:
-            local_viewer_path = path / _data_dir
-            if (local_viewer_path / _default_filename).is_file():
-                return local_viewer_path
+        local_viewer_path = importlib.resources.files(_viewer_module) / _data_dir
+        if (local_viewer_path / _default_filename).is_file():
+            return str(local_viewer_path)
     except ImportError:
         pass
     LOG.warning(
@@ -72,7 +71,7 @@ class ViewerConfigHandler(ApiHandler[ViewerContext]):
     def get(self, path: Optional[str]):
         config_items = self.ctx.config_items
         if config_items is None:
-            raise ApiError.NotFound(f"xcube viewer has not been been configured")
+            raise ApiError.NotFound("xcube viewer has not been been configured")
         try:
             data = config_items[path]
         except KeyError:


### PR DESCRIPTION
Ensures xcube can be installed and tested in Python 3.13 environments.

Checklist:

* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
