### PR TITLE
Update documentation page 'Data Access'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 
 ### Other change
 
-* Update `Access Data` page in documentation.
+* Added the following data stores to `Access Data` page in documentation: 
+  `https`, `ftp`, `reference`, `smos`, `stac`, `stac-cdse`, `stac-xcube`, `gedidb`,
+  `eopf-zarr`, `esa-cci-kc`.
+
 
 ## Changes in 1.11.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Changes in 1.11.1 (in development)
+
+### Other change
+
+* Update `Access Data` page in documentation.
+
 ## Changes in 1.11.0
 
 This release is fully dedicated to a more efficient and robust approach 

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -496,7 +496,7 @@ Common parameters for opening [xarray.Dataset] instances:
 
 ### Copernicus Land Monitoring Service `clms`
 
-The data store `cds` provides datasets of the [Copernicus Land Monitoring Service].
+The data store `clms` provides datasets of the [Copernicus Land Monitoring Service].
 
 This data store is provided by the xcube plugin [xcube-clms]. 
 You can install it using `conda install -c conda-forge xcube-clms`.

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -590,8 +590,7 @@ You can install it using `conda install -c conda-forge xcube-stac.`
 
 General Data store parameters:
 
-* `stack_mode: bool` - Stacking of STAC items is applied. If True,
-  'odc-stac' is used as a default backend. Defaults to `False`.
+* `stack_mode: bool` - Stacking of STAC items is applied. Defaults to `False`.
 * `anon: bool` - Connect to AWS S3 anonymously.
 * `key: str` - AWS access key ID.
 * `secret: str` - AWS secret access key.

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -588,32 +588,16 @@ the [SpatioTemporal Asset Catalogs].
 This data store is provided by the xcube plugin [xcube-stac]. 
 You can install it using `conda install -c conda-forge xcube-stac.`
 
-General Data store parameters:
+The general parameters for the data store are the same as those used for `https` 
+and `s3` stores. The STAC collection of interest determines whether data is accessed 
+via `https` or `s3`.
 
-* `stack_mode: bool` - Stacking of STAC items is applied. Defaults to `False`.
-* `anon: bool` - Connect to AWS S3 anonymously.
-* `key: str` - AWS access key ID.
-* `secret: str` - AWS secret access key.
-* `token: str` - Session token. 
-* `use_ssl: bool` - Use SSL in connections to S3. Defaults to `True`.
-* `requester_pays: bool` - Support of "RequesterPays" buckets. Defaults to `False`.
-* `s3_additional_kwargs: dict` - Parameters used when calling S3 API methods
-  (e.g., `ServerSideEncryption`).
-* `client_kwargs: dict` - Parameters passed to the underlying botocore client.
-    * `endpoint_url: str` - Alternative endpoint URL.
-    * `profile_name: str` - AWS configuration profile name.
-    * `region_name: str` - AWS storage region name.
-* `use_listings_cache: bool` - Whether to use a listings cache.
-* `listings_expiry_time: float` - Expiry time (in seconds) for cached listings.
-* `max_paths: int` - Maximum number of paths to consider when accessing S3 objects.
-* `skip_instance_cache: bool` - Skip using an instance-level cache for S3 clients.
-* `asynchronous: bool` - Enable asynchronous I/O for data access.
+Specific parameters are:
+* `url: str` - URL to STAC catalog. Required for `stac`  and `xcube-stac`
+* `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready 
+   format. Defaults to `False`.
 
-Additional data store parameters for `stac`  and `xcube-stac`:
-* `url: str` - URL to STAC catalog. Required.
 
-Additional data store parameters for `stac-cdse`:
-* `creodias_vm: bool` - xcube-stac is used on a Creodias VM. Defaults to `False`.
 
 There are no common parameters for opening datasets with the three stores.
 As the available datasets are varying across a wide spectrum of datatypes

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -551,7 +551,7 @@ Data store parameters:
 * `cache_store_params: dict` - Store parameters of a filesystem-based data store.
    Defaults to: `{"root":"zenodo_cache","max_depth":10}`.
 
-Before opening a specific dataset in .zip format, it's recommended to preload the data first.
+Before opening a specific dataset in .zip format, it's required to preload the data first.
 Preloading lets you create data requests ahead of time, which may sit in a queue before
 being processed. Once processed, the data is downloaded as zip files, unzipped,
 extracted to a cache, and prepared for use. After this, it can be accessed through the

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -203,6 +203,11 @@ demonstrates its specific usage in
 
 Use `list_data_store_ids()` to list all available data stores.
 
+```python
+from xcube.core.store import list_data_store_ids
+
+list_data_store_ids()
+
 ### Filesystem-based data stores
 
 The following filesystem-based data stores are available in xcube:
@@ -235,9 +240,9 @@ The `reference` store has the following additional parameters:
         * `data_descriptor: dict` - Optional metadata or descriptor.
 * `target_protocol: str` - Target Protocol. If not provided,
   derived from the given path.
-* `target_options: str` - Additional options for loadings reference files. Derived from 
+* `target_options: str` - Additional options for loading reference files. 
+* `remote_protocol: str` - Protocol of the filesystem on which the references. Derived from 
    the first reference with a protocol, if not given.
-* `remote_protocol: str` - Protocol of the filesystem on which the references 
    will be evaluated.
 * `remote_options: str` - Additional options for loadings reference files.
 * `max_gap: int` - Max byte-range gap allowed when merging concurrent requests.
@@ -382,12 +387,11 @@ Data store parameters:
 * `source_path: str` - Path or URL into SMOS archive filesystem.
 * `source_protocol: str`: Protocol name for the SMOS archive filesystem.
 * `source_storage_options: dict`: Storage options for the SMOS archive filesystem. See 
-   fsspec documentation for specific filesystems.
+   fsspec documentation for specific filesystems. Any option can be overriden by
+   passing it as additional data store parameter.
 * `cache_path: str`: Path to local cache directory. Must be given, if file caching 
   is desired. 
 * `xarray_kwargs: dict`: Extra keyword arguments accepted by `xarray.open_dataset`.
-* `extra_source_storage_options`: Extra keyword arguments that override settings in
-  *source_storage_options*.
 
 Common parameters for opening [xarray.Dataset] instances:
 

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -12,12 +12,21 @@
 [Sentinel Hub]: https://www.sentinel-hub.com/
 [Copernicus Marine Service]: https://marine.copernicus.eu/
 [Copernicus Climate Data Store]: https://cds.climate.copernicus.eu/
