### PR TITLE
Declare xcube as typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ xcube = "xcube.cli.main:main"
 xcube = "xcube.plugin:init_plugin"
 
 [tool.setuptools.package-data]
+"xcube" = ["py.typed"]
 "xcube.webapi.meta" = [
     "data/openapi.html",
 ]


### PR DESCRIPTION
- Add the PEP 561 `xcube/py.typed` marker.
- Configure setuptools to include the marker in built package artifacts.

This allows type checkers such as mypy to use xcube’s existing inline type annotations when xcube is installed as a dependency.

Also see: https://peps.python.org/pep-0561/

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] Test coverage remains or increases (target 100%)
