### PR TITLE
Dockerfile: move MICROMAMBA_VERSION declaration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG MICROMAMBA_VERSION=1.3.1
+
 # Export the locked default Pixi environment for the Micromamba runtime image.
 FROM ghcr.io/prefix-dev/pixi:0.77.1 AS pixi-export
 
@@ -10,7 +12,6 @@ RUN pixi project export conda-environment \
 
 # For micromamba image documentation,
 # goto https://hub.docker.com/r/mambaorg/micromamba
-ARG MICROMAMBA_VERSION=1.3.1
 FROM mambaorg/micromamba:${MICROMAMBA_VERSION}
 
 ARG NEW_MAMBA_USER=xcube


### PR DESCRIPTION
Move this declaration to the start of the file, so it's not restrictively scoped to the Pixi stage.

Fixes #1254
