### PR TITLE
Enable ordering of datasets from config file shown in `xcube-viewer`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
   - Added schema for the existing `replace` parameter. 
   - Updated schema for the `num_levels` parameter which now explains the parameter 
     in more detail.
+* Introduced a server-side configuration attribute `EntrypointDatasetId` to specify 
+  the initial dataset that should be displayed in the viewer application upon loading. 
 
 ## Changes in 1.9.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,10 @@
 ### Enhancements
 
 * Introduced a server-side configuration attribute `EntrypointDatasetId` to specify 
-  the initial dataset that should be displayed in the viewer application upon loading. 
+  the initial dataset that should be displayed in the viewer application upon loading. (#1135)
 
 * Added support for `SortValue` in the server configuration to define dataset sorting 
-  within groups displayed in the viewer app's dataset selection dropdown.
+  within groups displayed in the viewer app's dataset selection dropdown.  (#1135)
 
 ### Other changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Introduced a server-side configuration attribute `EntrypointDatasetId` to specify 
   the initial dataset that should be displayed in the viewer application upon loading. 
+
 * Added support for `SortValue` in the server configuration to define dataset sorting 
   within groups displayed in the viewer app's dataset selection dropdown.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Changes in 1.9.1 (in development)
 
+### Enhancements
+
+* Introduced a server-side configuration attribute `EntrypointDatasetId` to specify 
+  the initial dataset that should be displayed in the viewer application upon loading. 
+* Added support for `SortValue` in the server configuration to define dataset sorting 
+  within groups displayed in the viewer app's dataset selection dropdown.
+
 ### Other changes
 
 * Improved the filesystem data stores (`"file"`, `"s3"`, ...): 
@@ -8,8 +15,6 @@
   - Added schema for the existing `replace` parameter. 
   - Updated schema for the `num_levels` parameter which now explains the parameter 
     in more detail.
-* Introduced a server-side configuration attribute `EntrypointDatasetId` to specify 
-  the initial dataset that should be displayed in the viewer application upon loading. 
 
 ## Changes in 1.9.0
 

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -144,6 +144,7 @@ Datasets:
     Style: tif_style
 #    SortValue: 2
 
+# Add the initial dataset that needs to be shown in xcube-viewer upon loading here
 EntrypointDatasetId:
   Identifier: geotiff_local
 

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -134,7 +134,7 @@ Datasets:
     FileSystem: file
     Path: sample-cog.tif
     Style: tif_style
-#    SortValue: 1
+    SortValue: 1
 
   - Identifier: geotiff_local
     Title: GeoTIFF example
@@ -142,7 +142,7 @@ Datasets:
     FileSystem: file
     Path: sample-geotiff.tif
     Style: tif_style
-#    SortValue: 2
+    SortValue: 2
 
 # Add the initial dataset that needs to be shown in xcube-viewer upon loading here
 EntrypointDatasetId:

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -134,7 +134,7 @@ Datasets:
     FileSystem: file
     Path: sample-cog.tif
     Style: tif_style
-    SortValue: 1
+    SortValue: 2
 
   - Identifier: geotiff_local
     Title: GeoTIFF example
@@ -142,7 +142,7 @@ Datasets:
     FileSystem: file
     Path: sample-geotiff.tif
     Style: tif_style
-    SortValue: 2
+    SortValue: 1
 
 # Add the initial dataset that needs to be shown in xcube-viewer upon loading here
 EntrypointDatasetId:

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -134,6 +134,7 @@ Datasets:
     FileSystem: file
     Path: sample-cog.tif
     Style: tif_style
+#    SortValue: 1
 
   - Identifier: geotiff_local
     Title: GeoTIFF example
@@ -141,6 +142,10 @@ Datasets:
     FileSystem: file
     Path: sample-geotiff.tif
     Style: tif_style
+#    SortValue: 2
+
+EntrypointDatasetId:
+  Identifier: geotiff_local
 
 PlaceGroups:
   - Identifier: inside-cube

--- a/test/webapi/datasets/test_context.py
+++ b/test/webapi/datasets/test_context.py
@@ -673,3 +673,8 @@ class MaybeAssignStoreInstanceIdsTest(unittest.TestCase):
         ]
 
         self.assertEqual(expected_dataset_configs, dataset_configs)
