### PR TITLE
xcube server will not start when persistence path points to non-existing key on s3 filesystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 * Ensure compatibility with matplotlib 3.11.0 (#1219)
 * Fixed duplicated `tornado` log entries emitted by xcube Server. (#1224)
 * Fixed race conditions in `LazyMultiLevelDataset`. (#1225)
+* xcube server will not start when persistence path points to non-existing key 
+  on s3 filesystem (#1248)
 
 ### Other changes
 

--- a/test/webapi/res/config-persistence-nonmemory.yml
+++ b/test/webapi/res/config-persistence-nonmemory.yml
@@ -1,0 +1,16 @@
+Viewer:
+  Persistence:
+    Path: "s3://xcube-testing/cache"
+
+DataStores:
+  - Identifier: test
+    StoreId: file
+    StoreParams:
+      root: examples/serve/demo
+    Datasets:
+      - Path: "cube-1-250-250.zarr"
+        TimeSeriesDataset: "cube-5-100-200.zarr"
+
+ServiceProvider:
+  ProviderName: "Brockmann Consult GmbH"
+  ProviderSite: "https://www.brockmann-consult.de"

--- a/test/webapi/viewer/test_context.py
+++ b/test/webapi/viewer/test_context.py
@@ -58,6 +58,12 @@ class ViewerContextTest(unittest.TestCase):
         ctx = get_viewer_ctx("config-persistence.yml")
         self.assertIsInstance(ctx.persistence, MutableMapping)
 
+    @s3_test()
+    def test_with_persistence_s3(self, endpoint_url: str):
+        server_config = get_server_config("config-persistence-nonmemory.yml")
+        ctx = get_viewer_ctx(server_config)
+        self.assertIsInstance(ctx.persistence, MutableMapping)
+
     def test_panels_local(self):
         ctx = get_viewer_ctx("config-panels.yml")
         self.assert_extensions_ok(ctx.ext_ctx)

--- a/xcube/webapi/viewer/context.py
+++ b/xcube/webapi/viewer/context.py
@@ -66,7 +66,21 @@ class ViewerContext(ResourcesContext):
             path, **(storage_options or {})
         )
         fs, root = fs_root
-        self.persistence = fs.get_mapper(root, create=True, check=True)
+        # using the check parameter fails for s3 file systems,
+        # so we "only" check whether we can add and remove files
+        self.persistence = fs.get_mapper(root, create=True, check=False)
+        try:
+            count = 0
+            dummy_file = f"dummy/{count}"
+            while dummy_file in self.persistence:
+                count += 1
+                dummy_file = f"dummy/{count}"
+            self.persistence[dummy_file] = b""
+            del self.persistence[dummy_file]
+        except:
+            raise ValueError(
+                f"Persistence path '{root}' does not exist and could not be created."
+            )
         LOG.info(f"Viewer persistence established for path {path!r}")
 
     def set_extension_context(self, path: str | None, extension_refs: list[str]):


### PR DESCRIPTION
Solves #1248 
Checklist:

* [x] Add unit tests and/or doctests in docstrings
~* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
~* [ ] New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] Test coverage remains or increases (target 100%)
