### PR TITLE
Constrain matplotlib dependency to <3.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Changes in 1.13.4 (in developement)
+
+### Other changes
+* Constrained `matplotlib >=3.8.3,<3.11.0` (#1219)
+
 ## Changes in 1.13.3
 
 ### Enhancements

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - jsonschema >=3.2
   - libgdal-jp2openjpeg
   - mashumaro
-  - matplotlib-base >=3.8.3
+  - matplotlib-base >=3.8.3,<3.11.0 # see Issue #1219
   - netcdf4 >=1.5
   - numba >=0.52
   - numcodecs >=0.12.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "jdcal>=1.4",
   "jsonschema>=3.2",
   "mashumaro",
-  "matplotlib>=3.8.3",
+  "matplotlib>=3.8.3,<3.11.0", #see Issue #1219
   "netcdf4>=1.5",
   "numba>=0.52",
   "numcodecs>=0.12.1",

--- a/xcube/version.py
+++ b/xcube/version.py
@@ -2,4 +2,4 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-version = "1.13.3"
+version = "1.13.4.dev0"


### PR DESCRIPTION
This PR contrains `matplotlib` to `>=3.8.3,<3.11.0`.

See #1219. 

Checklist:

* [ ] ~~Add unit tests and/or doctests in docstrings~~
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in `docs/source/*`~~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