+[ESA Soil Moisture and Ocean Salinity]: https://earth.esa.int/eogateway/missions/smos
+[Zenodo]: https://zenodo.org/
+[SpatioTemporal Asset Catalogs]: https://stacspec.org/en/
+[Copernicus Land Monitoring Service]: https://land.copernicus.eu/en
+[Global Ecosystem Dynamics Investigation]: https://gedi.umd.edu/
 
 [xcube-cci]: https://github.com/dcs4cop/xcube-cci
 [xcube-cds]: https://github.com/dcs4cop/xcube-cds
+[xcube-clms]: https://github.com/xcube-dev/xcube-clms
 [xcube-cmems]: https://github.com/dcs4cop/xcube-cmems
+[xcube-gedi]: https://github.com/xcube-dev/xcube-gedi
 [xcube-sh]: https://github.com/dcs4cop/xcube-sh
 [xcube-smos]: https://github.com/dcs4cop/xcube-smos
+[xcube-stac]: https://github.com/xcube-dev/xcube-stac
+[xcube-zenodo]: https://github.com/xcube-dev/xcube-zenodo
 
 [API reference]: https://xcube.readthedocs.io/en/latest/api.html#data-store-framework
 [DataStore]: https://xcube.readthedocs.io/en/latest/api.html#xcube.core.store.DataStore
