### PR TITLE
Get version from `pyproject.toml`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
   `GenericZarrStore`. `GenericZarrStore` provides a flat `MutableMapping` view of a 
   Zarr store, making it independent of any specific Zarr store implementation. 
   This change prepares xcube for the migration to Zarr v3, whose store API differs 
-  significantly from that of Zarr v2.  (#1226)
+  significantly from that of Zarr v2. (#1226)
 * Migrated the development environment and project tasks to Pixi. (#1238)
 * The xcube version identifier is now retrieved from `pyproject.toml` as single 
   source of truth. (#1242)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,14 +5,6 @@
 * Migrated to Zarr v3, adapting xcube's Zarr handling to the new Zarr store API and
   ensuring compatibility with the latest Zarr ecosystem.  (#1182)
 
-### Fixes
-
-* Improved raster tile alignment by using nearest-pixel rounding during tile reprojection,
-  reducing visual offsets between rendered map tiles and dataset coordinates. (#1216, #1234)
-* Ensure compatibility with matplotlib 3.11.0 (#1219)
-* Fixed duplicated `tornado` log entries emitted by xcube Server. (#1224)
-* Fixed race conditions in `LazyMultiLevelDataset`. (#1225)
-
 ### Other changes
 
 * Removed most Zarr store implementations from `xcube.core.zarrstore`, retaining only
@@ -20,10 +12,34 @@
   Zarr store, making it independent of any specific Zarr store implementation. 
   This change prepares xcube for the migration to Zarr v3, whose store API differs 
   significantly from that of Zarr v2.  (#1182)
-* Pinned libjxl <=0.11.2 because libjxl >=0.12.0 causes CI failures due to 
-  rasterio/GDAL binary incompatibilities.
+* Migrated the development environment and project tasks to Pixi. (#1238)
 * The xcube version identifier is now retrieved from `pyproject.toml` as single 
-  source of truth. 
+  source of truth. (#1242)
+
+
+## Changes in 1.13.4
+ 
+### Enhancements
+
+* Optimized opening of multi-level datasets by reusing non-spatial coordinates
+  from level zero instead of reading them again for every level. (#1236)
+
+### Fixes
+
+* Improved raster tile alignment by using nearest-pixel rounding during tile 
+  reprojection, reducing visual offsets between rendered map tiles and dataset 
+  coordinates. (#1216, #1234)
+* Ensure compatibility with matplotlib 3.11.0 (#1219)
+* Fixed duplicated `tornado` log entries emitted by xcube Server. (#1224)
+* Fixed race conditions in `LazyMultiLevelDataset`. (#1225)
+
+### Other changes
+
+* Pinned libjxl <=0.11.2 because libjxl >=0.12.0 causes CI failures due to 
+  rasterio/GDAL binary incompatibilities. (#1229)
+* Updated installation instructions to use current mamba syntax and
+  canonical xcube repository URL (#1232)
+
 
 ## Changes in 1.13.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
   `GenericZarrStore`. `GenericZarrStore` provides a flat `MutableMapping` view of a 
   Zarr store, making it independent of any specific Zarr store implementation. 
   This change prepares xcube for the migration to Zarr v3, whose store API differs 
-  significantly from that of Zarr v2.  (#1182)
+  significantly from that of Zarr v2.  (#1226)
 * Migrated the development environment and project tasks to Pixi. (#1238)
 * The xcube version identifier is now retrieved from `pyproject.toml` as single 
   source of truth. (#1242)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,9 @@
 ## Changes in 1.14.0 (in development)
 
-### Other changes
+### Enhancements
 
 * Migrated to Zarr v3, adapting xcube's Zarr handling to the new Zarr store API and
-  ensuring compatibility with the latest Zarr ecosystem.
+  ensuring compatibility with the latest Zarr ecosystem.  (#1182)
 
 ### Fixes
 
@@ -19,7 +19,7 @@
   `GenericZarrStore`. `GenericZarrStore` provides a flat `MutableMapping` view of a 
   Zarr store, making it independent of any specific Zarr store implementation. 
   This change prepares xcube for the migration to Zarr v3, whose store API differs 
-  significantly from that of Zarr v2.
+  significantly from that of Zarr v2.  (#1182)
 * Pinned libjxl <=0.11.2 because libjxl >=0.12.0 causes CI failures due to 
   rasterio/GDAL binary incompatibilities.
 * The xcube version identifier is now retrieved from `pyproject.toml` as single 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,17 +1,12 @@
 ## Changes in 1.14.0 (in development)
 
 ### Other changes
-* Removed most Zarr store implementations from `xcube.core.zarrstore`, retaining only
-  `GenericZarrStore`. `GenericZarrStore` provides a flat `MutableMapping` view of a 
-  Zarr store, making it independent of any specific Zarr store implementation. 
-  This change prepares xcube for the migration to Zarr v3, whose store API differs 
-  significantly from that of Zarr v2.
+
 * Migrated to Zarr v3, adapting xcube's Zarr handling to the new Zarr store API and
   ensuring compatibility with the latest Zarr ecosystem.
 
-## Changes in 1.13.4
- 
 ### Fixes
+
 * Improved raster tile alignment by using nearest-pixel rounding during tile reprojection,
   reducing visual offsets between rendered map tiles and dataset coordinates. (#1216, #1234)
 * Ensure compatibility with matplotlib 3.11.0 (#1219)
@@ -19,8 +14,16 @@
 * Fixed race conditions in `LazyMultiLevelDataset`. (#1225)
 
 ### Other changes
+
+* Removed most Zarr store implementations from `xcube.core.zarrstore`, retaining only
+  `GenericZarrStore`. `GenericZarrStore` provides a flat `MutableMapping` view of a 
+  Zarr store, making it independent of any specific Zarr store implementation. 
+  This change prepares xcube for the migration to Zarr v3, whose store API differs 
+  significantly from that of Zarr v2.
 * Pinned libjxl <=0.11.2 because libjxl >=0.12.0 causes CI failures due to 
   rasterio/GDAL binary incompatibilities.
+* The xcube version identifier is now retrieved from `pyproject.toml` as single 
+  source of truth. 
 
 ## Changes in 1.13.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,7 @@
-[build-system]
-requires = ["setuptools >= 61.2.0"]
-build-backend = "setuptools.build_meta"
-
 [project]
-name = "xcube" # PYPI RENAME THIS LINE (do not remove this comment, see #1010) 
-dynamic = ["version", "readme"]
+name = "xcube" # PYPI RENAME THIS LINE (do not remove this comment, see #1010)
+version = "1.14.0.dev0"
+dynamic = ["readme"]
 authors = [
   {name = "xcube Development Team"}
 ]
@@ -85,6 +82,10 @@ xcube = "xcube.cli.main:main"
 # entry point xcube's default extensions
 [project.entry-points.xcube_plugins]
 xcube = "xcube.plugin:init_plugin"
+
+[build-system]
+requires = ["setuptools >= 61.2.0"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools.package-data]
 "xcube.webapi.meta" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ build-backend = "setuptools.build_meta"
 ]
 
 [tool.setuptools.dynamic]
-version = {attr = "xcube.__version__"}
 readme = {file = "README.md", content-type = "text/markdown"}
 
 [tool.setuptools.packages.find]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -14,4 +14,9 @@ sphinx:
 conda:
   environment: rtd-environment.yml
 
+python:
+  install:
+    - method: pip
+      path: .
+
 formats: all

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2018-2026 by xcube team and contributors
+# Permissions are hereby granted under the terms of the MIT License:
+# https://opensource.org/licenses/MIT.
+
+import importlib
+import unittest
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import call, patch
+
+
+class VersionTest(unittest.TestCase):
+    def test_falls_back_to_xcube_core_distribution(self):
+        version_module = importlib.import_module("xcube.version")
+
+        try:
+            with patch(
+                "importlib.metadata.version",
+                side_effect=[PackageNotFoundError, "1.2.3"],
+            ) as get_version:
+                importlib.reload(version_module)
+
+            self.assertEqual("1.2.3", version_module.version)
+            self.assertEqual(
+                [call("xcube"), call("xcube-core")],
+                get_version.call_args_list,
+            )
+        finally:
+            importlib.reload(version_module)

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -3,8 +3,10 @@
 # https://opensource.org/licenses/MIT.
 
 import importlib
+import tomllib
 import unittest
 from importlib.metadata import PackageNotFoundError
+from pathlib import Path
 from unittest.mock import call, patch
 
 
@@ -20,6 +22,28 @@ class VersionTest(unittest.TestCase):
                 importlib.reload(version_module)
 
             self.assertEqual("1.2.3", version_module.version)
+            self.assertEqual(
+                [call("xcube"), call("xcube-core")],
+                get_version.call_args_list,
+            )
+        finally:
+            importlib.reload(version_module)
+
+    def test_falls_back_to_pyproject_version(self):
+        version_module = importlib.import_module("xcube.version")
+
+        try:
+            expected = tomllib.loads(Path("pyproject.toml").read_text())["project"][
+                "version"
+            ]
+
+            with patch(
+                "importlib.metadata.version",
+                side_effect=[PackageNotFoundError, PackageNotFoundError],
+            ) as get_version:
+                importlib.reload(version_module)
+
+            self.assertEqual(expected, version_module.version)
             self.assertEqual(
                 [call("xcube"), call("xcube-core")],
                 get_version.call_args_list,

--- a/xcube/version.py
+++ b/xcube/version.py
@@ -2,4 +2,11 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
-version = "1.14.0.dev0"
+from importlib.metadata import PackageNotFoundError, version as get_version
+
+try:
+    # xcube on conda-forge and editable pip installs
+    version = get_version("xcube")
+except PackageNotFoundError:
+    # On PyPI, xcube is called xcube-core
+    version = get_version("xcube-core")

--- a/xcube/version.py
+++ b/xcube/version.py
@@ -9,4 +9,13 @@ try:
     version = get_version("xcube")
 except PackageNotFoundError:
     # On PyPI, xcube is called xcube-core
-    version = get_version("xcube-core")
+    try:
+        # On PyPI, xcube is called xcube-core
+        version = get_version("xcube-core")
+    except PackageNotFoundError:
+        # If neither distribution package is installed, look for the
+        # project file relative to this source file.
+        from pathlib import Path
+        import tomllib
+        with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as f:
+            version = tomllib.load(f)["project"]["version"]```

--- a/xcube/version.py
+++ b/xcube/version.py
@@ -17,5 +17,6 @@ except PackageNotFoundError:
         # project file relative to this source file.
         from pathlib import Path
         import tomllib
+
         with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as f:
-            version = tomllib.load(f)["project"]["version"]```
+            version = tomllib.load(f)["project"]["version"]


### PR DESCRIPTION
The xcube version identifier is now retrieved from `pyproject.toml` as single source of truth. 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] Test coverage remains or increases (target 100%)
