### PR TITLE
Allow using other xarray backends

### DIFF
--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -5,6 +5,7 @@
 import collections.abc
 import os.path
 import shutil
+import tempfile
 import unittest
 import warnings
 from abc import ABC, abstractmethod
@@ -69,8 +70,8 @@ def new_cube_data():
     return cube.chunk(dict(time=1, y=90, x=180))
 
 
-class NewCubeDataTestMixin(unittest.TestCase):
-    path = f"{DATA_PATH}/data.zarr"
+class DataPackingTest(unittest.TestCase):
+    path = f"{tempfile.gettempdir()}/data.zarr"
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -161,6 +162,13 @@ class FsDataStoresTestMixin(ABC):
             expected_return_type=xr.Dataset,
             expected_descriptor_type=DatasetDescriptor,
             assert_data_ok=self._assert_zarr_store_direct_ok,
+            # Not nice here, but we lack coverage for the case where
+            # the original Zarr store will be wrapped by the
+            # LoggingZarrStore and zarr.LRUStoreCache stores.
+            open_params={
+                "cache_size": 1 << 24,
+                "log_access": True,
+            },
         )
         self._assert_dataset_supported(
             data_store,

--- a/xcube/core/geom.py
+++ b/xcube/core/geom.py
@@ -677,42 +677,44 @@ def get_dataset_bounds(
     is_lon = xy_var_names[0] == "lon"
 
     # Note, x_min > x_max then we intersect with the anti-meridian
+    # We must explicitly cast to float, as coordinates can be uint (EOPF S2)
     x_bnds_name = get_dataset_bounds_var_name(dataset, x_name)
     if x_bnds_name is not None:
         x_bnds_var = dataset[x_bnds_name]
-        x1 = x_bnds_var[0, 0]
-        x2 = x_bnds_var[0, 1]
-        x3 = x_bnds_var[-1, 0]
-        x4 = x_bnds_var[-1, 1]
+        x1 = float(x_bnds_var[0, 0])
+        x2 = float(x_bnds_var[0, 1])
+        x3 = float(x_bnds_var[-1, 0])
+        x4 = float(x_bnds_var[-1, 1])
         x_min = min(x1, x2)
         x_max = max(x3, x4)
     else:
-        x_min = x_var[0]
-        x_max = x_var[-1]
+        x_min = float(x_var[0])
+        x_max = float(x_var[-1])
         delta = (x_max - x_min + (0 if (x_max >= x_min or not is_lon) else 360)) / (
             x_var.size - 1
         )
-        x_min -= 0.5 * delta
-        x_max += 0.5 * delta
+        x_min = x_min - 0.5 * delta
+        x_max = x_max + 0.5 * delta
 
     # Note, x-axis may be inverted
+    # We must explicitly cast to float, as coordinates can be uint (EOPF S2)
     y_bnds_name = get_dataset_bounds_var_name(dataset, y_name)
     if y_bnds_name is not None:
         y_bnds_var = dataset[y_bnds_name]
-        y1 = y_bnds_var[0, 0]
-        y2 = y_bnds_var[0, 1]
-        y3 = y_bnds_var[-1, 0]
-        y4 = y_bnds_var[-1, 1]
+        y1 = float(y_bnds_var[0, 0])
+        y2 = float(y_bnds_var[0, 1])
+        y3 = float(y_bnds_var[-1, 0])
+        y4 = float(y_bnds_var[-1, 1])
         y_min = min(y1, y2, y3, y4)
         y_max = max(y1, y2, y3, y4)
     else:
-        y1 = y_var[0]
-        y2 = y_var[-1]
+        y1 = float(y_var[0])
+        y2 = float(y_var[-1])
         delta = abs(y2 - y1) / (y_var.size - 1)
         y_min = min(y1, y2) - 0.5 * delta
         y_max = max(y1, y2) + 0.5 * delta
 
-    return float(x_min), float(y_min), float(x_max), float(y_max)
+    return x_min, y_min, x_max, y_max
 
 
 def get_box_split_bounds(

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -44,6 +44,10 @@ ZARR_OPEN_DATA_PARAMS_SCHEMA = JsonObjectSchema(
             description="Group path. (a.k.a. path in zarr terminology.).",
             min_length=1,
         ),
+        engine=JsonStringSchema(
+            description="xarray backend name.",
+            min_length=1,
+        ),
         chunks=JsonObjectSchema(
             description="Optional chunk sizes along each dimension."
             ' Chunk size values may be None, "auto"'
@@ -146,21 +150,32 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor):
         assert_instance(data_id, str, name="data_id")
         fs, root, open_params = self.load_fs(open_params)
         zarr_store = fs.get_mapper(data_id)
+        engine = open_params.pop("engine", "zarr")
         cache_size = open_params.pop("cache_size", None)
-        if isinstance(cache_size, int) and cache_size > 0:
-            zarr_store = zarr.LRUStoreCache(zarr_store, max_size=cache_size)
         log_access = open_params.pop("log_access", None)
-        if log_access:
-            zarr_store = LoggingZarrStore(zarr_store, name=f"zarr_store({data_id!r})")
         consolidated = open_params.pop(
             "consolidated", fs.exists(f"{data_id}/.zmetadata")
         )
-        try:
-            dataset = xr.open_zarr(zarr_store, consolidated=consolidated, **open_params)
-        except ValueError as e:
-            raise DataStoreError(f"Failed to open dataset {data_id!r}: {e}") from e
+        if engine == "zarr":
+            if isinstance(cache_size, int) and cache_size > 0:
+                zarr_store = zarr.LRUStoreCache(zarr_store, max_size=cache_size)
+            if log_access:
+                zarr_store = LoggingZarrStore(
+                    zarr_store, name=f"zarr_store({data_id!r})"
+                )
+            try:
+                dataset = xr.open_zarr(
+                    zarr_store, consolidated=consolidated, **open_params
+                )
+                dataset.zarr_store.set(zarr_store)
+            except ValueError as e:
+                raise DataStoreError(f"Failed to open dataset {data_id!r}: {e}") from e
+        else:
+            try:
+                dataset = xr.open_dataset(data_id, engine=engine, **open_params)
+            except ValueError as e:
+                raise DataStoreError(f"Failed to open dataset {data_id!r}: {e}") from e
 
-        dataset.zarr_store.set(zarr_store)
         return dataset
 
     # noinspection PyMethodMayBeStatic


### PR DESCRIPTION
In this PR:

- Allow using other xarray backends than "zarr" for Zarr datasets.
- When computing dataset bounding boxes, respect that 64-bit integer type coordinates must explicitly be cast to float to avoid raising TypeErrors.

I couldn't find a good way to test the new code in `xcube/core/store/fs/impl/dataset.py` as it would require a new additional xarray backend registered temporary.
