### PR TITLE
Update `PreloadedDataStore` to a TypeAlias

### DIFF
--- a/xcube/core/store/store.py
+++ b/xcube/core/store/store.py
@@ -693,6 +693,16 @@ class MutableDataStore(DataStore, DataWriter, ABC):
 
 class PreloadedDataStore(DataStore):
     """A preload data store is a multable data store which contains the preload handle.
+    This is a marker subclass of `DataStore` used for documentation and clarity.
+
+    This class is not intended to be instantiated or returned directly.
+    It exists solely to indicate that an additional property `preload_handle` is
+    logically associated with the base class.
+
+    This approach helps make the source code more understandable even though instances
+    of this class are not used at runtime. Instead, a different subclass of
+    `DataStore` or `MutableDataStore` that includes this additional property is
+    returned.
 
     Instances of this class are returned by the ``DataStore.preload_data()`` method.
     """

--- a/xcube/core/store/store.py
+++ b/xcube/core/store/store.py
@@ -4,7 +4,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Container, Iterator
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, TypeAlias
 
 from xcube.constants import EXTENSION_POINT_DATA_STORES
 from xcube.util.extension import Extension, ExtensionPredicate, ExtensionRegistry
@@ -691,7 +691,7 @@ class MutableDataStore(DataStore, DataWriter, ABC):
         """
 
 
-class PreloadedDataStore(DataStore):
+class Preloaded(DataStore):
     """A preload data store is a multable data store which contains the preload handle.
     This class solely acts as a protocol description or marker interface for `DataStore` 
     instances returned from another data store's `preload_data` method.
@@ -715,3 +715,6 @@ class PreloadedDataStore(DataStore):
         Implementors of this interface may use a `ExecutorPreloadHandle` or consider
         returning a `NullPreloadHandle` if the progress is not observable.
         """
+
+
+PreloadedDataStore: TypeAlias = DataStore | Preloaded

--- a/xcube/core/store/store.py
+++ b/xcube/core/store/store.py
@@ -696,9 +696,9 @@ class PreloadedDataStore(DataStore):
     This class solely acts as a protocol description or marker interface for `DataStore` 
     instances returned from another data store's `preload_data` method.
 
-    This class is not intended to be instantiated or returned directly.
-    It exists solely to indicate that an additional property `preload_handle` is
-    logically associated with the base class.
+    The data stores returned from `preload_data` are not required to directly implement this interface.
+    However, their instances must provide an attribute `preload_handle` of type `PreloadHandle`
+    that is used to represent the pre-loading process and interact with it.
 
     This approach helps make the source code more understandable even though instances
     of this class are not used at runtime. Instead, a different subclass of

--- a/xcube/core/store/store.py
+++ b/xcube/core/store/store.py
@@ -693,7 +693,8 @@ class MutableDataStore(DataStore, DataWriter, ABC):
 
 class PreloadedDataStore(DataStore):
     """A preload data store is a multable data store which contains the preload handle.
-    This is a marker subclass of `DataStore` used for documentation and clarity.
+    This class solely acts as a protocol description or marker interface for `DataStore` 
+    instances returned from another data store's `preload_data` method.
 
     This class is not intended to be instantiated or returned directly.
     It exists solely to indicate that an additional property `preload_handle` is


### PR DESCRIPTION
Updated docstring for the `PreloadedDataStore` class to let the user know that it is a marker interface.

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `CHANGES.md`~
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