@@ -191,6 +200,8 @@ For every data store we also provide a dedicated example Notebook that
 demonstrates its specific usage in 
 [examples/notebooks/datastores](https://github.com/dcs4cop/xcube/tree/main/examples/notebooks/datastores).
 
+Use the function `list_data_store_ids()` to list all available datastores.
+
 ### Filesystem-based data stores
 
 The following filesystem-based data stores are available in xcube:
@@ -198,7 +209,10 @@ The following filesystem-based data stores are available in xcube:
 * `"file"` for the local filesystem;
 * `"s3"` for AWS S3 compatible object storage; 
 * `"abfs"` for Azure blob storage;
-* `"memory"` for mimicking an in-memory filesystem. 
+* `"memory"` for mimicking an in-memory filesystem;
+* `"https"` for https protocols;
+* `"ftp"` for FTP server;
+* `"reference"` for read-only `fsspec` reference file systems.
 
 All filesystem-based data store have the following parameters:
 
@@ -246,6 +260,13 @@ The following `storage_options` can be used for the `abfs` data store:
 * `account_name: str` - Azure storage account name.
 * `account_key: str` - Azure storage account key.
 * `connection_string: str` - Connection string for Azure blob storage.
+
+The following `storage_options` can be used for the `ftp` data store:
+
+* `host` - The remote server name/ip to connect to
+* `port` - FTP Port to connect with, min.: 0, max.: 65535,`default`: 21
+* `username` - If authenticating, the user's identifier
+* `password` - User's password on the server, if using
 
 All filesystem data stores can open datasets from various data formats. 
 Datasets in Zarr, GeoTIFF / COG, or NetCDF format will be provided either by
@@ -319,14 +340,15 @@ It has no dedicated data store parameters.
 Its common dataset open parameters for opening [xarray.Dataset] instances are
 the same as for the filesystem-based data stores described above.
 
-### ESA SMOS
+### ESA SMOS `smos`
 
-A data store for ESA SMOS data is currently under development 
-and will be released soon.
+The data store `smos` provides datasets of the [ESA Soil Moisture and Ocean Salinity]
+mission.
 
-This data store is provided by the xcube plugin [xcube-smos].
-Once available, you will be able to install it using 
+This data store is provided by the xcube plugin [xcube-smos]. You can install it using
 `conda install -c conda-forge xcube-smos`.
+
+
 
 ### Copernicus Climate Data Store `cds`
 
@@ -422,6 +444,80 @@ Common parameters for opening [xarray.Dataset] instances:
 * `extra_search_params: dict` - Extra search parameters passed to a 
   catalogue query.
 * `max_cache_size: int` - Maximum chunk cache size in bytes.
+
+
+### Copernicus Land Monitoring Service `clms`
+
+The data store `cds` provides datasets of the [Copernicus Land Monitoring Service].
+
+This data store is provided by the xcube plugin [xcube-clms]. You can install it using `conda install -c conda-forge xcube-clms`.
+
+Data store parameters:
+
+* `credentials`: CLMS API credentials that can be obtained following the steps outlined
+   [here](https://eea.github.io/clms-api-docs/authentication.html). Required are
+   `client_id`, `user_id`, `token_uri`, and `private_key`.
+* `cache_store_id` - Store ID of cache data store. Defaults to `file`.
+* `cache_store_params` - Store parameters of a filesystem-based data store implemented in xcube.
+
+Common parameters for opening [xarray.Dataset] instances:
+
+TODO
+
+### Zenodo `zenodo`
+
+The data store `zenodo` provides access to datasets published on [Zenodo].
+
+This data store is provided by the xcube plugin [xcube-zenodo]. 
+You can install it using `conda install -c conda-forge xcube-zenodo`.
+
+Data store parameters:
+
+* `root` - Zenodo record ID. The record ID can be found in the url. Required.
+* `cache_store_id` - Store ID of cache data store. Defaults to `file`.
+* `cache_store_params` - Store parameters of a filesystem-based data store implemented in xcube.
+
+Common parameters for opening [xarray.Dataset] instances:
+
+TODO
+
+### SpatioTemporal Asset Catalogs `stac`
+
+The data store `cds` provides datasets of the [SpatioTemporal Asset Catalogs].
+
+This data store is provided by the xcube plugin [xcube-stac]. 
+You can install it using `conda install -c conda-forge xcube-stac.`
+
+Data store parameters:
+
+- `data_id`: The unique identifier for the data to open.
+- `opener_id`: Optional identifier specifying which data opener to use.
+- `data_type`: Optional data type to influence how the dataset is opened.
+- `**open_params`: Additional opening parameters.
+
+Common parameters for opening [xarray.Dataset] instances or  [MultiLevelDataset]:
+
+TODO
+
++ Preload Data !!
+
+
+### Global Ecosystem Dynamics Investigation `gedi`
+
+A data store for [Global Ecosystem Dynamics Investigation] (GEDI) data is currently 
+under development and will be released soon.
+
+This data store is provided by the xcube plugin [xcube-gedi]. Once available, you will 
+be able to install it using `conda install -c conda-forge xcube-gedi`.
+
+
+### EOPF Sample Service 
+
+A data store for EOPF Sample Service is currently under development and will be released
+soon.
+
+
+
 
 
 ## Developing new data stores

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -519,7 +519,7 @@ Data store parameters:
 * `cache_store_params: dict` - Store parameters of a filesystem-based data 
   store.
 
-Before opening a specific dataset from CLMS, it's recommended to preload the data first.
+Before opening a specific dataset from CLMS, it's required to preload the data first.
 Preloading lets you create data requests ahead of time, which may sit in a queue before 
 being processed. Once processed, the data is downloaded as zip files, unzipped, 
 extracted to a cache, and prepared for use. After this, it can be accessed through the 

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -201,7 +201,7 @@ For every data store we also provide a dedicated example Notebook that
 demonstrates its specific usage in 
 [examples/notebooks/datastores](https://github.com/dcs4cop/xcube/tree/main/examples/notebooks/datastores).
 
-Use `list_data_store_ids()` to list all available data stores.
+Use `list_data_store_ids()` to list all available data stores:
 
 ```python
 from xcube.core.store import list_data_store_ids
@@ -289,7 +289,7 @@ The following `storage_options` can be used for the `abfs` data store:
 The following `storage_options` can be used for the `ftp` data store:
 
 * `host` - Remote server name/ip 
-* `port` - FTP Port, min.: 0, max.: 65535,`default`: 21
+* `port` - FTP Port, min: 0, max: 65535,`default`: 21
 * `username` - User's identifier, if using
 * `password` - User's password, if using
 
@@ -496,13 +496,13 @@ Common parameters for opening [xarray.Dataset] instances:
 * `res_level: int` - Spatial resolution level in the range 0 to 4. Zero refers to
   the max resolution of 0.0439453125 degrees.
 
-### Global Ecosystem Dynamics Investigation `gedi`
+### Global Ecosystem Dynamics Investigation `gedidb`
 
 A data store for [Global Ecosystem Dynamics Investigation] (GEDI) data is currently
 under development and will be released soon.
 
-This data store is provided by the xcube plugin [xcube-gedi]. Once available, you will
-be able to install it using `conda install -c conda-forge xcube-gedi`.
+This data store is provided by the xcube plugin [xcube-gedidb]. Once available, you will
+be able to install it using `conda install -c conda-forge xcube-gedidb`.
 
 ### Sentinel Hub API 
 
@@ -557,7 +557,7 @@ Common parameters for opening [xarray.Dataset] instances:
 
 ### SpatioTemporal Asset Catalogs `stac`, `stac-xcube`, `stac-cdse`
 
-The data stores `stac`, `stac-xcube`, and `stac-cdse` provide datasets of
+The data stores `stac`, `stac-xcube`, and `stac-cdse` provide access to datasets of
 the [SpatioTemporal Asset Catalogs].
 
 The three data stores are provided by the xcube plugin [xcube-stac].
@@ -568,7 +568,7 @@ You can install it using `conda install -c conda-forge xcube-stac.`
 The data store `stac` provides datasets from a user-defined STAC API.
 
 The general parameters for the data store are the same as those used for `https`
-and `s3` stores. The STAC collection of interest determines whether data is accessed
+and `s3` stores. The STAC catalog of interest determines whether data is accessed
 via `https` or `s3`. Specific parameters for this store are:
 * `url: str` - URL to STAC catalog. Required.
 * `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready
@@ -578,7 +578,7 @@ via `https` or `s3`. Specific parameters for this store are:
 The data store `stac-xcube` connects to STAC catalogs published on a `xcube` Server.
 
 The general parameters for the data store are the same as those used for `https`
-and `s3` stores. The STAC collection of interest determines whether data is accessed
+and `s3` stores. The STAC catalog of interest determines whether data is accessed
 via `https` or `s3`. Specific parameters for this store are:
 * `url: str` - URL to STAC catalog. Required.
 * `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready
@@ -589,7 +589,7 @@ The data store `stac-cdse` provides direct access to Sentinel data using the
 CSDE STAC API.
 
 The general parameters for the data store are the same as those used for `https`
-and `s3` stores. The STAC collection of interest determines whether data is accessed
+and `s3` stores. The STAC catalog of interest determines whether data is accessed
 via `https` or `s3`. Specific parameters for this store are:
 * `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready
   format. Defaults to `False`.

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -421,7 +421,7 @@ soon.
 ### ESA Climate Data Centre `cciodp`, `ccizarr`, `esa-cci-kc`
 
 Three data stores are provided by the xcube plugin [xcube-cci].
-You can install it using `conda install -c conda-forge xcube-cci`.
+You can install the plugin using `conda install -c conda-forge xcube-cci`.
 
 #### `cciodp`
 
@@ -568,32 +568,34 @@ You can install it using `conda install -c conda-forge xcube-stac.`
 #### `stac`
 The data store `stac` provides datasets from a user-defined STAC API.
 
-The general parameters for the data store are the same as those used for `https`
-and `s3` stores. The STAC catalog of interest determines whether data is accessed
-via `https` or `s3`. Specific parameters for this store are:
+Specific parameters for this store are:
 * `url: str` - URL to STAC catalog. Required.
 * `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready
   format. Defaults to `False`.
+* `**store_params`: Store parameters to configure the store used to access the data, 
+  which are the same as those used for `https` and `s3` stores. The hrefs in the 
+  STAC assets determines whether data is accessed via `https` or `s3`. 
 
 #### `stac-xcube`
 The data store `stac-xcube` connects to STAC catalogs published on a `xcube` Server.
 
-The general parameters for the data store are the same as those used for `https`
-and `s3` stores. The STAC catalog of interest determines whether data is accessed
-via `https` or `s3`. Specific parameters for this store are:
+Specific parameters for this store are:
 * `url: str` - URL to STAC catalog. Required.
 * `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready
   format. Defaults to `False`.
+* `**store_params`: Store parameters to configure the `s3` store used to access 
+  the data. 
 
 #### `stac-cdse`
-The data store `stac-cdse` provides direct access to Sentinel data using the 
+The data store `stac-cdse` provides direct access datasets published by the 
 CSDE STAC API.
 
-The general parameters for the data store are the same as those used for `https`
-and `s3` stores. The STAC catalog of interest determines whether data is accessed
-via `https` or `s3`. Specific parameters for this store are:
 * `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready
   format. Defaults to `False`.
+* `key: str`- S3 key credential for CDSE data access
+* `secret: str`- S3 secret credential for CDSE data access
+In order to access [EO data via S3 from CDSE](https://documentation.dataspace.copernicus.eu/APIs/S3.html)
+one needs to [generate S3 credentials](https://documentation.dataspace.copernicus.eu/APIs/S3.html#generate-secrets).
 
 
 There are no common parameters for opening datasets with the three stores.

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -23,7 +23,7 @@
 [xcube-cds]: https://github.com/dcs4cop/xcube-cds
 [xcube-clms]: https://github.com/xcube-dev/xcube-clms
 [xcube-cmems]: https://github.com/dcs4cop/xcube-cmems
-[xcube-gedi]: https://github.com/xcube-dev/xcube-gedi
+[xcube-gedidb]: https://github.com/xcube-dev/xcube-gedidb
 [xcube-sh]: https://github.com/dcs4cop/xcube-sh
 [xcube-smos]: https://github.com/dcs4cop/xcube-smos
 [xcube-stac]: https://github.com/xcube-dev/xcube-stac
@@ -201,7 +201,8 @@ For every data store we also provide a dedicated example Notebook that
 demonstrates its specific usage in 
 [examples/notebooks/datastores](https://github.com/dcs4cop/xcube/tree/main/examples/notebooks/datastores).
 
-Use `list_data_store_ids()` to list all available data stores:
+Use `list_data_store_ids()` to list all data stores available in your current Python environment.
+The output depends on the installed xcube plugins. 
 
 ```python
 from xcube.core.store import list_data_store_ids
@@ -414,10 +415,10 @@ as for the filesystem-based data stores described above.
 
 ### EOPF Sample Service
 
-A data store for EOPF Sample Service is currently under development and will be released
+A data store for [EOPF Sentinel Zarr Samples](https://zarr.eopf.copernicus.eu/) is currently under development and will be released
 soon.
 
-### ESA Climate Data Centre `cciodp`, `ccizar`, `esa-cci-kc`
+### ESA Climate Data Centre `cciodp`, `ccizarr`, `esa-cci-kc`
 
 Three data stores are provided by the xcube plugin [xcube-cci].
 You can install it using `conda install -c conda-forge xcube-cci`.

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -352,17 +352,20 @@ Data store parameters:
     * A dictionary with:
         * `ref_path: str` - Path or URL to the reference file. Required.
         * `data_id: str` - Optional identifier for the referenced data.
-        * `data_descriptor: dict` - Optional metadata or descriptor. Can contain arbitrary fields.
-* `target_protocol: str` - Protocol used to load reference files. If not provided, derived from the given path.
+        * `data_descriptor: dict` - Optional metadata or descriptor.
+* `target_protocol: str` - Protocol used to load reference files. If not provided, 
+   derived from the given path.
 * `target_options: dict` - Additional filesystem options for loading the reference files.
-* `remote_protocol: str` - Protocol of the filesystem used to access referenced data. Derived from the first reference with a protocol, if not given.
+* `remote_protocol: str` - Protocol of the filesystem used to access referenced data. 
+   Derived from the first reference with a protocol, if not given.
 * `remote_options: dict` - Additional filesystem options for accessing the referenced data.
-* `max_gap: int` - Maximum byte-range gap allowed when merging concurrent requests. See `max_block`.
-* `max_block: int` - Max size of merged byte ranges. Default: 256MB. Set `0` to merge only touching ranges. Negative disables merging.
-* `cache_size: int` - Maximum LRU cache size. Controls how many references (based on `record_size`) can be held in memory. Used for lazy loading.
+* `max_gap: int` - Max byte-range gap allowed when merging concurrent requests. See `max_block`.
+* `max_block: int` - Max size of merged byte ranges. Defaults to `256MB`. Set `0` to merge 
+   only touching ranges. Negative disables merging.
+* `cache_size: int` - Max LRU cache size.
 * `use_listings_cache: bool` - Whether to use a cache for listings.
 * `listings_expiry_time: float` - Expiry time (in seconds) for cached listings.
-* `max_paths: int` - Maximum number of paths to consider.
+* `max_paths: int` - Max number of paths to consider.
 * `skip_instance_cache: bool` - Skip using an internal cache per instance.
 * `asynchronous: bool` - Enable asynchronous I/O.
 
@@ -386,14 +389,13 @@ Data store parameters:
 * `cache_path: str`: Path to local cache directory. Must be given, if file caching 
   is desired. 
 * `xarray_kwargs: dict`: Extra keyword arguments accepted by `xarray.open_dataset`.
-  See xarray documentation for allowed keywords.
 * `extra_source_storage_options`: Extra keyword arguments that override settings in
   *source_storage_options*.
 
 Common parameters for opening [xarray.Dataset] instances:
 
-* `time_range: (str, str)` - Time range given as pair of start and stop dates. Dates 
-  must be given using format 'YYYY-MM-DD'. Start and stop are inclusive.. Required.
+* `time_range: (str, str)` - Time range given as pair of start and stop dates. 
+  Format: `YYYY-MM-DD`. Required.
 * `bbox: (float, float, float, float)` - Bounding box in geographical
   coordinates.
 * `res_level: int` - Spatial resolution level in the range 0 to 4. Zero refers to 
@@ -517,25 +519,27 @@ Data store parameters:
   * `user_id: str` - Required.
 
 * `cache_store_id: str` - Store ID of cache data store. Defaults to `file`.
-* `cache_store_params: dict` - Store parameters of a filesystem-based data store implemented in xcube.
+* `cache_store_params: dict` - Store parameters of a filesystem-based data 
+  store.
 
-Before opening a specific dataset from CLMS preload the data before opening (recommended).
-The preloading allows you to create data requests, with undetermined time to wait in the
-queue for the request to be processed, followed by downloading zip files, unzipping them,
-extracting them in a cache and processing them which can be then finally opened using a
+Before opening a specific dataset from CLMS, it's recommended to preload the data first.
+Preloading lets you create data requests ahead of time, which may sit in a queue before 
+being processed. Once processed, the data is downloaded as zip files, unzipped, 
+extracted to a cache, and prepared for use. After this, it can be accessed through the 
 cache data store.
+
 The preload parameters are:
 * `blocking: bool` - Switch to make the preloading process blocking or non-blocking.
-  If True, the preloading process blocks the script. Defaults to `true`.
+  If True, the preloading process blocks the script. Defaults to `True`.
 * `silent: bool` - Silence the output of Preload API. If True, no preload state
-  output is given. Defaults to `false`.
-* `cleanup: bool` - Option to cleanup the download directory before and after the
-  preload job and to cleanup the cache directory when preload_handle.close() is called.
-  Defaults to `true`.
+  output is given. Defaults to `False`.
+* `cleanup: bool` - Cleanup the download directory before and after the
+  preload job and the cache directory when preload_handle.close() is called.
+  Defaults to `True`.
 
 
-Common parameters for opening [xarray.Dataset] instances:
-
+Its common dataset open parameters for opening [xarray.Dataset] instances are the same 
+as for the filesystem-based data stores described above.
 
 
 ### Zenodo `zenodo`
@@ -555,10 +559,10 @@ Data store parameters:
 Before opening a specific dataset in .zip format preload the data before opening.
 The preload parameters are:
 * `blocking: bool` - Switch to make the preloading process blocking or non-blocking.
-  If True, the preloading process blocks the script. Defaults to `true`.
+  If True, the preloading process blocks the script. Defaults to `True`.
 * `silent: bool` - Switch to visualize the preloading process. If False, the 
   preloading progress will be visualized in a table. If True, the visualization will 
-  be suppressed. Defaults to `true`.
+  be suppressed. Defaults to `True`.
 
 There are no common parameters for opening datasets with the `xcube-zenodo` store.
 As the datasets uploaded on Zenodo are varying across a wide spectrum of datatypes 

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -207,6 +207,7 @@ Use `list_data_store_ids()` to list all available data stores.
 from xcube.core.store import list_data_store_ids
 
 list_data_store_ids()
+```
 
 ### Filesystem-based data stores
 
@@ -324,84 +325,6 @@ Common parameters for opening [xarray.Dataset] instances:
   been consolidated. Defaults to `False`.
 * `log_access: bool` - Defaults to `False`.
 
-### ESA Climate Data Centre `cciodp`
-
-The data store `cciodp` provides the datasets of 
-the [ESA Climate Data Centre]. 
-
-This data store is provided by the xcube plugin [xcube-cci].
-You can install it using `conda install -c conda-forge xcube-cci`.
-
-Data store parameters:
-
-* `endpoint_url: str` - Defaults to 
-  `'https://archive.opensearch.ceda.ac.uk/opensearch/request'`.
-* `endpoint_description_url: str` - Defaults to 
-  `'https://archive.opensearch.ceda.ac.uk/opensearch/description.xml?parentIdentifier=cci'`.
-* `enable_warnings: bool` - Whether to output warnings. Defaults to `False`.
-* `num_retries: int` - Number of retries when requesting data fails. 
-  Defaults to `200`.
-* `retry_backoff_max: int` - Defaults to `40`.
-* `retry_backoff_base: float` - Defaults to `1.001`.
-
-Common parameters for opening [xarray.Dataset] instances:
-
-* `variable_names: list[str]` - List of variable names. Defaults to all.
-* `bbox: (float, float, float, float)` - Bounding box in geographical 
-  coordinates. 
-* `time_range: (str, str)` - Time range.
-* `normalize_data: bool` - Whether to normalize and sanitize the data. 
-  Defaults to `True`.
-
-### ESA Climate Data Centre `ccizarr`
-
-A subset of the datasets of the `cciodp` store have been made available 
-using the Zarr format using the data store `ccizarr`. It provides 
-much better data access performance. 
-
-It has no dedicated data store parameters.
-
-Its common dataset open parameters for opening [xarray.Dataset] instances are
-the same as for the filesystem-based data stores described above.
-
-### ESA Climate Data Centre `esa-cci-kc`
-
-The data store `esa-cci-kc` accesses datasets that are offered by the [Open Data Portal]
-via the references format.
-
-Data store parameters are the same as for the filesystem-based `reference` store.
-
-Its common dataset open parameters for opening [xarray.Dataset] instances are
-the same as for the filesystem-based data stores described above.
-
-
-### ESA SMOS `smos`
-
-The data store `smos` provides L2C datasets of the [ESA Soil Moisture and Ocean Salinity]
-mission.
-
-This data store is provided by the xcube plugin [xcube-smos]. You can install it using
-`conda install -c conda-forge xcube-smos`.
-
-Data store parameters:
-* `source_path: str` - Path or URL into SMOS archive filesystem.
-* `source_protocol: str`: Protocol name for the SMOS archive filesystem.
-* `source_storage_options: dict`: Storage options for the SMOS archive filesystem. See 
-   fsspec documentation for specific filesystems. Any option can be overriden by
-   passing it as additional data store parameter.
-* `cache_path: str`: Path to local cache directory. Must be given, if file caching 
-  is desired. 
-* `xarray_kwargs: dict`: Extra keyword arguments accepted by `xarray.open_dataset`.
-
-Common parameters for opening [xarray.Dataset] instances:
-
-* `time_range: (str, str)` - Time range given as pair of start and stop dates. 
-  Format: `YYYY-MM-DD`. Required.
-* `bbox: (float, float, float, float)` - Bounding box in geographical
-  coordinates.
-* `res_level: int` - Spatial resolution level in the range 0 to 4. Zero refers to 
-  the max resolution of 0.0439453125 degrees.
-
 ### Copernicus Climate Data Store `cds`
 
 The data store `cds` provides datasets of the [Copernicus Climate Data Store].
@@ -445,6 +368,141 @@ Common parameters for opening [xarray.Dataset] instances:
 
 * `variable_names: list[str]` - List of variable names.
 * `time_range: [str, str]` - Time range.
+
+### Copernicus Land Monitoring Service `clms`
+
+The data store `clms` provides datasets of the [Copernicus Land Monitoring Service].
+
+This data store is provided by the xcube plugin [xcube-clms].
+You can install it using `conda install -c conda-forge xcube-clms`.
+
+Data store parameters:
+
+* `credentials: dict`: CLMS API credentials that can be obtained following the steps outlined
+  [here](https://eea.github.io/clms-api-docs/authentication.html).
+  These are the credentials parameters:
+
+    * `client_id: str` - Required.
+    * `issued: str`
+    * `private_key: str` - Required.
+    * `key_id: str`
+    * `title: str`
+    * `token_uri: str` - Required.
+    * `user_id: str` - Required.
+
+* `cache_store_id: str` - Store ID of cache data store. Defaults to `file`.
+* `cache_store_params: dict` - Store parameters of a filesystem-based data
+  store.
+
+Before opening a specific dataset from CLMS, it's required to preload the data first.
+Preloading lets you create data requests ahead of time, which may sit in a queue before
+being processed. Once processed, the data is downloaded as zip files, unzipped,
+extracted to a cache, and prepared for use. After this, it can be accessed through the
+cache data store.
+
+The preload parameters are:
+* `blocking: bool` - Switch to make the preloading process blocking or non-blocking.
+  If True, the preloading process blocks the script. Defaults to `True`.
+* `silent: bool` - Silence the output of Preload API. If True, no preload state
+  output is given. Defaults to `False`.
+* `cleanup: bool` - Cleanup the download directory before and after the
+  preload job and the cache directory when preload_handle.close() is called.
+  Defaults to `True`.
+
+Its common dataset open parameters for opening [xarray.Dataset] instances are the same
+as for the filesystem-based data stores described above.
+
+### EOPF Sample Service
+
+A data store for EOPF Sample Service is currently under development and will be released
+soon.
+
+### ESA Climate Data Centre `cciodp`, `ccizar`, `esa-cci-kc`
+
+Three data stores are provided by the xcube plugin [xcube-cci].
+You can install it using `conda install -c conda-forge xcube-cci`.
+
+#### `cciodp`
+
+The data store `cciodp` provides the datasets of
+the [ESA Climate Data Centre].
+
+Data store parameters:
+
+* `endpoint_url: str` - Defaults to
+  `'https://archive.opensearch.ceda.ac.uk/opensearch/request'`.
+* `endpoint_description_url: str` - Defaults to
+  `'https://archive.opensearch.ceda.ac.uk/opensearch/description.xml?parentIdentifier=cci'`.
+* `enable_warnings: bool` - Whether to output warnings. Defaults to `False`.
+* `num_retries: int` - Number of retries when requesting data fails.
+  Defaults to `200`.
+* `retry_backoff_max: int` - Defaults to `40`.
+* `retry_backoff_base: float` - Defaults to `1.001`.
+
+Common parameters for opening [xarray.Dataset] instances:
+
+* `variable_names: list[str]` - List of variable names. Defaults to all.
+* `bbox: (float, float, float, float)` - Bounding box in geographical
+  coordinates.
+* `time_range: (str, str)` - Time range.
+* `normalize_data: bool` - Whether to normalize and sanitize the data.
+  Defaults to `True`.
+
+#### `ccizarr`
+
+A subset of the datasets of the `cciodp` store have been made available
+using the Zarr format using the data store `ccizarr`. It provides
+much better data access performance.
+
+It has no dedicated data store parameters.
+
+Its common dataset open parameters for opening [xarray.Dataset] instances are
+the same as for the filesystem-based data stores described above.
+
+#### `esa-cci-kc`
+
+The data store `esa-cci-kc` accesses datasets that are offered by the [Open Data Portal]
+via the references format.
+
+Data store parameters are the same as for the filesystem-based `reference` store.
+
+Its common dataset open parameters for opening [xarray.Dataset] instances are
+the same as for the filesystem-based data stores described above.
+
+### ESA SMOS `smos`
+
+The data store `smos` provides L2C datasets of the [ESA Soil Moisture and Ocean Salinity]
+mission.
+
+This data store is provided by the xcube plugin [xcube-smos]. You can install it using
+`conda install -c conda-forge xcube-smos`.
+
+Data store parameters:
+* `source_path: str` - Path or URL into SMOS archive filesystem.
+* `source_protocol: str`: Protocol name for the SMOS archive filesystem.
+* `source_storage_options: dict`: Storage options for the SMOS archive filesystem. See
+  fsspec documentation for specific filesystems. Any option can be overriden by
+  passing it as additional data store parameter.
+* `cache_path: str`: Path to local cache directory. Must be given, if file caching
+  is desired.
+* `xarray_kwargs: dict`: Extra keyword arguments accepted by `xarray.open_dataset`.
+
+Common parameters for opening [xarray.Dataset] instances:
+
+* `time_range: (str, str)` - Time range given as pair of start and stop dates.
+  Format: `YYYY-MM-DD`. Required.
+* `bbox: (float, float, float, float)` - Bounding box in geographical
+  coordinates.
+* `res_level: int` - Spatial resolution level in the range 0 to 4. Zero refers to
+  the max resolution of 0.0439453125 degrees.
+
+### Global Ecosystem Dynamics Investigation `gedi`
+
+A data store for [Global Ecosystem Dynamics Investigation] (GEDI) data is currently
+under development and will be released soon.
+
+This data store is provided by the xcube plugin [xcube-gedi]. Once available, you will
+be able to install it using `conda install -c conda-forge xcube-gedi`.
 
 ### Sentinel Hub API 
 
@@ -497,49 +555,57 @@ Common parameters for opening [xarray.Dataset] instances:
   catalogue query.
 * `max_cache_size: int` - Maximum chunk cache size in bytes.
 
+### SpatioTemporal Asset Catalogs `stac`, `stac-xcube`, `stac-cdse`
 
-### Copernicus Land Monitoring Service `clms`
+The data stores `stac`, `stac-xcube`, and `stac-cdse` provide datasets of
+the [SpatioTemporal Asset Catalogs].
 
-The data store `clms` provides datasets of the [Copernicus Land Monitoring Service].
+The three data stores are provided by the xcube plugin [xcube-stac].
+You can install it using `conda install -c conda-forge xcube-stac.`
 
-This data store is provided by the xcube plugin [xcube-clms]. 
-You can install it using `conda install -c conda-forge xcube-clms`.
 
-Data store parameters:
+#### `stac`
+The data store `stac` provides datasets from a user-defined STAC API.
 
-* `credentials: dict`: CLMS API credentials that can be obtained following the steps outlined
-   [here](https://eea.github.io/clms-api-docs/authentication.html). 
-    These are the credentials parameters:
+The general parameters for the data store are the same as those used for `https`
+and `s3` stores. The STAC collection of interest determines whether data is accessed
+via `https` or `s3`. Specific parameters for this store are:
+* `url: str` - URL to STAC catalog. Required.
+* `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready
+  format. Defaults to `False`.
 
-  * `client_id: str` - Required.
-  * `issued: str`
-  * `private_key: str` - Required.
-  * `key_id: str`
-  * `title: str`
-  * `token_uri: str` - Required.
-  * `user_id: str` - Required.
+#### `stac-xcube`
+The data store `stac-xcube` connects to STAC catalogs published on a `xcube` Server.
 
-* `cache_store_id: str` - Store ID of cache data store. Defaults to `file`.
-* `cache_store_params: dict` - Store parameters of a filesystem-based data 
-  store.
+The general parameters for the data store are the same as those used for `https`
+and `s3` stores. The STAC collection of interest determines whether data is accessed
+via `https` or `s3`. Specific parameters for this store are:
+* `url: str` - URL to STAC catalog. Required.
+* `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready
+  format. Defaults to `False`.
 
-Before opening a specific dataset from CLMS, it's required to preload the data first.
-Preloading lets you create data requests ahead of time, which may sit in a queue before 
-being processed. Once processed, the data is downloaded as zip files, unzipped, 
-extracted to a cache, and prepared for use. After this, it can be accessed through the 
-cache data store.
+#### `stac-cdse`
+The data store `stac-cdse` provides direct access to Sentinel data using the 
+CSDE STAC API.
 
-The preload parameters are:
-* `blocking: bool` - Switch to make the preloading process blocking or non-blocking.
-  If True, the preloading process blocks the script. Defaults to `True`.
-* `silent: bool` - Silence the output of Preload API. If True, no preload state
-  output is given. Defaults to `False`.
-* `cleanup: bool` - Cleanup the download directory before and after the
-  preload job and the cache directory when preload_handle.close() is called.
-  Defaults to `True`.
+The general parameters for the data store are the same as those used for `https`
+and `s3` stores. The STAC collection of interest determines whether data is accessed
+via `https` or `s3`. Specific parameters for this store are:
+* `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready
+  format. Defaults to `False`.
 
-Its common dataset open parameters for opening [xarray.Dataset] instances are the same 
-as for the filesystem-based data stores described above.
+
+There are no common parameters for opening datasets with the three stores.
+As the available datasets are varying across a wide spectrum of datatypes
+no specific opening parameters can be named here. The stores delegate to the
+general xcube Data Opener which offers a variety of parameters depending on the
+datatype of the dataset.
+
+Use the following function to access the parameters fitting for the dataset of interest:
+
+```python
+open_schema = store.get_open_data_params_schema("data_id")
+```
 
 ### Zenodo `zenodo`
 
@@ -579,55 +645,6 @@ Use the following function to access the parameters fitting for the dataset of i
 ```python
 open_schema = store.get_open_data_params_schema("data_id")
 ```
-
-### SpatioTemporal Asset Catalogs `stac`, `stac-xcube`, `stac-cdse`
-
-The data stores `stac`, `stac-xcube`, and `stac-cdse` provide datasets of 
-the [SpatioTemporal Asset Catalogs].
-
-`stac` - General store that connects to a user-defined STAC API. 
-`stac-xcube` - Connects to STAC catalogs published on a `xcube` Server.
-`stac-cse` - Provides direct access to Sentinel data using the CSDE STAC API.
-
-This data store is provided by the xcube plugin [xcube-stac]. 
-You can install it using `conda install -c conda-forge xcube-stac.`
-
-The general parameters for the data store are the same as those used for `https` 
-and `s3` stores. The STAC collection of interest determines whether data is accessed 
-via `https` or `s3`.
-
-Specific parameters are:
-* `url: str` - URL to STAC catalog. Required for `stac`  and `xcube-stac`
-* `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready 
-   format. Defaults to `False`.
-
-
-
-There are no common parameters for opening datasets with the three stores.
-As the available datasets are varying across a wide spectrum of datatypes
-no specific opening parameters can be named here. The stores delegate to the
-general xcube Data Opener which offers a variety of parameters depending on the
-datatype of the dataset.
-
-Use the following function to access the parameters fitting for the dataset of interest:
-
-```python
-open_schema = store.get_open_data_params_schema("data_id")
-```
-
-### Global Ecosystem Dynamics Investigation `gedi`
-
-A data store for [Global Ecosystem Dynamics Investigation] (GEDI) data is currently 
-under development and will be released soon.
-
-This data store is provided by the xcube plugin [xcube-gedi]. Once available, you will 
-be able to install it using `conda install -c conda-forge xcube-gedi`.
-
-
-### EOPF Sample Service 
-
-A data store for EOPF Sample Service is currently under development and will be released
-soon.
 
 
 ## Developing new data stores

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -16,6 +16,7 @@
 [ESA Climate Data Centre]: https://climate.esa.int/en/odp/
 [ESA Soil Moisture and Ocean Salinity]: https://earth.esa.int/eogateway/missions/smos
 [Global Ecosystem Dynamics Investigation]: https://gedi.umd.edu/
+[gedidb]: https://gedidb.readthedocs.io/en/latest/
 [Open Data Portal]: https://climate.esa.int/en/data/#/dashboard
 [SpatioTemporal Asset Catalogs]: https://stacspec.org/en/
 [Sentinel Hub]: https://www.sentinel-hub.com/
@@ -520,11 +521,39 @@ Common parameters for opening [xarray.Dataset] instances:
 
 ### Global Ecosystem Dynamics Investigation `gedidb`
 
-A data store for [Global Ecosystem Dynamics Investigation] (GEDI) data is currently
-under development and will be released soon.
+The data store `gedidb` provides access to [Global Ecosystem Dynamics Investigation] 
+(GEDI) data. The store is developed using the API from [gedidb] which is licensed under
+[European Union Public License 1.2](https://github.com/simonbesnard1/gedidb/blob/main/LICENSE).
 
-This data store is provided by the xcube plugin [xcube-gedidb]. Once available, you will
-be able to install it using `conda install -c conda-forge xcube-gedidb`.
+This data store is provided by the xcube plugin [xcube-gedidb]. Due to the 
+unavailability of `gedidb` as a conda package, `xcube-gedidb` is packaged via PyPi. 
+To install it, please make sure you have an activated conda environment created from the 
+[environment.yml](https://github.com/xcube-dev/xcube-gedidb/blob/main/environment.yml), 
+and then do `pip install xcube-gedi`.
+
+It has no dedicated data store parameters.
+
+This data store can be requested to open the datasets in one of two ways:
+
+- request all available data within a **bounding box** by specifying a `bbox` in 
+  the `open_data` method.
+- request all available data around a given **point** by specifying a `point` in 
+  the `open_data` method.
+
+Parameters for opening [xarray.Dataset] instances:
+
+Either  
+* `bbox: (float, float, float, float)` - A bounding box in the form of 
+  `(xmin, ymin, xmax, ymax)`. Required.
+
+Or  
+* `point: (float, float)` - Reference point for nearest query. Required
+* `num_shots: int` - Number of shots to retrieve. Defaults to `10`.
+* `radius: float` - Radius in degrees around the point Defaults to`0.1`.
+
+Common:  
+* `time_range: (str, str)` - Time range. Required.
+* `variables: list[str]` - List of variables to retrieve from the database.
 
 ### Sentinel Hub API 
 
@@ -677,7 +706,6 @@ Use the following function to access the parameters fitting for the dataset of i
 ```python
 open_schema = store.get_open_data_params_schema("data_id")
 ```
-
 
 ## Developing new data stores
 

--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -8,16 +8,18 @@
 [JSON Object Schema]: https://json-schema.org/understanding-json-schema/reference/object.html
 [setuptools entry point]: https://setuptools.pypa.io/en/latest/userguide/entry_point.html
 
-[ESA Climate Data Centre]: https://climate.esa.int/en/odp/
-[Sentinel Hub]: https://www.sentinel-hub.com/
+[CDSE STAC API]: https://browser.stac.dataspace.copernicus.eu
 [Copernicus Marine Service]: https://marine.copernicus.eu/
 [Copernicus Climate Data Store]: https://cds.climate.copernicus.eu/
-[ESA Soil Moisture and Ocean Salinity]: https://earth.esa.int/eogateway/missions/smos
-[Zenodo]: https://zenodo.org/
-[SpatioTemporal Asset Catalogs]: https://stacspec.org/en/
 [Copernicus Land Monitoring Service]: https://land.copernicus.eu/en
+[EOPF Sentinel Zarr Samples]: https://zarr.eopf.copernicus.eu/
+[ESA Climate Data Centre]: https://climate.esa.int/en/odp/
+[ESA Soil Moisture and Ocean Salinity]: https://earth.esa.int/eogateway/missions/smos
 [Global Ecosystem Dynamics Investigation]: https://gedi.umd.edu/
 [Open Data Portal]: https://climate.esa.int/en/data/#/dashboard
+[SpatioTemporal Asset Catalogs]: https://stacspec.org/en/
+[Sentinel Hub]: https://www.sentinel-hub.com/
+[Zenodo]: https://zenodo.org/
 
 [xcube-cci]: https://github.com/dcs4cop/xcube-cci
 [xcube-cds]: https://github.com/dcs4cop/xcube-cds
@@ -38,6 +40,7 @@
 [DatasetDescriptor]: https://xcube.readthedocs.io/en/latest/api.html#xcube.core.store.DatasetDescriptor
 [GenericZarrStore]: https://xcube.readthedocs.io/en/latest/api.html#xcube.core.zarrstore.GenericZarrStore
 [MultiLevelDataset]: https://xcube.readthedocs.io/en/latest/api.html#xcube.core.mldataset.MultiLevelDataset
+[Server]: https://xcube.readthedocs.io/en/latest/cli/xcube_serve.html
 
 # Data Access
 
@@ -413,12 +416,30 @@ The preload parameters are:
 Its common dataset open parameters for opening [xarray.Dataset] instances are the same
 as for the filesystem-based data stores described above.
 
-### EOPF Sample Service
+### EOPF Sample Service `eopf-zarr`
 
-A data store for [EOPF Sentinel Zarr Samples](https://zarr.eopf.copernicus.eu/) is currently under development and will be released
-soon.
+The data store `eopf-zarr` provides access to the [EOPF Sentinel Zarr Samples] as an
+analysis-ready datacube (ARDC).
 
-### ESA Climate Data Centre `cciodp`, `ccizarr`, `esa-cci-kc`
+This data store is provided by the xcube plugin `xcube-eopf`.
+You can install it using `conda install -c conda-forge xcube-eopf`.
+
+No data store parameters needed.
+
+Common parameters for opening [xarray.Dataset] instances:
+
+* `bbox: ?[float|int, float|int, float|int, float|int]?`- Bounding box 
+   ["west", "south", "est", "north"] in CRS coordinates. 
+* `time_range: [str, str]` - Temporal extent ["YYYY-MM-DD", "YYYY-MM-DD"]. 
+* `spatial_res: int|float` - Spatial resolution in meter of degree (depending on the CRS). 
+* `crs: str` - Coordinate reference system (e.g. `"EPSG:4326"`). 
+* `variables: ?str | list[str]?` - Variables to include in the dataset. Can be a name 
+   or regex pattern or iterable of the latter. 
+* `query: Any (not specified)` - Additional query options for filtering STAC Items by 
+   properties. See [STAC Query Extension](https://github.com/stac-api-extensions/query) 
+   for details.
+
+### ESA Climate Data Centre (ESA CCI) `cciodp`, `ccizarr`, `esa-cci-kc`
 
 Three data stores are provided by the xcube plugin [xcube-cci].
 You can install the plugin using `conda install -c conda-forge xcube-cci`.
@@ -577,7 +598,7 @@ Specific parameters for this store are:
   STAC assets determines whether data is accessed via `https` or `s3`. 
 
 #### `stac-xcube`
-The data store `stac-xcube` connects to STAC catalogs published on a `xcube` Server.
+The data store `stac-xcube` connects to STAC catalogs published on a xcube [Server].
 
 Specific parameters for this store are:
 * `url: str` - URL to STAC catalog. Required.
@@ -588,20 +609,28 @@ Specific parameters for this store are:
 
 #### `stac-cdse`
 The data store `stac-cdse` provides direct access datasets published by the 
-CSDE STAC API.
+[CDSE STAC API].
 
 * `stack_mode: bool` - Stacking of STAC items. Transforms data into analysis-ready
-  format. Defaults to `False`.
+  format. Defaults to `False`. Available for `data_id="sentinel-2-l2"`, which allows to 
+  build 3D spatiotemporal data cubes from multiple Sentinel-2 Level-2A tiles. 
+  Commen opening parameter:
+
+  * `float, float, float, float)` - Bounding box ["west", "south", "est", "north"] 
+    in CRS coordinates. 
+  * `time_range: [str, str]`: Temporal extent ["YYYY-MM-DD", "YYYY-MM-DD"]. 
+  * `spatial_res: int | float` - Spatial resolution in meter of degree (depending on the CRS). 
+  * `crs: str` - Coordinate reference system (e.g. `"EPSG:4326"`).
+
 * `key: str`- S3 key credential for CDSE data access
-* `secret: str`- S3 secret credential for CDSE data access
-In order to access [EO data via S3 from CDSE](https://documentation.dataspace.copernicus.eu/APIs/S3.html)
+* `secret: str`- S3 secret credential for CDSE data access. In order to access [EO data via S3 from CDSE](https://documentation.dataspace.copernicus.eu/APIs/S3.html)
 one needs to [generate S3 credentials](https://documentation.dataspace.copernicus.eu/APIs/S3.html#generate-secrets).
 
 
 There are no common parameters for opening datasets with the three stores.
 As the available datasets are varying across a wide spectrum of datatypes
 no specific opening parameters can be named here. The stores delegate to the
-general xcube Data Opener which offers a variety of parameters depending on the
+general xcube DataOpener which offers a variety of parameters depending on the
 datatype of the dataset.
 
 Use the following function to access the parameters fitting for the dataset of interest:
@@ -640,7 +669,7 @@ The preload parameters are:
 There are no common parameters for opening datasets with the `xcube-zenodo` store.
 As the datasets uploaded on Zenodo are varying across a wide spectrum of datatypes 
 no specific opening parameters can be named here. `xcube-zenodo` delegates to the
-general xcube Data Opener which offers a variety of open parameters depending on the
+general xcube DataOpener which offers a variety of open parameters depending on the
 datatype of the dataset.
 
 Use the following function to access the parameters fitting for the dataset of interest:

--- a/xcube/version.py
+++ b/xcube/version.py
@@ -2,4 +2,4 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-version = "1.11.0"
+version = "1.11.1.dev0"


### PR DESCRIPTION
This PR updates the documentation page 'Data Access'.

The content for the following stores was either updated or added:
- filesystem-based stores: `https`, `ftp`, `reference`
- other stores: `smos`, `clms`, `zenodo`, `stac` /`stac-cdse`/`stac-xcube`
- stores in development: `gedi`, `eopf`

I considered including information on preload_data() and get_preload_data_params_schema(), but decided against it since they're still marked as experimental in the documentation.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
