### PR TITLE
add resolutions and spatialUnits to mldataset

### DIFF
--- a/xcube/webapi/datasets/controllers.py
+++ b/xcube/webapi/datasets/controllers.py
@@ -224,6 +224,8 @@ def get_dataset(
     dataset_dict["bbox"] = list(ds_bbox)
     dataset_dict["geometry"] = get_bbox_geometry(dataset_bounds, transformer)
     dataset_dict["spatialRef"] = crs.to_string()
+    dataset_dict["resolutions"] = list(ml_ds.avg_resolutions)
+    dataset_dict["spatialUnits"] = ml_ds.grid_mapping.spatial_unit_name
 
     variable_dicts = []
     dim_names = set()


### PR DESCRIPTION
This PR:
- is needed for https://github.com/xcube-dev/xcube-viewer/pull/544, to access information on the **resolutions** and **spatialUnits** of MultilevelDatasets from xcube Server in xcube Viewer.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