+
+    def test_entrypoint_dataset_id(self):
+        ctx = get_datasets_ctx("config-entrypoint-sortvalue.yml")
+        entrypoint_config = ctx.get_entrypoint_dataset_id_config()
+        self.assertEqual("demo-1w", entrypoint_config.get("Identifier"))

--- a/test/webapi/datasets/test_controllers.py
+++ b/test/webapi/datasets/test_controllers.py
@@ -154,7 +154,8 @@ class DatasetsControllerTest(DatasetsControllerTestBase):
         print(datasets[0].get("id"))
         for dataset in datasets:
             self.assertIsInstance(dataset, dict)
-            # The sort value has no relation to the id, but we need it for the assert.
+            # The sort value has no relation to the id for deriving its value,
+            # but we need it for the assert.
             expected_sort_value = 2 if dataset.get("id") == "demo" else 1
             self.assertEqual(expected_sort_value, dataset.get("sortValue"))
 

--- a/test/webapi/datasets/test_controllers.py
+++ b/test/webapi/datasets/test_controllers.py
@@ -144,6 +144,20 @@ class DatasetsControllerTest(DatasetsControllerTestBase):
             f"{cm.exception}",
         )
 
+    def test_dataset_with_sortvalue(self):
+        response = get_datasets(
+            get_datasets_ctx("config-entrypoint-sortvalue.yml"),
+            details=True,
+            base_url="http://test",
+        )
+        datasets = self.assertDatasetsOk(response, expected_count=2)
+        print(datasets[0].get("id"))
+        for dataset in datasets:
+            self.assertIsInstance(dataset, dict)
+            # The sort value has no relation to the id, but we need it for the assert.
+            expected_sort_value = 2 if dataset.get("id") == "demo" else 1
+            self.assertEqual(expected_sort_value, dataset.get("sortValue"))
+
     def test_dataset_with_details_and_rgb_schema(self):
         response = get_datasets(
             get_datasets_ctx("config-rgb.yml"), details=True, base_url="http://test"

--- a/test/webapi/res/config-entrypoint-sortvalue.yml
+++ b/test/webapi/res/config-entrypoint-sortvalue.yml
@@ -1,0 +1,126 @@
+DatasetAttribution:
+  - © by Brockmann Consult GmbH 2020, contains modified Copernicus Data 2019, processed by ESA
+
+Datasets:
+  - Identifier: demo
+    Title: xcube-server Demonstration L2C Cube
+    GroupTitle: Demo
+    Tags: ["demo", "zarr"]
+    Path: ../../../examples/serve/demo/cube-1-250-250.zarr
+    Variables:
+      - "conc_chl"
+      - "chl_category"
+      - "conc_tsm"
+      - "chl_tsm_sum"
+      - "kd489"
+      - "*"
+    Style: default
+    Attribution: © by EU H2020 CyanoAlert project
+    SortValue: 2
+
+  - Identifier: demo-1w
+    Title: xcube-server Demonstration L3 Cube
+    GroupTitle: Demo
+    Tags: ["demo", "zarr", "computed"]
+    FileSystem: memory
+    Path: script.py
+    Variables:
+      - "conc_chl"
+      - "chl_category"
+      - "conc_tsm"
+      - "chl_tsm_sum"
+      - "kd489"
+      - "*"
+    Function: compute_dataset
+    InputDatasets: ["demo"]
+    InputParameters:
+      period: "1W"
+      incl_stdev: True
+    Style: default
+    SortValue: 1
+
+EntrypointDatasetId:
+  Identifier: demo-1w
+
+PlaceGroups:
+  - Identifier: inside-cube
+    Title: Points inside the cube
+    Path: places/inside-cube.geojson
+  - Identifier: outside-cube
+    Title: Points outside the cube
+    Path: places/outside-cube.geojson
+
+Styles:
+  - Identifier: default
+    ColorMappings:
+      conc_chl:
+        ColorBar: my_cmap
+        ValueRange: [0., 20.]
+      conc_tsm:
+        ColorBar: cmap_bloom_risk
+        ValueRange: [0., 1.]
+      kd489:
+        ColorBar: jet
+        ValueRange: [0., 6.]
+
+CustomColorMaps:
+  - Identifier: my_cmap
+    Type: continuous # or categorical, stepwise
+    Colors:
+      - Value: 0
+        Color: red
+        Label: low
+      - Value: 12
+        Color: "#0000FF"
+        Label: medium
+      - Value: 18
+        Color: [0, 255, 0]
+        Label: mediumhigh
+      - Value: 24
+        Color: [0, 1, 0, 0.3]
+        Label: high
+  - Identifier: cmap_bloom_risk
+    Type: categorical
+    Colors:
+      - [ 0, [0, 1, 0., 0.5]]
+      - [ 1, orange]
+      - [ 2, [1, 0, 0]]
+  - Identifier: s2_l2_scl
+    Type: categorical
+    Colors:
+      - [ 0, red,     no data]
+      - [ 1, yellow,  defective]
+      - [ 2, black,   dark area pixels]
+      - [ 3, gray,    cloud shadows]
+      - [ 4, green,   vegetation]
+      - [ 5, tan,     bare soils]
+      - [ 6, blue,    water]
+      - [ 7, "#aaaabb", clouds low prob ]
+      - [ 8, "#bbbbcc", clouds medium prob]
+      - [ 9, "#ccccdd", clouds high prob]
+      - [10, "#ddddee", cirrus]
+      - [11, "#ffffff", snow or ice]
+      - [11, "#ffffff", snow or ice]
+
+Viewer:
+  Configuration:
+    Path: viewer
+
+ServiceProvider:
+  ProviderName: "Brockmann Consult GmbH"
+  ProviderSite: "https://www.brockmann-consult.de"
+  ServiceContact:
+    IndividualName: "Norman Fomferra"
+    PositionName: "Senior Software Engineer"
+    ContactInfo:
+      Phone:
+        Voice: "+49 4152 889 303"
+        Facsimile: "+49 4152 889 330"
+      Address:
+        DeliveryPoint: "HZG / GITZ"
+        City: "Geesthacht"
+        AdministrativeArea: "Herzogtum Lauenburg"
+        PostalCode: "21502"
+        Country: "Germany"
+        ElectronicMailAddress: "norman.fomferra@brockmann-consult.de"
+

--- a/xcube/webapi/datasets/config.py
+++ b/xcube/webapi/datasets/config.py
@@ -238,6 +238,14 @@ SERVICE_PROVIDER_SCHEMA = JsonObjectSchema(
     additional_properties=True,
 )
 
+ENTRYPOINT_DATASET_ID_SCHEMA = JsonObjectSchema(
+    properties=dict(
+        Identifier=IDENTIFIER_SCHEMA,
+    ),
+    required=["Identifier"],
+    additional_properties=False,
+)
+
 CONFIG_SCHEMA = JsonObjectSchema(
     properties=dict(
         DatasetAttribution=ATTRIBUTION_SCHEMA,
@@ -248,5 +256,8 @@ CONFIG_SCHEMA = JsonObjectSchema(
         Styles=JsonArraySchema(items=STYLE_SCHEMA),
         CustomColorMaps=JsonArraySchema(items=CUSTOM_COLORMAP_SCHEMA),
         ServiceProvider=SERVICE_PROVIDER_SCHEMA,
+        EntrypointDatasetId=ENTRYPOINT_DATASET_ID_SCHEMA,
+        # TODO: Maybe another attribute for sorting boolean
+        # DatasetOrdering:
     )
 )

--- a/xcube/webapi/datasets/config.py
+++ b/xcube/webapi/datasets/config.py
@@ -17,6 +17,7 @@ from xcube.webapi.common.schemas import (
     PATH_SCHEMA,
     STRING_SCHEMA,
     URI_SCHEMA,
+    NUMBER_SCHEMA,
 )
 
 from ..places.config import PLACE_GROUP_SCHEMA
@@ -66,6 +67,7 @@ COMMON_DATASET_PROPERTIES = dict(
     Title=STRING_SCHEMA,
     Description=STRING_SCHEMA,
     GroupTitle=STRING_SCHEMA,
+    SortValue=NUMBER_SCHEMA,
     Tags=JsonArraySchema(items=STRING_SCHEMA),
     Variables=VARIABLES_SCHEMA,
     TimeSeriesDataset=IDENTIFIER_SCHEMA,

--- a/xcube/webapi/datasets/config.py
+++ b/xcube/webapi/datasets/config.py
@@ -259,7 +259,5 @@ CONFIG_SCHEMA = JsonObjectSchema(
         CustomColorMaps=JsonArraySchema(items=CUSTOM_COLORMAP_SCHEMA),
         ServiceProvider=SERVICE_PROVIDER_SCHEMA,
         EntrypointDatasetId=ENTRYPOINT_DATASET_ID_SCHEMA,
-        # TODO: Maybe another attribute for sorting boolean
-        # DatasetOrdering:
     )
 )

--- a/xcube/webapi/datasets/context.py
+++ b/xcube/webapi/datasets/context.py
@@ -84,9 +84,11 @@ class DatasetsContext(ResourcesContext):
         # cache for all dataset configs
         # contains tuples of form (MultiLevelDataset, dataset_config)
         self._dataset_cache = dict()
-        self._data_store_pool, self._dataset_configs, self._entrypoint_dataset_id = (
-            self._process_dataset_configs(self.config, self.base_dir)
-        )
+        (
+            self._data_store_pool,
+            self._dataset_configs,
+            self.entrypoint_dataset_id_config,
+        ) = self._process_dataset_configs(self.config, self.base_dir)
         self._cm_styles, self._colormap_registry = self._get_cm_styles()
 
     def on_dispose(self):
@@ -468,8 +470,8 @@ class DatasetsContext(ResourcesContext):
         return self._dataset_configs
 
     def get_entrypoint_dataset_id_config(self) -> DatasetConfig | None:
-        if self._entrypoint_dataset_id:
-            return self._entrypoint_dataset_id
+        if self.entrypoint_dataset_id_config:
+            return self.entrypoint_dataset_id_config
         return None
 
     def get_data_store_pool(self) -> DataStorePool:

--- a/xcube/webapi/datasets/context.py
+++ b/xcube/webapi/datasets/context.py
@@ -84,8 +84,8 @@ class DatasetsContext(ResourcesContext):
         # cache for all dataset configs
         # contains tuples of form (MultiLevelDataset, dataset_config)
         self._dataset_cache = dict()
-        self._data_store_pool, self._dataset_configs = self._process_dataset_configs(
-            self.config, self.base_dir
+        self._data_store_pool, self._dataset_configs, self._entrypoint_dataset_id = (
+            self._process_dataset_configs(self.config, self.base_dir)
         )
         self._cm_styles, self._colormap_registry = self._get_cm_styles()
 
@@ -467,6 +467,11 @@ class DatasetsContext(ResourcesContext):
         assert self._dataset_configs is not None
         return self._dataset_configs
 
+    def get_entrypoint_dataset_id_config(self) -> DatasetConfig | None:
+        if self._entrypoint_dataset_id:
+            return self._entrypoint_dataset_id
+        return None
+
     def get_data_store_pool(self) -> DataStorePool:
         assert self._data_store_pool is not None
         return self._data_store_pool
@@ -474,9 +479,10 @@ class DatasetsContext(ResourcesContext):
     @classmethod
     def _process_dataset_configs(
         cls, config: ServerConfig, base_dir: str
-    ) -> tuple[DataStorePool, list[dict[str, Any]]]:
+    ) -> tuple[DataStorePool, list[dict[str, Any]], dict[str, Any]]:
         data_store_configs = config.get("DataStores", [])
         dataset_configs = config.get("Datasets", [])
+        entrypoint_dataset_id_config = config.get("EntrypointDatasetId", {})
 
         data_store_pool = DataStorePool()
         for data_store_config_dict in data_store_configs:
@@ -496,7 +502,7 @@ class DatasetsContext(ResourcesContext):
         # entries:
         dataset_configs = [dict(c) for c in dataset_configs]
         cls._maybe_assign_store_instance_ids(dataset_configs, data_store_pool, base_dir)
-        return data_store_pool, dataset_configs
+        return data_store_pool, dataset_configs, entrypoint_dataset_id_config
 
     def get_rgb_color_mapping(
         self, ds_id: str, norm_range: tuple[float, float] = (0.0, 1.0)

--- a/xcube/webapi/datasets/controllers.py
+++ b/xcube/webapi/datasets/controllers.py
@@ -108,6 +108,10 @@ def get_datasets(
             # Note, dataset_config is validated
             dataset_dict["bbox"] = ds_bbox
 
+        sort_value = dataset_config.get("SortValue")
+        if sort_value:
+            dataset_dict["sortValue"] = sort_value
+
         LOG.info(f"Collected dataset {ds_id}")
         dataset_dicts.append(dataset_dict)
 

--- a/xcube/webapi/datasets/controllers.py
+++ b/xcube/webapi/datasets/controllers.py
@@ -141,7 +141,7 @@ def get_datasets(
     if not dataset_dicts:
         LOG.warning("No datasets provided for current user.")
 
-    return dict(datasets=dataset_dicts, entrypoint_dataset_id=entrypoint_dataset_id)
+    return dict(datasets=dataset_dicts, entrypointDatasetId=entrypoint_dataset_id)
 
 
 def get_dataset(

--- a/xcube/webapi/datasets/controllers.py
+++ b/xcube/webapi/datasets/controllers.py
@@ -77,6 +77,12 @@ def get_datasets(
     LOG.info(f"Collecting datasets for granted scopes {granted_scopes!r}")
 
     dataset_configs = list(ctx.get_dataset_configs())
+    entrypoint_dataset_id_config = ctx.get_entrypoint_dataset_id_config()
+    entrypoint_dataset_id = (
+        entrypoint_dataset_id_config.get("Identifier")
+        if entrypoint_dataset_id_config
+        else None
+    )
 
     dataset_dicts = list()
     for dataset_config in dataset_configs:
@@ -135,7 +141,7 @@ def get_datasets(
     if not dataset_dicts:
         LOG.warning("No datasets provided for current user.")
 
-    return dict(datasets=dataset_dicts)
+    return dict(datasets=dataset_dicts, entrypoint_dataset_id=entrypoint_dataset_id)
 
 
 def get_dataset(

--- a/xcube/webapi/datasets/routes.py
+++ b/xcube/webapi/datasets/routes.py
@@ -75,8 +75,7 @@ class DatasetsHandler(ApiHandler[DatasetsContext]):
 
     @api.operation(
         operation_id="getDatasets",
-        summary="Get all datasets. This endpoint now includes an additional "
-                "field in the response dictionary: `entrypointDatasetId`.",
+        summary="Get all datasets.",
         parameters=[
             {
                 "name": "details",

--- a/xcube/webapi/datasets/routes.py
+++ b/xcube/webapi/datasets/routes.py
@@ -75,7 +75,8 @@ class DatasetsHandler(ApiHandler[DatasetsContext]):
 
     @api.operation(
         operation_id="getDatasets",
-        summary="Get all datasets.",
+        summary="Get all datasets. This endpoint now includes an additional "
+                "field in the response dictionary: `entrypointDatasetId`.",
         parameters=[
             {
                 "name": "details",


### PR DESCRIPTION
This PR adds the following to the config file of xcube server:

- allows showing a specific dataset with a new attribute `EntrypointDatasetId` upon loading xcube-viewer based on the user's choice.
- ordering of the datasets within a group using `SortValue` attribute (currently only supports numbers)

See also https://github.com/xcube-dev/xcube-viewer/pull/509

Closes:  #1135

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
