### PR TITLE
Return empty viewer contributions when extensions are not configured

### DIFF
--- a/test/webapi/viewer/test_routes.py
+++ b/test/webapi/viewer/test_routes.py
@@ -141,7 +141,10 @@ class ViewerExtRoutesWithDefaultConfigTest(RoutesTestCase):
 
     def test_viewer_ext_contributions(self):
         response = self.fetch("/viewer/ext/contributions")
-        self.assertResourceNotFoundResponse(response)
+        self.assertResponseOK(response)
+        self.assertEqual(
+            {"result": {"extensions": [], "contributions": {}}}, response.json()
+        )
 
     def test_viewer_ext_layout(self):
         response = self.fetch(

--- a/xcube/webapi/viewer/routes.py
+++ b/xcube/webapi/viewer/routes.py
@@ -160,7 +160,9 @@ class ViewerStateHandler(ApiHandler[ViewerContext]):
 class ViewerExtHandler(ApiHandler[ViewerContext]):
     def do_get_contributions(self):
         if self.ctx.ext_ctx is None:
-            self._write_no_ext_status()
+            self._write_response(
+                ExtResponse.success({"extensions": [], "contributions": {}})
+            )
         else:
             self._write_response(get_contributions(self.ctx.ext_ctx))
 


### PR DESCRIPTION
## Description

closes #1245 

Return an empty contributions collection from `GET /viewer/ext/contributions` when no viewer extensions are configured, instead of responding with `404 No extensions configured`.

This prevents xcube Viewer from producing a misleading failed-resource error in browser DevTools during normal startup without extensions.

Updated the default-configuration route test to assert the empty successful response.

Checklist:

- [x] Add unit tests and/or doctests in docstrings
- [x] Add docstrings and API docs for any new/modified user-facing classes and functions (not applicable; no new or modified public Python API)
- [x] New/modified features documented in `docs/source/*` (not applicable; this is a response-status correction)
- [ ] Changes documented in `CHANGES.md`
- [ ] GitHub CI passes
- [ ] Test coverage remains or increases (not measured locally)