### PR TITLE
Update micromamba version in Dockerfile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-* Fixed Docker build workflow. (#1254)
+* Fixed Docker build workflow. (#1254, #1258)
 
 ## Changes in 1.14.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG MICROMAMBA_VERSION=1.3.1
+ARG MICROMAMBA_VERSION=2.9.0
 
 # Export the locked default Pixi environment for the Micromamba runtime image.
 FROM ghcr.io/prefix-dev/pixi:0.77.1 AS pixi-export


### PR DESCRIPTION
This PR updates the Docker base image from `mambaorg/micromamba:1.3.1` to `2.9.0` because the old image is based on Debian Bullseye, whose security repository metadata now causes apt-get update failures after Bullseye LTS EOL.

Closes #1258. 

Checklist:

* [ ] ~~Add unit tests and/or doctests in docstrings~~
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in `docs/source/*`~~
* [x] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] Test coverage remains or increases (target 100%)
