### PR TITLE
Update docstring of `resample_in_space` method

### DIFF
--- a/xcube/core/resampling/spatial.py
+++ b/xcube/core/resampling/spatial.py
@@ -98,7 +98,8 @@ def resample_in_space(
     the resampling is a direct rectification.
 
     Args:
-        source_ds: The source dataset.
+        source_ds: The source dataset. Must follow the dimension order of the variables:
+            ("time", "latitude", "longitude").
         source_gm: The source grid mapping.
         target_gm: The target grid mapping. Must be regular.
         ref_ds: An optional dataset that provides the

--- a/xcube/core/resampling/spatial.py
+++ b/xcube/core/resampling/spatial.py
@@ -98,8 +98,10 @@ def resample_in_space(
     the resampling is a direct rectification.
 
     Args:
-        source_ds: The source dataset. Must follow the dimension order of the variables:
-            ("time", "latitude", "longitude").
+        source_ds: The source dataset. Data variables must have 
+            dimensions in the following order: optional `time` followed
+            by the y-dimension (e.g., `y` or `lat`) followed by the 
+            x-dimension (e.g., `x` or `lon`).
         source_gm: The source grid mapping.
         target_gm: The target grid mapping. Must be regular.
         ref_ds: An optional dataset that provides the


### PR DESCRIPTION
This PR adds information about the expected dimension order to the `resample_in_space` method as it was discovered recently by a user who faced this issue.

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `CHANGES.md`~
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
