### PR TITLE
Fix failing `EntrypointDatasetId` test

### DIFF
--- a/test/webapi/datasets/test_context.py
+++ b/test/webapi/datasets/test_context.py
@@ -676,5 +676,5 @@ class MaybeAssignStoreInstanceIdsTest(unittest.TestCase):
 
     def test_entrypoint_dataset_id(self):
         ctx = get_datasets_ctx("config-entrypoint-sortvalue.yml")
-        entrypoint_config = ctx.get_entrypoint_dataset_id_config()
-        self.assertEqual("demo-1w", entrypoint_config.get("Identifier"))
+        entrypoint_config = ctx.get_entrypoint_dataset_id()
+        self.assertEqual("demo-1w", entrypoint_config)

--- a/test/webapi/res/config-entrypoint-sortvalue.yml
+++ b/test/webapi/res/config-entrypoint-sortvalue.yml
@@ -39,8 +39,7 @@ Datasets:
     Style: default
     SortValue: 1
 
-EntrypointDatasetId:
-  Identifier: demo-1w
+EntrypointDatasetId: demo-1w
 
 PlaceGroups:
   - Identifier: inside-cube


### PR DESCRIPTION
[Description of PR]

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `CHANGES.md`~
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
