### PR TITLE
Remove mix_stderr=False argument to CliRunner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changes in 1.9.2 (in development)
 
+### Other changes
+
+* Make test suite compatible with click >=8.2.0 (#1155)
 
 ## Changes in 1.9.1 
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - affine >=2.2
   - botocore >=1.34.51
   - cftime >=1.6.3
-  - click >=8.0
+  - click >=8.2.0
   - cmocean >=2.0
   - dask >=2021.6
   - dask-image >=0.6

--- a/test/cli/helpers.py
+++ b/test/cli/helpers.py
@@ -19,7 +19,7 @@ TEST_ZARR_DIR = "test.zarr"
 
 class CliTest(unittest.TestCase, metaclass=ABCMeta):
     def invoke_cli(self, args: list[str]):
-        self.runner = click.testing.CliRunner(mix_stderr=False)
+        self.runner = click.testing.CliRunner()
         # noinspection PyTypeChecker
         return self.runner.invoke(cli, args, catch_exceptions=False)
 


### PR DESCRIPTION
`test.cli.helper.CliTest.invoke_cli` instantiates a `CliRunner` with `mix_stderr=False`, but this parameter has been removed in click 8.2.0. The default behaviour now corresponds to `mix_stderr=False`, so we can simply bump the minimum click version in the dependencies and remove the argument, which is what this PR does.

Fixes #1154.
See https://github.com/pallets/click/issues/2522
and https://github.com/pallets/click/pull/2523

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~ n/a
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~ n/a
* ~[ ] New/modified features documented in `docs/source/*`~ n/a
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
