### PR TITLE
Fix tile rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
  
 ### Fixes
 * Improved raster tile alignment by using nearest-pixel rounding during tile reprojection,
-  reducing visual offsets between rendered map tiles and dataset coordinates. (#1216)
+  reducing visual offsets between rendered map tiles and dataset coordinates. (#1216, #1234)
 * Ensure compatibility with matplotlib 3.11.0 (#1219)
 * Fixed duplicated `tornado` log entries emitted by xcube Server. (#1224)
 

--- a/test/core/test_tile.py
+++ b/test/core/test_tile.py
@@ -14,7 +14,12 @@ import pytest
 import xarray as xr
 
 from xcube.core.mldataset import BaseMultiLevelDataset, MultiLevelDataset
-from xcube.core.tile import compute_rgba_tile, compute_tiles, get_var_valid_range
+from xcube.core.tile import (
+    TileException,
+    compute_rgba_tile,
+    compute_tiles,
+    get_var_valid_range,
+)
 from xcube.core.tilingscheme import GEOGRAPHIC_CRS_NAME, WEB_MERCATOR_CRS_NAME
 from xcube.util.cmaps import Colormap, ColormapProvider
 
@@ -193,6 +198,20 @@ class ComputeTilesTest(TileTest, unittest.TestCase):
                 dtype=np.float32,
             ),
         )
+
+    def test_compute_tiles_with_single_x_coord(self):
+        ml_ds = self._get_ml_dataset(self.crs_name)
+        ml_ds.set_dataset(0, ml_ds.get_dataset(0).isel(x=[0]))
+
+        with self.assertRaises(TileException) as cm:
+            compute_tiles(
+                ml_ds,
+                "var_a",
+                self.args[2],
+                **self.kwargs,
+            )
+
+        self.assertEqual("Cannot determine dataset coordinate step", str(cm.exception))
 
     def test_compute_tiles_with_assignment_expr(self):
         tiles = compute_tiles(

--- a/xcube/core/tile.py
+++ b/xcube/core/tile.py
@@ -138,6 +138,7 @@ def compute_tiles(
     with measure_time("Transforming tile map to dataset coordinates"):
         ds_x_name, ds_y_name = ml_dataset.grid_mapping.xy_dim_names
 
+        ds_x_coords = variable_0[ds_x_name]
         ds_y_coords = variable_0[ds_y_name]
         ds_y_points_up = bool(ds_y_coords[0] < ds_y_coords[-1])
 
@@ -201,11 +202,18 @@ def compute_tiles(
                 "Tile bounds NaN after map projection", logger=logger
             )
 
+        try:
+            ds_dx = abs(_get_coord_step(ds_x_coords))
+            ds_dy = abs(_get_coord_step(ds_y_coords))
+        except (IndexError, ZeroDivisionError) as e:
+            raise TileException(
+                "Cannot determine dataset coordinate step", logger=logger
+            ) from e
+
         num_extra_pixels = tile_enlargement
-        res_x = (ds_x_max - ds_x_min) / tile_width
-        res_y = (ds_y_max - ds_y_min) / tile_height
-        extra_dx = num_extra_pixels * res_x
-        extra_dy = num_extra_pixels * res_y
+        extra_dx = (num_extra_pixels + 0.5) * ds_dx
+        extra_dy = (num_extra_pixels + 0.5) * ds_dy
+
         ds_x_slice = slice(ds_x_min - extra_dx, ds_x_max + extra_dx)
         if ds_y_points_up:
             ds_y_slice = slice(ds_y_min - extra_dy, ds_y_max + extra_dy)
@@ -230,14 +238,11 @@ def compute_tiles(
 
         ds_x1 = float(ds_x_coords[0])
         ds_y1 = float(ds_y_coords[0])
-        ds_x2 = float(ds_x_coords[-1])
-        ds_y2 = float(ds_y_coords[-1])
-
         ds_size_x = ds_x_coords.size
         ds_size_y = ds_y_coords.size
 
-        ds_dx = (ds_x2 - ds_x1) / (ds_size_x - 1)
-        ds_dy = (ds_y2 - ds_y1) / (ds_size_y - 1)
+        ds_dx = _get_coord_step(ds_x_coords)
+        ds_dy = _get_coord_step(ds_y_coords)
 
         ds_x_indices = (tile_ds_x_2d - ds_x1) / ds_dx
         ds_y_indices = (tile_ds_y_2d - ds_y1) / ds_dy
@@ -285,6 +290,12 @@ def compute_tiles(
         )
 
     return var_tiles
+
+
+def _get_coord_step(coord: xr.DataArray) -> float:
+    coord_1 = float(coord[0])
+    coord_2 = float(coord[-1])
+    return (coord_2 - coord_1) / (coord.size - 1)
 
 
 def _new_tile_dataset(
@@ -674,7 +685,7 @@ def get_non_spatial_labels(
     variable: xr.DataArray,
     labels: Optional[dict[str, Any]],
     logger: logging.Logger = None,
-    excluded_dims: Iterable[str] | None = None
+    excluded_dims: Iterable[str] | None = None,
 ) -> dict[Hashable, Any]:
     labels = labels if labels is not None else {}
     excluded_dims = excluded_dims or []
@@ -684,10 +695,7 @@ def get_non_spatial_labels(
     # and ignore specified dims to keep the log clean (see
     # xcube.webapi.timeseries.routes.get_non_spatial_dimensions)
     assert variable.ndim >= 2
-    non_spatial_dims = [
-        dim for dim in variable.dims[0:-2]
-        if dim not in excluded_dims
-    ]
+    non_spatial_dims = [dim for dim in variable.dims[0:-2] if dim not in excluded_dims]
     if not non_spatial_dims:
         #  Ignore any extra labels passed.
         return new_labels

--- a/xcube/core/tile.py
+++ b/xcube/core/tile.py
@@ -203,8 +203,8 @@ def compute_tiles(
             )
 
         try:
-            ds_dx = abs(_get_coord_step(ds_x_coords))
-            ds_dy = abs(_get_coord_step(ds_y_coords))
+            ds_dx = abs(_get_pixel_size(ds_x_coords))
+            ds_dy = abs(_get_pixel_size(ds_y_coords))
         except (IndexError, ZeroDivisionError) as e:
             raise TileException(
                 "Cannot determine dataset coordinate step", logger=logger
@@ -241,8 +241,8 @@ def compute_tiles(
         ds_size_x = ds_x_coords.size
         ds_size_y = ds_y_coords.size
 
-        ds_dx = _get_coord_step(ds_x_coords)
-        ds_dy = _get_coord_step(ds_y_coords)
+        ds_dx = _get_pixel_size(ds_x_coords)
+        ds_dy = _get_pixel_size(ds_y_coords)
 
         ds_x_indices = (tile_ds_x_2d - ds_x1) / ds_dx
         ds_y_indices = (tile_ds_y_2d - ds_y1) / ds_dy
@@ -292,7 +292,7 @@ def compute_tiles(
     return var_tiles
 
 
-def _get_coord_step(coord: xr.DataArray) -> float:
+def _get_pixel_size(coord: xr.DataArray) -> float:
     coord_1 = float(coord[0])
     coord_2 = float(coord[-1])
     return (coord_2 - coord_1) / (coord.size - 1)


### PR DESCRIPTION
This PR is a follow-up to #1216.

#1216 improved the tile indexing step by using nearest-pixel rounding when mapping tile pixels to dataset pixels. This fixed the actual tile shift, because target pixels are now sampled from the nearest source pixel instead of being consistently biased toward one side.

However, the source subset used for rendering was still computed too tightly. The subset bbox describes the transformed positions of the target tile pixel centers, but nearest-pixel rounding may select a source pixel whose center lies just outside that bbox.

```text
source pixel centers:
      x        x        x        x
      |--------|--------|--------|

transformed target bbox:
           |----------------|
           ^                ^
   nearest source pixel     
   may lie outside bbox     
```
If such an edge source pixel was not included in the loaded subset, it was treated as invalid and rendered as missing or transparent data. **This PR fixes** this behaviour by enlarging the source subset now using the dataset’s own pixel size, including the half-pixel margin required by nearest-pixel rounding.

Example: `xcube serve -vvv -c examples/serve/panels-demo/config.yaml`

<img width="350" alt="image" src="https://github.com/user-attachments/assets/cc2d358b-eabe-457e-a8e7-09ac83d542b3" />



Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in `docs/source/*`~~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] Test coverage remains or increases (target 100%)
